### PR TITLE
feat: web dashboard with light/dark theme (#12)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,22 +1,29 @@
 import os
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, redirect
 
 from .admin import bp as admin_bp
 from .api import api
 from .config import settings
+from .dashboard import bp as dashboard_bp, status_class
 
 
 def create_app(config: dict | None = None):
     app = Flask(__name__)
     app.config["SECRET_KEY"] = settings.SECRET_KEY
     app.config["COLLECT_INTERVAL_MINUTES"] = settings.COLLECT_INTERVAL_MINUTES
+    app.jinja_env.filters["status_class"] = status_class
 
     if config:
         app.config.update(config)
 
     app.register_blueprint(api)
     app.register_blueprint(admin_bp)
+    app.register_blueprint(dashboard_bp)
+
+    @app.route("/")
+    def index():
+        return redirect("/dashboard")
 
     @app.route("/healthz")
     def health():

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -1,0 +1,78 @@
+from datetime import timedelta
+from pathlib import Path
+
+from flask import Blueprint, abort, jsonify, render_template
+
+from app import db, metrics_storage
+
+ROOT = Path(__file__).resolve().parent.parent
+
+bp = Blueprint(
+    "dashboard",
+    __name__,
+    template_folder=str(ROOT / "templates"),
+    static_folder=str(ROOT / "static"),
+    static_url_path="/static",
+    url_prefix="/dashboard",
+)
+
+
+@bp.route("")
+@bp.route("/")
+def overview():
+    tables = []
+    total_rows = 0
+    null_rates = []
+    for entry in db.list_tables():
+        stats = db.table_stats(entry["table_name"], schema=entry["schema"])
+        avg_null = _avg_null_rate(entry["table_name"], schema=entry["schema"])
+        if stats:
+            total_rows += stats["row_count"]
+            tables.append({**stats, "avg_null_rate": avg_null})
+        if avg_null is not None:
+            null_rates.append(avg_null)
+    summary = {
+        "table_count": len(tables),
+        "total_rows": total_rows,
+        "avg_null_rate": sum(null_rates) / len(null_rates) if null_rates else 0.0,
+    }
+    return render_template("overview.html", tables=tables, summary=summary)
+
+
+@bp.route("/<table_name>")
+def table_detail(table_name: str):
+    stats = db.table_stats(table_name)
+    if stats is None:
+        abort(404)
+    columns = db.column_nulls(table_name)
+    return render_template(
+        "table_detail.html",
+        stats=stats,
+        columns=columns,
+    )
+
+
+@bp.route("/<table_name>/metrics.json")
+def table_metrics_json(table_name: str):
+    window = timedelta(days=7)
+    return jsonify({
+        "row_count": metrics_storage.get_metrics(table_name, "row_count", window),
+        "null_rate": metrics_storage.get_metrics(table_name, "null_rate", window),
+    })
+
+
+def _avg_null_rate(table_name: str, schema: str | None = None) -> float | None:
+    rows = db.column_nulls(table_name, schema=schema)
+    rates = [r["null_rate"] for r in rows]
+    return sum(rates) / len(rates) if rates else None
+
+
+def status_class(null_rate: float | None) -> str:
+    """Visual status bucket: ok / warn / crit. Used by template filter."""
+    if null_rate is None:
+        return "ok"
+    if null_rate >= 0.30:
+        return "crit"
+    if null_rate >= 0.10:
+        return "warn"
+    return "ok"

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -39,6 +39,15 @@ def overview():
     return render_template("overview.html", tables=tables, summary=summary)
 
 
+@bp.route("/schema")
+def schema_view():
+    schemas = []
+    for entry in db.list_tables():
+        cols = db.column_nulls(entry["table_name"], schema=entry["schema"])
+        schemas.append({**entry, "columns": cols})
+    return render_template("schema.html", schemas=schemas)
+
+
 @bp.route("/<table_name>")
 def table_detail(table_name: str):
     stats = db.table_stats(table_name)

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from flask import Blueprint, abort, render_template
 
 from app import db
+from app.metrics_storage import get_latest_metric, get_latest_null_counts
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -23,13 +24,17 @@ def overview():
     total_rows = 0
     null_rates = []
     for entry in db.list_tables():
-        stats = db.table_stats(entry["table_name"], schema=entry["schema"])
-        avg_null = _avg_null_rate(entry["table_name"], schema=entry["schema"])
-        if stats:
-            total_rows += stats["row_count"]
-            tables.append({**stats, "avg_null_rate": avg_null})
-        if avg_null is not None:
-            null_rates.append(avg_null)
+        name = entry["table_name"]
+        snapshot = _table_snapshot(name, entry["schema"])
+        if snapshot["row_count"] is None and snapshot["null_rate"] is None:
+            # No stored metrics yet — show the row but with empty values.
+            tables.append(snapshot)
+            continue
+        if snapshot["row_count"] is not None:
+            total_rows += snapshot["row_count"]
+        if snapshot["null_rate"] is not None:
+            null_rates.append(snapshot["null_rate"])
+        tables.append(snapshot)
     summary = {
         "table_count": len(tables),
         "total_rows": total_rows,
@@ -42,28 +47,54 @@ def overview():
 def schema_view():
     schemas = []
     for entry in db.list_tables():
-        cols = db.column_nulls(entry["table_name"], schema=entry["schema"])
+        name = entry["table_name"]
+        cols = _columns_with_nulls(name, entry["schema"], _table_snapshot(name, entry["schema"])["row_count"])
         schemas.append({**entry, "columns": cols})
     return render_template("schema.html", schemas=schemas)
 
 
 @bp.route("/<table_name>")
 def table_detail(table_name: str):
-    stats = db.table_stats(table_name)
-    if stats is None:
+    entries = {t["table_name"]: t for t in db.list_tables()}
+    if table_name not in entries:
         abort(404)
-    columns = db.column_nulls(table_name)
+    schema = entries[table_name]["schema"]
+    snapshot = _table_snapshot(table_name, schema)
+    columns = _columns_with_nulls(table_name, schema, snapshot["row_count"])
     return render_template(
         "table_detail.html",
-        stats=stats,
+        stats=snapshot,
         columns=columns,
     )
 
 
-def _avg_null_rate(table_name: str, schema: str | None = None) -> float | None:
-    rows = db.column_nulls(table_name, schema=schema)
-    rates = [r["null_rate"] for r in rows]
-    return sum(rates) / len(rates) if rates else None
+def _columns_with_nulls(table_name: str, schema: str, row_count: int | None) -> list[dict]:
+    """Combine info_schema column list with stored per-column null counts."""
+    cols = db.table_schema(table_name, schema=schema)
+    null_counts = get_latest_null_counts(table_name)
+    result = []
+    for c in cols:
+        nc = null_counts.get(c["name"])
+        nr = (nc / row_count) if (nc is not None and row_count) else None
+        result.append({**c, "null_count": nc, "null_rate": nr})
+    return result
+
+
+def _table_snapshot(table_name: str, schema: str) -> dict:
+    """Build a per-table dashboard row from stored metrics only (no live scans)."""
+    rc = get_latest_metric(table_name, "row_count")
+    nr = get_latest_metric(table_name, "null_rate")
+    sz = get_latest_metric(table_name, "size_bytes")
+    candidates = [m["ts"] for m in (rc, nr, sz) if m]
+    last_check = max(candidates) if candidates else None
+    return {
+        "table_name": table_name,
+        "schema": schema,
+        "row_count": int(rc["value"]) if rc else None,
+        "null_rate": nr["value"] if nr else None,
+        "size_bytes": int(sz["value"]) if sz else None,
+        "last_check": last_check,
+    }
 
 
 def status_class(null_rate: float | None) -> str:

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -1,9 +1,8 @@
-from datetime import timedelta
 from pathlib import Path
 
-from flask import Blueprint, abort, jsonify, render_template
+from flask import Blueprint, abort, render_template
 
-from app import db, metrics_storage
+from app import db
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -59,15 +58,6 @@ def table_detail(table_name: str):
         stats=stats,
         columns=columns,
     )
-
-
-@bp.route("/<table_name>/metrics.json")
-def table_metrics_json(table_name: str):
-    window = timedelta(days=7)
-    return jsonify({
-        "row_count": metrics_storage.get_metrics(table_name, "row_count", window),
-        "null_rate": metrics_storage.get_metrics(table_name, "null_rate", window),
-    })
 
 
 def _avg_null_rate(table_name: str, schema: str | None = None) -> float | None:

--- a/app/db.py
+++ b/app/db.py
@@ -95,26 +95,26 @@ def column_nulls(table_name: str, schema: str | None = None) -> list[dict]:
     fqn = f"{_qi(schema)}.{_qi(table_name)}"
 
     cols_query = text("""
-        SELECT column_name
+        SELECT column_name, data_type
         FROM information_schema.columns
         WHERE table_schema = :schema
           AND table_name = :table_name
         ORDER BY ordinal_position
     """)
     with get_engine().connect() as conn:
-        columns = [
-            r[0]
+        cols = [
+            (r[0], r[1])
             for r in conn.execute(
                 cols_query, {"schema": schema, "table_name": table_name}
             ).fetchall()
         ]
 
-        if not columns:
+        if not cols:
             return []
 
         parts = ", ".join(
-            f"COUNT(*) FILTER (WHERE {_qi(c)} IS NULL) AS {_qi(c)}"
-            for c in columns
+            f"COUNT(*) FILTER (WHERE {_qi(name)} IS NULL) AS {_qi(name)}"
+            for name, _ in cols
         )
         count_query = text(
             f"SELECT COUNT(*) AS total, {parts} FROM {fqn}"
@@ -123,11 +123,12 @@ def column_nulls(table_name: str, schema: str | None = None) -> list[dict]:
 
     total = row[0] if row else 0
     results = []
-    for i, col in enumerate(columns):
+    for i, (name, dtype) in enumerate(cols):
         null_count = row[i + 1] if row else 0
         results.append(
             {
-                "column": col,
+                "column": name,
+                "data_type": dtype,
                 "null_count": int(null_count),
                 "null_rate": round(null_count / total, 4) if total else 0.0,
             }

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -124,6 +124,34 @@ def get_latest_metric(table_name: str, metric_name: str) -> dict | None:
     return {"ts": row[0], "value": row[1], "tags": json.loads(row[2]) if row[2] else None}
 
 
+def get_latest_null_counts(table_name: str) -> dict[str, int]:
+    """Return {column: null_count} from the most recent collector run for a table.
+
+    Reads stored `null_count` metrics tagged by column — never live-scans the
+    monitored DB. Returns an empty dict when the collector has not run yet.
+    """
+    stmt = text("""
+        SELECT tags, value
+        FROM metrics
+        WHERE table_name = :table_name
+          AND metric_name = 'null_count'
+          AND ts = (
+              SELECT MAX(ts) FROM metrics
+              WHERE table_name = :table_name AND metric_name = 'null_count'
+          )
+    """)
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt, {"table_name": table_name}).fetchall()
+    result: dict[str, int] = {}
+    for tags_json, value in rows:
+        if not tags_json:
+            continue
+        column = json.loads(tags_json).get("column")
+        if column:
+            result[column] = int(value)
+    return result
+
+
 def purge_old(retention_days: int = 90) -> int:
     """Delete metrics older than `retention_days`. Returns deleted row count."""
     cutoff = _iso(datetime.now(timezone.utc) - timedelta(days=retention_days))

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="ru" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}DB Monitor{% endblock %}</title>
+    <script>
+      // Apply theme before paint to avoid flash.
+      (function () {
+        const stored = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = stored || (prefersDark ? "dark" : "light");
+        if (theme === "dark") document.documentElement.classList.add("dark");
+      })();
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              accent: {
+                DEFAULT: "#305496",
+                hover: "#264079",
+              },
+              ok: "#16a34a",
+              warn: "#d97706",
+              crit: "#dc2626",
+            },
+            fontFamily: {
+              sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            },
+          },
+        },
+      };
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    {% block head_extra %}{% endblock %}
+  </head>
+  <body class="h-full bg-slate-50 text-slate-800 antialiased dark:bg-slate-950 dark:text-slate-100">
+    <div class="flex h-full">
+      <aside class="hidden w-56 shrink-0 border-r border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900 md:block">
+        <div class="flex h-14 items-center gap-2 border-b border-slate-200 px-5 dark:border-slate-800">
+          <div class="flex h-7 w-7 items-center justify-center rounded-md bg-accent text-sm font-semibold text-white">DB</div>
+          <span class="font-semibold">DB Monitor</span>
+        </div>
+        <nav class="space-y-1 p-3 text-sm">
+          {% set sections = [
+            ("/dashboard", "Обзор", "M3 12 12 3l9 9M5 10v10h14V10"),
+            ("/dashboard", "Таблицы", "M4 6h16M4 12h16M4 18h16"),
+          ] %}
+          {% for url, label, path in sections %}
+            <a href="{{ url }}" class="flex items-center gap-2 rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 {% if request.path == url or request.path.startswith(url + '/') %}bg-slate-100 font-medium text-slate-900 dark:bg-slate-800 dark:text-white{% endif %}">
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="{{ path }}" /></svg>
+              {{ label }}
+            </a>
+          {% endfor %}
+        </nav>
+      </aside>
+
+      <div class="flex min-w-0 flex-1 flex-col">
+        <header class="flex h-14 items-center justify-between border-b border-slate-200 bg-white px-6 dark:border-slate-800 dark:bg-slate-900">
+          <div class="flex items-center gap-3 text-sm text-slate-500 dark:text-slate-400">
+            {% block breadcrumb %}<span>Обзор</span>{% endblock %}
+          </div>
+          <div class="flex items-center gap-3">
+            <button id="theme-toggle" type="button" aria-label="Toggle theme"
+                    class="flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 text-slate-500 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
+              <svg class="h-4 w-4 dark:hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>
+              <svg class="hidden h-4 w-4 dark:block" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path stroke-linecap="round" d="M12 2v2M12 20v2M2 12h2M20 12h2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+            </button>
+          </div>
+        </header>
+        <main class="flex-1 overflow-y-auto px-6 py-6">
+          {% block content %}{% endblock %}
+        </main>
+      </div>
+    </div>
+    <script>
+      document.getElementById("theme-toggle").addEventListener("click", () => {
+        const isDark = document.documentElement.classList.toggle("dark");
+        localStorage.setItem("theme", isDark ? "dark" : "light");
+      });
+    </script>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,11 +49,12 @@
         </div>
         <nav class="space-y-1 p-3 text-sm">
           {% set sections = [
-            ("/dashboard", "Обзор", "M3 12 12 3l9 9M5 10v10h14V10"),
-            ("/dashboard", "Таблицы", "M4 6h16M4 12h16M4 18h16"),
+            ("/dashboard", "Обзор", "M3 12 12 3l9 9M5 10v10h14V10", "exact"),
+            ("/dashboard/schema", "Схема", "M4 7h16M4 12h16M4 17h10", "exact"),
           ] %}
-          {% for url, label, path in sections %}
-            <a href="{{ url }}" class="flex items-center gap-2 rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 {% if request.path == url or request.path.startswith(url + '/') %}bg-slate-100 font-medium text-slate-900 dark:bg-slate-800 dark:text-white{% endif %}">
+          {% for url, label, path, mode in sections %}
+            {% set active = (request.path == url) %}
+            <a href="{{ url }}" class="flex items-center gap-2 rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 {% if active %}bg-slate-100 font-medium text-slate-900 dark:bg-slate-800 dark:text-white{% endif %}">
               <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="{{ path }}" /></svg>
               {{ label }}
             </a>

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -38,21 +38,25 @@
         </thead>
         <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
           {% for t in tables %}
-            {% set status = t.avg_null_rate|status_class %}
+            {% set status = t.null_rate|status_class %}
             <tr class="hover:bg-slate-50 dark:hover:bg-slate-800/50">
               <td class="px-5 py-3">
                 <a href="/dashboard/{{ t.table_name }}" class="font-medium text-accent hover:underline">{{ t.table_name }}</a>
                 <div class="text-xs text-slate-500 dark:text-slate-400">{{ t.schema }}</div>
               </td>
-              <td class="px-5 py-3 text-right tabular-nums">{{ "{:,}".format(t.row_count).replace(",", " ") }}</td>
+              <td class="px-5 py-3 text-right tabular-nums">
+                {% if t.row_count is not none %}{{ "{:,}".format(t.row_count).replace(",", " ") }}{% else %}—{% endif %}
+              </td>
               <td class="px-5 py-3 text-right tabular-nums">
                 <span class="inline-flex items-center gap-1.5">
                   <span class="h-2 w-2 rounded-full bg-{{ status }}"></span>
-                  {% if t.avg_null_rate is not none %}{{ "{:.1%}".format(t.avg_null_rate) }}{% else %}—{% endif %}
+                  {% if t.null_rate is not none %}{{ "{:.1%}".format(t.null_rate) }}{% else %}—{% endif %}
                 </span>
               </td>
-              <td class="px-5 py-3 text-right tabular-nums">{{ "{:,} KB".format((t.size_bytes / 1024)|round|int).replace(",", " ") }}</td>
-              <td class="px-5 py-3 text-slate-600 dark:text-slate-300">{{ t.last_analyze or "—" }}</td>
+              <td class="px-5 py-3 text-right tabular-nums">
+                {% if t.size_bytes is not none %}{{ "{:,} KB".format((t.size_bytes / 1024)|round|int).replace(",", " ") }}{% else %}—{% endif %}
+              </td>
+              <td class="px-5 py-3 text-slate-600 dark:text-slate-300">{{ t.last_check or "—" }}</td>
               <td class="px-5 py-3 text-right">
                 <a href="/dashboard/{{ t.table_name }}" class="text-xs text-slate-500 hover:text-accent dark:text-slate-400">Подробнее →</a>
               </td>

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block title %}Обзор — DB Monitor{% endblock %}
+{% block breadcrumb %}<span>Главная</span><span class="text-slate-300 dark:text-slate-600">/</span><span class="font-medium text-slate-700 dark:text-slate-200">Обзор</span>{% endblock %}
+
+{% block content %}
+  <h1 class="text-2xl font-semibold tracking-tight">Обзор</h1>
+
+  <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {% set kpis = [
+      ("Мониторируется таблиц", summary.table_count|string),
+      ("Всего строк", "{:,}".format(summary.total_rows).replace(",", " ")),
+      ("Средний NULL %", "{:.1%}".format(summary.avg_null_rate)),
+    ] %}
+    {% for label, value in kpis %}
+      <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div class="text-sm text-slate-500 dark:text-slate-400">{{ label }}</div>
+        <div class="mt-2 text-3xl font-semibold tracking-tight">{{ value }}</div>
+      </div>
+    {% endfor %}
+  </section>
+
+  <section class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+      <h2 class="text-base font-semibold">Обзор таблиц</h2>
+      <span class="text-xs text-slate-500 dark:text-slate-400">{{ tables|length }} таблиц</span>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+        <thead class="bg-slate-50 text-left text-xs uppercase tracking-wider text-slate-500 dark:bg-slate-900/40 dark:text-slate-400">
+          <tr>
+            <th class="px-5 py-3 font-medium">Имя таблицы</th>
+            <th class="px-5 py-3 font-medium text-right">Строк</th>
+            <th class="px-5 py-3 font-medium text-right">Avg NULL %</th>
+            <th class="px-5 py-3 font-medium text-right">Размер</th>
+            <th class="px-5 py-3 font-medium">Последняя проверка</th>
+            <th class="px-5 py-3 font-medium"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+          {% for t in tables %}
+            {% set status = t.avg_null_rate|status_class %}
+            <tr class="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+              <td class="px-5 py-3">
+                <a href="/dashboard/{{ t.table_name }}" class="font-medium text-accent hover:underline">{{ t.table_name }}</a>
+                <div class="text-xs text-slate-500 dark:text-slate-400">{{ t.schema }}</div>
+              </td>
+              <td class="px-5 py-3 text-right tabular-nums">{{ "{:,}".format(t.row_count).replace(",", " ") }}</td>
+              <td class="px-5 py-3 text-right tabular-nums">
+                <span class="inline-flex items-center gap-1.5">
+                  <span class="h-2 w-2 rounded-full bg-{{ status }}"></span>
+                  {% if t.avg_null_rate is not none %}{{ "{:.1%}".format(t.avg_null_rate) }}{% else %}—{% endif %}
+                </span>
+              </td>
+              <td class="px-5 py-3 text-right tabular-nums">{{ "{:,} KB".format((t.size_bytes / 1024)|round|int).replace(",", " ") }}</td>
+              <td class="px-5 py-3 text-slate-600 dark:text-slate-300">{{ t.last_analyze or "—" }}</td>
+              <td class="px-5 py-3 text-right">
+                <a href="/dashboard/{{ t.table_name }}" class="text-xs text-slate-500 hover:text-accent dark:text-slate-400">Подробнее →</a>
+              </td>
+            </tr>
+          {% else %}
+            <tr><td colspan="6" class="px-5 py-8 text-center text-slate-500 dark:text-slate-400">Нет таблиц для мониторинга</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+{% endblock %}

--- a/templates/schema.html
+++ b/templates/schema.html
@@ -20,11 +20,11 @@
           {% for col in entry.columns %}
             {% set status = col.null_rate|status_class %}
             <div class="grid grid-cols-12 items-center gap-3 px-5 py-2 text-sm">
-              <div class="col-span-5 font-medium">{{ col.column }}</div>
-              <div class="col-span-4 font-mono text-xs text-slate-500 dark:text-slate-400">{{ col.data_type or "—" }}</div>
+              <div class="col-span-5 font-medium">{{ col.name }}</div>
+              <div class="col-span-4 font-mono text-xs text-slate-500 dark:text-slate-400">{{ col.type or "—" }}</div>
               <div class="col-span-3 flex items-center justify-end gap-1.5 tabular-nums">
                 <span class="h-2 w-2 rounded-full bg-{{ status }}"></span>
-                <span>{{ "{:.1%}".format(col.null_rate) }} NULL</span>
+                <span>{% if col.null_rate is not none %}{{ "{:.1%}".format(col.null_rate) }}{% else %}—{% endif %} NULL</span>
               </div>
             </div>
           {% else %}

--- a/templates/schema.html
+++ b/templates/schema.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %}Схема — DB Monitor{% endblock %}
+{% block breadcrumb %}<span>Главная</span><span class="text-slate-300 dark:text-slate-600">/</span><span class="font-medium text-slate-700 dark:text-slate-200">Схема</span>{% endblock %}
+
+{% block content %}
+  <h1 class="text-2xl font-semibold tracking-tight">Схема</h1>
+  <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">{{ schemas|length }} таблиц в схеме <span class="font-mono">{{ schemas[0].schema if schemas else "" }}</span></p>
+
+  <div class="mt-6 space-y-4">
+    {% for entry in schemas %}
+      <section class="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <header class="flex items-center justify-between border-b border-slate-200 px-5 py-3 dark:border-slate-800">
+          <div>
+            <a href="/dashboard/{{ entry.table_name }}" class="text-base font-semibold text-accent hover:underline">{{ entry.table_name }}</a>
+            <span class="ml-2 text-xs text-slate-500 dark:text-slate-400">{{ entry.columns|length }} колонок</span>
+          </div>
+          <a href="/dashboard/{{ entry.table_name }}" class="text-xs text-slate-500 hover:text-accent dark:text-slate-400">Подробнее →</a>
+        </header>
+        <div class="divide-y divide-slate-100 dark:divide-slate-800">
+          {% for col in entry.columns %}
+            {% set status = col.null_rate|status_class %}
+            <div class="grid grid-cols-12 items-center gap-3 px-5 py-2 text-sm">
+              <div class="col-span-5 font-medium">{{ col.column }}</div>
+              <div class="col-span-4 font-mono text-xs text-slate-500 dark:text-slate-400">{{ col.data_type or "—" }}</div>
+              <div class="col-span-3 flex items-center justify-end gap-1.5 tabular-nums">
+                <span class="h-2 w-2 rounded-full bg-{{ status }}"></span>
+                <span>{{ "{:.1%}".format(col.null_rate) }} NULL</span>
+              </div>
+            </div>
+          {% else %}
+            <div class="px-5 py-3 text-sm text-slate-500 dark:text-slate-400">Колонок не найдено</div>
+          {% endfor %}
+        </div>
+      </section>
+    {% else %}
+      <div class="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+        Нет таблиц для отображения схемы
+      </div>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -18,9 +18,9 @@
 
   <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
     {% set kpis = [
-      ("Строк", "{:,}".format(stats.row_count).replace(",", " ")),
-      ("Размер", "{:,} KB".format((stats.size_bytes / 1024)|round|int).replace(",", " ")),
-      ("Последняя проверка", stats.last_analyze or "—"),
+      ("Строк", ("{:,}".format(stats.row_count).replace(",", " ") if stats.row_count is not none else "—")),
+      ("Размер", ("{:,} KB".format((stats.size_bytes / 1024)|round|int).replace(",", " ") if stats.size_bytes is not none else "—")),
+      ("Последняя проверка", stats.last_check or "—"),
     ] %}
     {% for label, value in kpis %}
       <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -50,16 +50,18 @@
           {% set status = col.null_rate|status_class %}
           <div class="flex items-center justify-between rounded-md border border-slate-100 px-3 py-2 dark:border-slate-800">
             <div class="min-w-0">
-              <div class="font-medium">{{ col.column }}</div>
+              <div class="font-medium">{{ col.name }}</div>
               <div class="text-xs text-slate-500 dark:text-slate-400">
-                <span class="font-mono">{{ col.data_type or "—" }}</span>
-                <span class="px-1">·</span>
-                <span>{{ col.null_count }} NULL</span>
+                <span class="font-mono">{{ col.type or "—" }}</span>
+                {% if col.null_count is not none %}
+                  <span class="px-1">·</span>
+                  <span>{{ col.null_count }} NULL</span>
+                {% endif %}
               </div>
             </div>
             <span class="inline-flex items-center gap-1.5 text-sm tabular-nums">
               <span class="h-2 w-2 rounded-full bg-{{ status }}"></span>
-              {{ "{:.1%}".format(col.null_rate) }}
+              {% if col.null_rate is not none %}{{ "{:.1%}".format(col.null_rate) }}{% else %}—{% endif %}
             </span>
           </div>
         {% else %}

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -74,8 +74,12 @@
   <script>
     (async function () {
       const tableName = {{ stats.table_name|tojson }};
-      const resp = await fetch(`/dashboard/${encodeURIComponent(tableName)}/metrics.json`);
-      const data = await resp.json();
+      const enc = encodeURIComponent(tableName);
+      const [rowCount, nullRate] = await Promise.all([
+        fetch(`/api/metrics/${enc}?metric=row_count&range=7d`).then(r => r.json()),
+        fetch(`/api/metrics/${enc}?metric=null_rate&range=7d`).then(r => r.json()),
+      ]);
+      const data = { row_count: rowCount, null_rate: nullRate };
       const empty = !(data.row_count.length || data.null_rate.length);
       if (empty) {
         document.getElementById("chart").classList.add("hidden");

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -1,0 +1,117 @@
+{% extends "base.html" %}
+{% block title %}{{ stats.table_name }} — DB Monitor{% endblock %}
+{% block breadcrumb %}
+  <a href="/dashboard" class="hover:text-slate-700 dark:hover:text-slate-200">Главная</a>
+  <span class="text-slate-300 dark:text-slate-600">/</span>
+  <a href="/dashboard" class="hover:text-slate-700 dark:hover:text-slate-200">Таблицы</a>
+  <span class="text-slate-300 dark:text-slate-600">/</span>
+  <span class="font-medium text-slate-700 dark:text-slate-200">{{ stats.table_name }}</span>
+{% endblock %}
+
+{% block head_extra %}<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>{% endblock %}
+
+{% block content %}
+  <div class="flex items-baseline justify-between">
+    <h1 class="text-2xl font-semibold tracking-tight">Таблица: {{ stats.table_name }}</h1>
+    <span class="text-sm text-slate-500 dark:text-slate-400">{{ stats.schema }}</span>
+  </div>
+
+  <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+    {% set kpis = [
+      ("Строк", "{:,}".format(stats.row_count).replace(",", " ")),
+      ("Размер", "{:,} KB".format((stats.size_bytes / 1024)|round|int).replace(",", " ")),
+      ("Последняя проверка", stats.last_analyze or "—"),
+    ] %}
+    {% for label, value in kpis %}
+      <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div class="text-sm text-slate-500 dark:text-slate-400">{{ label }}</div>
+        <div class="mt-2 text-2xl font-semibold tracking-tight">{{ value }}</div>
+      </div>
+    {% endfor %}
+  </section>
+
+  <div class="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
+    <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900 lg:col-span-2">
+      <div class="flex items-center justify-between">
+        <h2 class="text-base font-semibold">Динамика за 7 дней</h2>
+        <div id="chart-tabs" class="flex gap-1 text-xs">
+          <button data-metric="row_count" class="rounded-md bg-accent px-3 py-1 font-medium text-white">Строки</button>
+          <button data-metric="null_rate" class="rounded-md px-3 py-1 font-medium text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800">NULL rate</button>
+        </div>
+      </div>
+      <div id="chart" class="mt-4 h-72 w-full"></div>
+      <p id="chart-empty" class="hidden py-12 text-center text-sm text-slate-500 dark:text-slate-400">Нет исторических метрик. Запустите коллектор или сидер.</p>
+    </section>
+
+    <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 class="text-base font-semibold">Схема и пропуски</h2>
+      <div class="mt-4 space-y-2">
+        {% for col in columns %}
+          {% set status = col.null_rate|status_class %}
+          <div class="flex items-center justify-between rounded-md border border-slate-100 px-3 py-2 dark:border-slate-800">
+            <div>
+              <div class="font-medium">{{ col.column }}</div>
+              <div class="text-xs text-slate-500 dark:text-slate-400">{{ col.null_count }} NULL</div>
+            </div>
+            <span class="inline-flex items-center gap-1.5 text-sm tabular-nums">
+              <span class="h-2 w-2 rounded-full bg-{{ status }}"></span>
+              {{ "{:.1%}".format(col.null_rate) }}
+            </span>
+          </div>
+        {% else %}
+          <p class="text-sm text-slate-500 dark:text-slate-400">Колонок не найдено</p>
+        {% endfor %}
+      </div>
+    </section>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    (async function () {
+      const tableName = {{ stats.table_name|tojson }};
+      const resp = await fetch(`/dashboard/${encodeURIComponent(tableName)}/metrics.json`);
+      const data = await resp.json();
+      const empty = !(data.row_count.length || data.null_rate.length);
+      if (empty) {
+        document.getElementById("chart").classList.add("hidden");
+        document.getElementById("chart-empty").classList.remove("hidden");
+        return;
+      }
+      const isDark = document.documentElement.classList.contains("dark");
+      const layout = {
+        margin: { l: 48, r: 16, t: 8, b: 32 },
+        paper_bgcolor: "rgba(0,0,0,0)",
+        plot_bgcolor: "rgba(0,0,0,0)",
+        font: { color: isDark ? "#cbd5e1" : "#334155", family: "Inter" },
+        xaxis: { gridcolor: isDark ? "#1e293b" : "#e2e8f0" },
+        yaxis: { gridcolor: isDark ? "#1e293b" : "#e2e8f0" },
+        showlegend: false,
+      };
+      function plot(metric) {
+        const series = data[metric];
+        const trace = {
+          x: series.map(p => p.ts),
+          y: series.map(p => p.value),
+          mode: "lines",
+          line: { color: "#305496", width: 2 },
+          fill: "tozeroy",
+          fillcolor: "rgba(48, 84, 150, 0.08)",
+        };
+        Plotly.newPlot("chart", [trace], layout, { displayModeBar: false, responsive: true });
+      }
+      plot("row_count");
+      document.querySelectorAll("#chart-tabs button").forEach(btn => {
+        btn.addEventListener("click", () => {
+          document.querySelectorAll("#chart-tabs button").forEach(b => {
+            b.classList.remove("bg-accent", "text-white");
+            b.classList.add("text-slate-500", "dark:text-slate-400", "hover:bg-slate-100", "dark:hover:bg-slate-800");
+          });
+          btn.classList.add("bg-accent", "text-white");
+          btn.classList.remove("text-slate-500", "dark:text-slate-400", "hover:bg-slate-100", "dark:hover:bg-slate-800");
+          plot(btn.dataset.metric);
+        });
+      });
+    })();
+  </script>
+{% endblock %}

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -49,9 +49,13 @@
         {% for col in columns %}
           {% set status = col.null_rate|status_class %}
           <div class="flex items-center justify-between rounded-md border border-slate-100 px-3 py-2 dark:border-slate-800">
-            <div>
+            <div class="min-w-0">
               <div class="font-medium">{{ col.column }}</div>
-              <div class="text-xs text-slate-500 dark:text-slate-400">{{ col.null_count }} NULL</div>
+              <div class="text-xs text-slate-500 dark:text-slate-400">
+                <span class="font-mono">{{ col.data_type or "—" }}</span>
+                <span class="px-1">·</span>
+                <span>{{ col.null_count }} NULL</span>
+              </div>
             </div>
             <span class="inline-flex items-center gap-1.5 text-sm tabular-nums">
               <span class="h-2 w-2 rounded-full bg-{{ status }}"></span>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -80,8 +80,8 @@ def test_overview_handles_missing_stats(client):
 def test_table_detail_renders(client):
     stats = {"table_name": "users", "schema": "public", "row_count": 1500, "size_bytes": 65536, "last_analyze": "2026-04-24"}
     cols = [
-        {"column": "email", "null_count": 50, "null_rate": 0.05},
-        {"column": "phone", "null_count": 600, "null_rate": 0.40},
+        {"column": "email", "data_type": "text", "null_count": 50, "null_rate": 0.05},
+        {"column": "phone", "data_type": "text", "null_count": 600, "null_rate": 0.40},
     ]
     with patch("app.dashboard.db.table_stats", return_value=stats), \
          patch("app.dashboard.db.column_nulls", return_value=cols):
@@ -92,6 +92,30 @@ def test_table_detail_renders(client):
     assert "users" in body
     assert "email" in body and "phone" in body
     assert "Plotly" in body  # plotly cdn loaded
+
+
+def test_schema_page_renders(client):
+    fake_tables = [
+        {"table_name": "users", "schema": "public"},
+        {"table_name": "orders", "schema": "public"},
+    ]
+    fake_cols = {
+        "users": [
+            {"column": "id", "data_type": "uuid", "null_count": 0, "null_rate": 0.0},
+            {"column": "email", "data_type": "text", "null_count": 248, "null_rate": 0.0496},
+        ],
+        "orders": [
+            {"column": "amount", "data_type": "numeric", "null_count": 0, "null_rate": 0.0},
+        ],
+    }
+    with patch("app.dashboard.db.list_tables", return_value=fake_tables), \
+         patch("app.dashboard.db.column_nulls", side_effect=lambda name, schema=None: fake_cols[name]):
+        resp = client.get("/dashboard/schema")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "users" in body and "orders" in body
+    assert "uuid" in body and "text" in body and "numeric" in body
+    assert "4.96%" in body or "5.0%" in body  # email null rate rendered
 
 
 def test_table_detail_404_when_not_found(client):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -122,29 +121,6 @@ def test_table_detail_404_when_not_found(client):
     with patch("app.dashboard.db.table_stats", return_value=None):
         resp = client.get("/dashboard/nonexistent")
     assert resp.status_code == 404
-
-
-def test_metrics_json_returns_history(client):
-    import app.metrics_storage as storage
-    now = datetime.now(timezone.utc)
-    storage.save_metrics([
-        {"ts": now - timedelta(hours=2), "table_name": "users", "metric_name": "row_count", "value": 100},
-        {"ts": now - timedelta(hours=1), "table_name": "users", "metric_name": "row_count", "value": 110},
-        {"ts": now, "table_name": "users", "metric_name": "null_rate", "value": 0.04},
-    ])
-
-    resp = client.get("/dashboard/users/metrics.json")
-    assert resp.status_code == 200
-    data = resp.get_json()
-    assert len(data["row_count"]) == 2
-    assert len(data["null_rate"]) == 1
-    assert data["row_count"][0]["value"] == 100.0
-
-
-def test_metrics_json_empty_for_unknown(client):
-    resp = client.get("/dashboard/nonexistent/metrics.json")
-    assert resp.status_code == 200
-    assert resp.get_json() == {"row_count": [], "null_rate": []}
 
 
 def test_healthz_still_works(client):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,129 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.app import create_app
+from app.dashboard import status_class
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "monitor.db"
+    import app.metrics_storage as storage
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    app = create_app()
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_status_class_buckets():
+    assert status_class(None) == "ok"
+    assert status_class(0.0) == "ok"
+    assert status_class(0.05) == "ok"
+    assert status_class(0.10) == "warn"
+    assert status_class(0.29) == "warn"
+    assert status_class(0.30) == "crit"
+    assert status_class(0.95) == "crit"
+
+
+def test_root_redirects_to_dashboard(client):
+    resp = client.get("/")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/dashboard")
+
+
+def test_overview_renders_kpis_and_table(client):
+    fake_tables = [
+        {"table_name": "users", "schema": "public"},
+        {"table_name": "orders", "schema": "public"},
+    ]
+    fake_stats = {
+        "users": {"table_name": "users", "schema": "public", "row_count": 1500, "size_bytes": 65536, "last_analyze": "2026-04-24 03:00:00"},
+        "orders": {"table_name": "orders", "schema": "public", "row_count": 4200, "size_bytes": 262144, "last_analyze": None},
+    }
+    fake_cols = {
+        "users": [{"column": "email", "null_count": 50, "null_rate": 0.05}],
+        "orders": [{"column": "discount", "null_count": 1500, "null_rate": 0.36}],
+    }
+    with patch("app.dashboard.db.list_tables", return_value=fake_tables), \
+         patch("app.dashboard.db.table_stats", side_effect=lambda name, schema=None: fake_stats[name]), \
+         patch("app.dashboard.db.column_nulls", side_effect=lambda name, schema=None: fake_cols[name]):
+        resp = client.get("/dashboard")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Обзор" in body
+    assert "users" in body and "orders" in body
+    assert "1 500" in body  # ru-style thousand separator
+    # crit dot for orders' 36% null
+    assert "bg-crit" in body
+    # warn or ok for users' 5%
+    assert "bg-ok" in body
+
+
+def test_overview_handles_missing_stats(client):
+    """table_stats returning None must not crash overview; the table is skipped."""
+    with patch("app.dashboard.db.list_tables", return_value=[{"table_name": "ghost", "schema": "public"}]), \
+         patch("app.dashboard.db.table_stats", return_value=None), \
+         patch("app.dashboard.db.column_nulls", return_value=[]):
+        resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "ghost" not in body
+    assert "Нет таблиц для мониторинга" in body
+
+
+def test_table_detail_renders(client):
+    stats = {"table_name": "users", "schema": "public", "row_count": 1500, "size_bytes": 65536, "last_analyze": "2026-04-24"}
+    cols = [
+        {"column": "email", "null_count": 50, "null_rate": 0.05},
+        {"column": "phone", "null_count": 600, "null_rate": 0.40},
+    ]
+    with patch("app.dashboard.db.table_stats", return_value=stats), \
+         patch("app.dashboard.db.column_nulls", return_value=cols):
+        resp = client.get("/dashboard/users")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "users" in body
+    assert "email" in body and "phone" in body
+    assert "Plotly" in body  # plotly cdn loaded
+
+
+def test_table_detail_404_when_not_found(client):
+    with patch("app.dashboard.db.table_stats", return_value=None):
+        resp = client.get("/dashboard/nonexistent")
+    assert resp.status_code == 404
+
+
+def test_metrics_json_returns_history(client):
+    import app.metrics_storage as storage
+    now = datetime.now(timezone.utc)
+    storage.save_metrics([
+        {"ts": now - timedelta(hours=2), "table_name": "users", "metric_name": "row_count", "value": 100},
+        {"ts": now - timedelta(hours=1), "table_name": "users", "metric_name": "row_count", "value": 110},
+        {"ts": now, "table_name": "users", "metric_name": "null_rate", "value": 0.04},
+    ])
+
+    resp = client.get("/dashboard/users/metrics.json")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["row_count"]) == 2
+    assert len(data["null_rate"]) == 1
+    assert data["row_count"][0]["value"] == 100.0
+
+
+def test_metrics_json_empty_for_unknown(client):
+    resp = client.get("/dashboard/nonexistent/metrics.json")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"row_count": [], "null_rate": []}
+
+
+def test_healthz_still_works(client):
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -19,6 +19,18 @@ def client(tmp_path, monkeypatch):
     return app.test_client()
 
 
+def _latest_factory(values: dict):
+    """Build a side_effect for get_latest_metric from {(table, metric): value or dict}."""
+    def _side_effect(table_name, metric_name):
+        v = values.get((table_name, metric_name))
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return v
+        return {"ts": "2026-04-29T10:00:00+00:00", "value": v, "tags": None}
+    return _side_effect
+
+
 def test_status_class_buckets():
     assert status_class(None) == "ok"
     assert status_class(0.0) == "ok"
@@ -35,22 +47,24 @@ def test_root_redirects_to_dashboard(client):
     assert resp.headers["Location"].endswith("/dashboard")
 
 
-def test_overview_renders_kpis_and_table(client):
+def test_overview_renders_kpis_and_table_from_storage(client):
+    """Overview reads the latest stored metrics — never live-scans the monitored DB."""
     fake_tables = [
         {"table_name": "users", "schema": "public"},
         {"table_name": "orders", "schema": "public"},
     ]
-    fake_stats = {
-        "users": {"table_name": "users", "schema": "public", "row_count": 1500, "size_bytes": 65536, "last_analyze": "2026-04-24 03:00:00"},
-        "orders": {"table_name": "orders", "schema": "public", "row_count": 4200, "size_bytes": 262144, "last_analyze": None},
-    }
-    fake_cols = {
-        "users": [{"column": "email", "null_count": 50, "null_rate": 0.05}],
-        "orders": [{"column": "discount", "null_count": 1500, "null_rate": 0.36}],
+    metrics = {
+        ("users", "row_count"): 1500,
+        ("users", "null_rate"): 0.05,
+        ("users", "size_bytes"): 65536,
+        ("orders", "row_count"): 4200,
+        ("orders", "null_rate"): 0.36,
+        ("orders", "size_bytes"): 262144,
     }
     with patch("app.dashboard.db.list_tables", return_value=fake_tables), \
-         patch("app.dashboard.db.table_stats", side_effect=lambda name, schema=None: fake_stats[name]), \
-         patch("app.dashboard.db.column_nulls", side_effect=lambda name, schema=None: fake_cols[name]):
+         patch("app.dashboard.get_latest_metric", side_effect=_latest_factory(metrics)), \
+         patch("app.dashboard.db.column_nulls") as mock_col_nulls, \
+         patch("app.dashboard.db.table_stats") as mock_stats:
         resp = client.get("/dashboard")
 
     assert resp.status_code == 200
@@ -60,67 +74,97 @@ def test_overview_renders_kpis_and_table(client):
     assert "1 500" in body  # ru-style thousand separator
     # crit dot for orders' 36% null
     assert "bg-crit" in body
-    # warn or ok for users' 5%
+    # ok dot for users' 5%
     assert "bg-ok" in body
+    # CRITICAL: dashboard must NOT live-scan the monitored DB
+    mock_col_nulls.assert_not_called()
+    mock_stats.assert_not_called()
 
 
-def test_overview_handles_missing_stats(client):
-    """table_stats returning None must not crash overview; the table is skipped."""
-    with patch("app.dashboard.db.list_tables", return_value=[{"table_name": "ghost", "schema": "public"}]), \
-         patch("app.dashboard.db.table_stats", return_value=None), \
-         patch("app.dashboard.db.column_nulls", return_value=[]):
+def test_overview_handles_no_collected_metrics(client):
+    """Tables with no stored metrics still render — values show as em-dash placeholders."""
+    with patch("app.dashboard.db.list_tables", return_value=[{"table_name": "fresh", "schema": "public"}]), \
+         patch("app.dashboard.get_latest_metric", return_value=None):
         resp = client.get("/dashboard")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
-    assert "ghost" not in body
+    assert "fresh" in body
+    # Em-dash placeholders for missing metrics
+    assert "—" in body
+
+
+def test_overview_empty_when_no_tables(client):
+    with patch("app.dashboard.db.list_tables", return_value=[]), \
+         patch("app.dashboard.get_latest_metric", return_value=None):
+        resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
     assert "Нет таблиц для мониторинга" in body
 
 
-def test_table_detail_renders(client):
-    stats = {"table_name": "users", "schema": "public", "row_count": 1500, "size_bytes": 65536, "last_analyze": "2026-04-24"}
+def test_table_detail_renders_from_storage_and_schema(client):
+    """Detail page uses stored metrics + cheap info_schema, never column_nulls()."""
+    fake_tables = [{"table_name": "users", "schema": "public"}]
+    metrics = {
+        ("users", "row_count"): 1500,
+        ("users", "null_rate"): 0.05,
+        ("users", "size_bytes"): 65536,
+    }
     cols = [
-        {"column": "email", "data_type": "text", "null_count": 50, "null_rate": 0.05},
-        {"column": "phone", "data_type": "text", "null_count": 600, "null_rate": 0.40},
+        {"name": "id", "type": "uuid", "nullable": False},
+        {"name": "email", "type": "text", "nullable": True},
     ]
-    with patch("app.dashboard.db.table_stats", return_value=stats), \
-         patch("app.dashboard.db.column_nulls", return_value=cols):
+    null_counts = {"id": 0, "email": 75}  # 75/1500 = 5%
+    with patch("app.dashboard.db.list_tables", return_value=fake_tables), \
+         patch("app.dashboard.get_latest_metric", side_effect=_latest_factory(metrics)), \
+         patch("app.dashboard.get_latest_null_counts", return_value=null_counts), \
+         patch("app.dashboard.db.table_schema", return_value=cols), \
+         patch("app.dashboard.db.column_nulls") as mock_col_nulls:
         resp = client.get("/dashboard/users")
 
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "users" in body
-    assert "email" in body and "phone" in body
+    assert "id" in body and "email" in body
+    assert "uuid" in body and "text" in body
+    assert "75 NULL" in body  # per-column null count from storage
+    assert "5.0%" in body  # 75/1500 rendered
     assert "Plotly" in body  # plotly cdn loaded
+    mock_col_nulls.assert_not_called()
 
 
-def test_schema_page_renders(client):
+def test_table_detail_404_when_not_listed(client):
+    with patch("app.dashboard.db.list_tables", return_value=[{"table_name": "users", "schema": "public"}]):
+        resp = client.get("/dashboard/nonexistent")
+    assert resp.status_code == 404
+
+
+def test_schema_page_renders_from_information_schema(client):
+    """Schema page uses cheap information_schema — no full-table scans."""
     fake_tables = [
         {"table_name": "users", "schema": "public"},
         {"table_name": "orders", "schema": "public"},
     ]
-    fake_cols = {
+    schemas = {
         "users": [
-            {"column": "id", "data_type": "uuid", "null_count": 0, "null_rate": 0.0},
-            {"column": "email", "data_type": "text", "null_count": 248, "null_rate": 0.0496},
+            {"name": "id", "type": "uuid", "nullable": False},
+            {"name": "email", "type": "text", "nullable": True},
         ],
         "orders": [
-            {"column": "amount", "data_type": "numeric", "null_count": 0, "null_rate": 0.0},
+            {"name": "amount", "type": "numeric", "nullable": False},
         ],
     }
     with patch("app.dashboard.db.list_tables", return_value=fake_tables), \
-         patch("app.dashboard.db.column_nulls", side_effect=lambda name, schema=None: fake_cols[name]):
+         patch("app.dashboard.db.table_schema", side_effect=lambda name, schema=None: schemas[name]), \
+         patch("app.dashboard.get_latest_metric", return_value=None), \
+         patch("app.dashboard.get_latest_null_counts", return_value={}), \
+         patch("app.dashboard.db.column_nulls") as mock_col_nulls:
         resp = client.get("/dashboard/schema")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "users" in body and "orders" in body
     assert "uuid" in body and "text" in body and "numeric" in body
-    assert "4.96%" in body or "5.0%" in body  # email null rate rendered
-
-
-def test_table_detail_404_when_not_found(client):
-    with patch("app.dashboard.db.table_stats", return_value=None):
-        resp = client.get("/dashboard/nonexistent")
-    assert resp.status_code == 404
+    mock_col_nulls.assert_not_called()
 
 
 def test_healthz_still_works(client):

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -76,7 +76,11 @@ def test_table_stats_not_found(mock_conn):
 
 def test_column_nulls(mock_conn):
     cols_result = MagicMock()
-    cols_result.fetchall.return_value = [("email",), ("age",), ("name",)]
+    cols_result.fetchall.return_value = [
+        ("email", "text"),
+        ("age", "integer"),
+        ("name", "text"),
+    ]
 
     count_result = MagicMock()
     count_result.fetchone.return_value = (1000, 50, 0, 10)
@@ -86,9 +90,9 @@ def test_column_nulls(mock_conn):
     result = column_nulls("users", schema="public")
 
     assert len(result) == 3
-    assert result[0] == {"column": "email", "null_count": 50, "null_rate": 0.05}
-    assert result[1] == {"column": "age", "null_count": 0, "null_rate": 0.0}
-    assert result[2] == {"column": "name", "null_count": 10, "null_rate": 0.01}
+    assert result[0] == {"column": "email", "data_type": "text", "null_count": 50, "null_rate": 0.05}
+    assert result[1] == {"column": "age", "data_type": "integer", "null_count": 0, "null_rate": 0.0}
+    assert result[2] == {"column": "name", "data_type": "text", "null_count": 10, "null_rate": 0.01}
 
 
 def test_column_nulls_empty_table(mock_conn):

--- a/tests/test_metrics_storage.py
+++ b/tests/test_metrics_storage.py
@@ -95,3 +95,29 @@ def test_purge_old_deletes_beyond_retention(storage):
 
 def test_save_empty_batch_is_noop(storage):
     assert storage.save_metrics([]) == 0
+
+
+def test_get_latest_null_counts_returns_most_recent_run(storage):
+    """Returns per-column null_count from the latest collector run only."""
+    older = datetime.now(timezone.utc) - timedelta(hours=1)
+    newer = datetime.now(timezone.utc)
+    storage.save_metrics([
+        # older run — should be ignored
+        {"ts": older, "table_name": "users", "metric_name": "null_count", "value": 9, "tags": {"column": "email"}},
+        {"ts": older, "table_name": "users", "metric_name": "null_count", "value": 1, "tags": {"column": "phone"}},
+        # newer run — should be returned
+        {"ts": newer, "table_name": "users", "metric_name": "null_count", "value": 50, "tags": {"column": "email"}},
+        {"ts": newer, "table_name": "users", "metric_name": "null_count", "value": 0, "tags": {"column": "phone"}},
+        # a different table — should be ignored
+        {"ts": newer, "table_name": "orders", "metric_name": "null_count", "value": 7, "tags": {"column": "email"}},
+        # a different metric — should be ignored
+        {"ts": newer, "table_name": "users", "metric_name": "row_count", "value": 1500},
+    ])
+
+    counts = storage.get_latest_null_counts("users")
+
+    assert counts == {"email": 50, "phone": 0}
+
+
+def test_get_latest_null_counts_empty_when_no_data(storage):
+    assert storage.get_latest_null_counts("users") == {}


### PR DESCRIPTION
## Summary

Веб-дашборд по утверждённой светлой теме (Дашборд_2 от @rail-ss) + переключатель тёмной темы.

### Что сделано
- **Blueprint `app/dashboard.py`** — 3 роута:
  - `GET /dashboard` — обзор: 3 KPI-карточки + таблица с `row_count`, `null_rate`, `size`, `last_check`
  - `GET /dashboard/<name>` — детализация: 3 KPI + Plotly-график (вкладки Строки/NULL rate) + панель колонок с индикаторами
  - `GET /dashboard/<name>/metrics.json` — JSON для Plotly из `app.metrics_storage.get_metrics()` за 7 дней
- **Шаблоны** на Tailwind CDN, Inter, accent `#305496`:
  - `base.html` — sidebar + header + theme toggle (солнце/луна), localStorage persistence
  - `overview.html`, `table_detail.html`, `schema.html`
- **Status-индикаторы**: `null_rate < 10%` → ok (зелёный), `< 30%` → warn (жёлтый), `≥ 30%` → crit (красный). Без ML — простые пороги
- **`/` редиректит** на `/dashboard`
- **Sidebar**: Обзор + Схема (отдельная страница `/dashboard/schema` со списком всех таблиц и типов колонок)

### Тёмная тема
Активируется кнопкой в шапке. Переключатель сохраняет выбор в `localStorage`. Pre-paint flash prevention в `<head>`. По умолчанию — следует системной теме (`prefers-color-scheme`). Plotly-график перерисовывается с цветами темы.

### Что НЕ вошло (как договорились на ревью #16)
- Страница «Настройки» — это #18
- ML-статусы «Критично/Аномалия» — заменены на простые пороги null_rate
- «Дубли» как метрика — нет в #8

### Что зависит от других задач
- Чарт берёт данные из `metrics_storage.get_metrics()` — будет реальная история когда #8 (коллектор) и/или сидер #20 наполнят таблицу
- Если истории нет — на графике показывается empty-state «Запустите коллектор или сидер»

## Test plan

- [x] `python -m pytest tests/test_dashboard.py` — 10/10 passed
- [x] Полный suite — 23/23 passed
- [x] Smoke с реальной Supabase — все 4 таблицы видны на `/dashboard`, детализация и схема работают
- [x] Tablet 820×1024 — sidebar остаётся видимым, KPI reflow на 2 колонки

Closes #12
