### PR TITLE
feat: DB connection layer (#7)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,14 +1,11 @@
 from flask import Flask, jsonify
+
 from .config import settings
 
 
 def create_app():
     app = Flask(__name__)
     app.config["SECRET_KEY"] = settings.SECRET_KEY
-
-    # Blueprints (подключаем по мере готовности)
-    # from api.routes import api_bp
-    # app.register_blueprint(api_bp, url_prefix="/api")
 
     @app.route("/healthz")
     def health():

--- a/app/db.py
+++ b/app/db.py
@@ -69,9 +69,14 @@ def table_stats(table_name: str, schema: str | None = None) -> dict:
     }
 
 
+def _qi(identifier: str) -> str:
+    """Quote a SQL identifier (schema, table, column) to prevent injection."""
+    return '"' + identifier.replace('"', '""') + '"'
+
+
 def column_nulls(table_name: str, schema: str | None = None) -> list[dict]:
     schema = schema or settings.MONITORED_SCHEMA
-    fqn = f"{schema}.{table_name}"
+    fqn = f"{_qi(schema)}.{_qi(table_name)}"
 
     cols_query = text("""
         SELECT column_name
@@ -88,16 +93,16 @@ def column_nulls(table_name: str, schema: str | None = None) -> list[dict]:
             ).fetchall()
         ]
 
-    if not columns:
-        return []
+        if not columns:
+            return []
 
-    parts = ", ".join(
-        f"COUNT(*) FILTER (WHERE {c} IS NULL) AS {c}" for c in columns
-    )
-    count_query = text(
-        f"SELECT COUNT(*) AS total, {parts} FROM {fqn}"  # noqa: S608
-    )
-    with get_engine().connect() as conn:
+        parts = ", ".join(
+            f"COUNT(*) FILTER (WHERE {_qi(c)} IS NULL) AS {_qi(c)}"
+            for c in columns
+        )
+        count_query = text(
+            f"SELECT COUNT(*) AS total, {parts} FROM {fqn}"
+        )
         row = conn.execute(count_query).fetchone()
 
     total = row[0] if row else 0

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,114 @@
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from app.config import settings
+
+_engine: Engine | None = None
+
+
+def get_engine() -> Engine:
+    global _engine
+    if _engine is None:
+        _engine = create_engine(
+            settings.DATABASE_URL,
+            pool_size=5,
+            pool_pre_ping=True,
+        )
+    return _engine
+
+
+def list_tables(schema: str | None = None) -> list[dict]:
+    schema = schema or settings.MONITORED_SCHEMA
+    query = text("""
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = :schema
+          AND table_type = 'BASE TABLE'
+        ORDER BY table_name
+    """)
+    with get_engine().connect() as conn:
+        rows = conn.execute(query, {"schema": schema}).fetchall()
+    return [{"table_name": r[0], "schema": schema} for r in rows]
+
+
+def table_stats(table_name: str, schema: str | None = None) -> dict:
+    schema = schema or settings.MONITORED_SCHEMA
+    query = text("""
+        SELECT
+            n_live_tup,
+            pg_total_relation_size(
+                quote_ident(:schema) || '.' || quote_ident(:table_name)
+            ),
+            last_analyze,
+            last_autoanalyze
+        FROM pg_stat_user_tables
+        WHERE schemaname = :schema
+          AND relname = :table_name
+    """)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            query, {"schema": schema, "table_name": table_name}
+        ).fetchone()
+
+    if not row:
+        return {
+            "table_name": table_name,
+            "schema": schema,
+            "row_count": 0,
+            "size_bytes": 0,
+            "last_analyze": None,
+        }
+
+    last_analyze = row[2] or row[3]
+    return {
+        "table_name": table_name,
+        "schema": schema,
+        "row_count": int(row[0]),
+        "size_bytes": int(row[1]),
+        "last_analyze": str(last_analyze) if last_analyze else None,
+    }
+
+
+def column_nulls(table_name: str, schema: str | None = None) -> list[dict]:
+    schema = schema or settings.MONITORED_SCHEMA
+    fqn = f"{schema}.{table_name}"
+
+    cols_query = text("""
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = :schema
+          AND table_name = :table_name
+        ORDER BY ordinal_position
+    """)
+    with get_engine().connect() as conn:
+        columns = [
+            r[0]
+            for r in conn.execute(
+                cols_query, {"schema": schema, "table_name": table_name}
+            ).fetchall()
+        ]
+
+    if not columns:
+        return []
+
+    parts = ", ".join(
+        f"COUNT(*) FILTER (WHERE {c} IS NULL) AS {c}" for c in columns
+    )
+    count_query = text(
+        f"SELECT COUNT(*) AS total, {parts} FROM {fqn}"  # noqa: S608
+    )
+    with get_engine().connect() as conn:
+        row = conn.execute(count_query).fetchone()
+
+    total = row[0] if row else 0
+    results = []
+    for i, col in enumerate(columns):
+        null_count = row[i + 1] if row else 0
+        results.append(
+            {
+                "column": col,
+                "null_count": int(null_count),
+                "null_rate": round(null_count / total, 4) if total else 0.0,
+            }
+        )
+    return results

--- a/app/db.py
+++ b/app/db.py
@@ -1,20 +1,32 @@
+import threading
+
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 from app.config import settings
 
 _engine: Engine | None = None
+_engine_lock = threading.Lock()
 
 
 def get_engine() -> Engine:
     global _engine
     if _engine is None:
-        _engine = create_engine(
-            settings.DATABASE_URL,
-            pool_size=5,
-            pool_pre_ping=True,
-        )
+        with _engine_lock:
+            if _engine is None:
+                _engine = create_engine(
+                    settings.DATABASE_URL,
+                    pool_size=5,
+                    max_overflow=2,
+                    pool_pre_ping=True,
+                    connect_args={"connect_timeout": 5},
+                )
     return _engine
+
+
+def _qi(identifier: str) -> str:
+    """Quote a SQL identifier (schema, table, column) to prevent injection."""
+    return '"' + identifier.replace('"', '""') + '"'
 
 
 def list_tables(schema: str | None = None) -> list[dict]:
@@ -31,7 +43,7 @@ def list_tables(schema: str | None = None) -> list[dict]:
     return [{"table_name": r[0], "schema": schema} for r in rows]
 
 
-def table_stats(table_name: str, schema: str | None = None) -> dict:
+def table_stats(table_name: str, schema: str | None = None) -> dict | None:
     schema = schema or settings.MONITORED_SCHEMA
     query = text("""
         SELECT
@@ -51,13 +63,7 @@ def table_stats(table_name: str, schema: str | None = None) -> dict:
         ).fetchone()
 
     if not row:
-        return {
-            "table_name": table_name,
-            "schema": schema,
-            "row_count": 0,
-            "size_bytes": 0,
-            "last_analyze": None,
-        }
+        return None
 
     last_analyze = row[2] or row[3]
     return {
@@ -67,11 +73,6 @@ def table_stats(table_name: str, schema: str | None = None) -> dict:
         "size_bytes": int(row[1]),
         "last_analyze": str(last_analyze) if last_analyze else None,
     }
-
-
-def _qi(identifier: str) -> str:
-    """Quote a SQL identifier (schema, table, column) to prevent injection."""
-    return '"' + identifier.replace('"', '""') + '"'
 
 
 def column_nulls(table_name: str, schema: str | None = None) -> list[dict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,7 +1,3 @@
-import os
-
-os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
-
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -75,9 +71,7 @@ def test_table_stats_not_found(mock_conn):
 
     result = table_stats("nonexistent", schema="public")
 
-    assert result["row_count"] == 0
-    assert result["size_bytes"] == 0
-    assert result["last_analyze"] is None
+    assert result is None
 
 
 def test_column_nulls(mock_conn):

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,108 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
+
+import pytest
+
+from app.db import column_nulls, list_tables, table_stats
+
+
+@pytest.fixture
+def mock_conn():
+    conn = MagicMock()
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    with patch("app.db.get_engine", return_value=mock_engine):
+        yield conn
+
+
+def test_list_tables(mock_conn):
+    mock_conn.execute.return_value.fetchall.return_value = [
+        ("users",),
+        ("orders",),
+        ("products",),
+    ]
+
+    result = list_tables(schema="public")
+
+    assert len(result) == 3
+    assert result[0] == {"table_name": "users", "schema": "public"}
+    assert result[2] == {"table_name": "products", "schema": "public"}
+
+
+def test_list_tables_empty(mock_conn):
+    mock_conn.execute.return_value.fetchall.return_value = []
+
+    result = list_tables(schema="public")
+
+    assert result == []
+
+
+def test_table_stats(mock_conn):
+    mock_conn.execute.return_value.fetchone.return_value = (
+        1500,
+        65536,
+        "2026-04-17 03:00:00",
+        None,
+    )
+
+    result = table_stats("users", schema="public")
+
+    assert result["table_name"] == "users"
+    assert result["row_count"] == 1500
+    assert result["size_bytes"] == 65536
+    assert result["last_analyze"] == "2026-04-17 03:00:00"
+
+
+def test_table_stats_autoanalyze_fallback(mock_conn):
+    mock_conn.execute.return_value.fetchone.return_value = (
+        200,
+        8192,
+        None,
+        "2026-04-16 01:00:00",
+    )
+
+    result = table_stats("orders", schema="public")
+
+    assert result["last_analyze"] == "2026-04-16 01:00:00"
+
+
+def test_table_stats_not_found(mock_conn):
+    mock_conn.execute.return_value.fetchone.return_value = None
+
+    result = table_stats("nonexistent", schema="public")
+
+    assert result["row_count"] == 0
+    assert result["size_bytes"] == 0
+    assert result["last_analyze"] is None
+
+
+def test_column_nulls(mock_conn):
+    cols_result = MagicMock()
+    cols_result.fetchall.return_value = [("email",), ("age",), ("name",)]
+
+    count_result = MagicMock()
+    count_result.fetchone.return_value = (1000, 50, 0, 10)
+
+    mock_conn.execute.side_effect = [cols_result, count_result]
+
+    result = column_nulls("users", schema="public")
+
+    assert len(result) == 3
+    assert result[0] == {"column": "email", "null_count": 50, "null_rate": 0.05}
+    assert result[1] == {"column": "age", "null_count": 0, "null_rate": 0.0}
+    assert result[2] == {"column": "name", "null_count": 10, "null_rate": 0.01}
+
+
+def test_column_nulls_empty_table(mock_conn):
+    mock_conn.execute.return_value.fetchall.return_value = []
+
+    result = column_nulls("empty_table", schema="public")
+
+    assert result == []

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,11 +1,8 @@
 import os
-import sys
-from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 


### PR DESCRIPTION
## Summary

- `app/db.py` — слой подключения к мониторируемой PostgreSQL через SQLAlchemy
- Lazy init engine с thread-safe double-checked locking, `pool_size=5`, `max_overflow=2`, `pool_pre_ping=True`, `connect_timeout=5`
- Утилиты: `list_tables(schema)`, `table_stats(table)`, `column_nulls(table)` — параметризованные запросы, `quote_ident` через PostgreSQL для idfqn в `pg_total_relation_size`
- `_qi()` хелпер для безопасного квотирования идентификаторов в динамическом SQL
- 7 юнит-тестов с моком engine

## Test plan

- [x] `python -m pytest tests/test_db_utils.py` — 7/7 passed
- [ ] Smoke на реальной Supabase — `list_tables()` возвращает таблицы из `public`

Closes #7
