### PR TITLE
feat: REST API endpoints for dashboard (#11)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,58 @@
+from datetime import timedelta
+
+from flask import Blueprint, jsonify, request
+
+from .db import list_tables, table_schema
+from .metrics_storage import get_latest_metric, get_metrics
+
+api = Blueprint("api", __name__, url_prefix="/api")
+
+_VALID_METRICS = {"row_count", "null_rate"}
+_RANGES = {
+    "1h": timedelta(hours=1),
+    "6h": timedelta(hours=6),
+    "24h": timedelta(hours=24),
+    "7d": timedelta(days=7),
+    "14d": timedelta(days=14),
+    "30d": timedelta(days=30),
+}
+
+
+@api.route("/tables")
+def tables():
+    result = []
+    for t in list_tables():
+        name = t["table_name"]
+        rc = get_latest_metric(name, "row_count")
+        nr = get_latest_metric(name, "null_rate")
+        candidates = [x["ts"] for x in (rc, nr) if x]
+        last_check = max(candidates) if candidates else None
+        result.append({
+            "table_name": name,
+            "row_count": rc["value"] if rc else None,
+            "null_rate": nr["value"] if nr else None,
+            "last_check": last_check,
+        })
+    return jsonify(result)
+
+
+@api.route("/metrics/<table_name>")
+def metrics(table_name: str):
+    metric = request.args.get("metric", "row_count")
+    range_str = request.args.get("range", "24h")
+
+    if metric not in _VALID_METRICS:
+        return jsonify({"error": f"metric must be one of {sorted(_VALID_METRICS)}"}), 400
+    if range_str not in _RANGES:
+        return jsonify({"error": f"range must be one of {sorted(_RANGES)}"}), 400
+
+    rows = get_metrics(table_name, metric, window=_RANGES[range_str])
+    return jsonify([{"ts": r["ts"], "value": r["value"]} for r in rows])
+
+
+@api.route("/schema/<table_name>")
+def schema(table_name: str):
+    columns = table_schema(table_name)
+    if not columns:
+        return jsonify({"error": "table not found"}), 404
+    return jsonify(columns)

--- a/app/api.py
+++ b/app/api.py
@@ -20,6 +20,12 @@ _RANGES = {
 
 @api.route("/tables")
 def tables():
+    """List monitored tables with their latest collected metrics.
+
+    Returns row_count, null_rate and last_check as null until the metrics
+    collector has run at least once. Schedule: every COLLECT_INTERVAL_MINUTES
+    (default 15 min) via APScheduler.
+    """
     result = []
     for t in list_tables():
         name = t["table_name"]
@@ -38,6 +44,14 @@ def tables():
 
 @api.route("/metrics/<table_name>")
 def metrics(table_name: str):
+    """Return time-series data for a single metric of a table.
+
+    Query params:
+      metric — one of the values in _VALID_METRICS (default: row_count)
+      range  — one of 1h | 6h | 24h | 7d | 14d | 30d (default: 24h)
+
+    Returns [] when no data exists for the requested window.
+    """
     metric = request.args.get("metric", "row_count")
     range_str = request.args.get("range", "24h")
 
@@ -52,6 +66,10 @@ def metrics(table_name: str):
 
 @api.route("/schema/<table_name>")
 def schema(table_name: str):
+    """Return column schema for a table: [{name, type, nullable}].
+
+    Returns 404 when the table does not exist in the monitored schema.
+    """
     columns = table_schema(table_name)
     if not columns:
         return jsonify({"error": "table not found"}), 404

--- a/app/app.py
+++ b/app/app.py
@@ -1,11 +1,14 @@
 from flask import Flask, jsonify
 
+from .api import api
 from .config import settings
 
 
 def create_app():
     app = Flask(__name__)
     app.config["SECRET_KEY"] = settings.SECRET_KEY
+
+    app.register_blueprint(api)
 
     @app.route("/healthz")
     def health():

--- a/app/db.py
+++ b/app/db.py
@@ -75,6 +75,21 @@ def table_stats(table_name: str, schema: str | None = None) -> dict | None:
     }
 
 
+def table_schema(table_name: str, schema: str | None = None) -> list[dict]:
+    schema = schema or settings.MONITORED_SCHEMA
+    query = text("""
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = :schema AND table_name = :table_name
+        ORDER BY ordinal_position
+    """)
+    with get_engine().connect() as conn:
+        rows = conn.execute(
+            query, {"schema": schema, "table_name": table_name}
+        ).fetchall()
+    return [{"name": r[0], "type": r[1], "nullable": r[2] == "YES"} for r in rows]
+
+
 def column_nulls(table_name: str, schema: str | None = None) -> list[dict]:
     schema = schema or settings.MONITORED_SCHEMA
     fqn = f"{_qi(schema)}.{_qi(table_name)}"

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -106,6 +106,24 @@ def get_metrics(
     ]
 
 
+def get_latest_metric(table_name: str, metric_name: str) -> dict | None:
+    """Return the most recent {ts, value, tags} for (table, metric), or None."""
+    stmt = text("""
+        SELECT ts, value, tags
+        FROM metrics
+        WHERE table_name = :table_name AND metric_name = :metric_name
+        ORDER BY ts DESC
+        LIMIT 1
+    """)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            stmt, {"table_name": table_name, "metric_name": metric_name}
+        ).fetchone()
+    if not row:
+        return None
+    return {"ts": row[0], "value": row[1], "tags": json.loads(row[2]) if row[2] else None}
+
+
 def purge_old(retention_days: int = 90) -> int:
     """Delete metrics older than `retention_days`. Returns deleted row count."""
     cutoff = _iso(datetime.now(timezone.utc) - timedelta(days=retention_days))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,127 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tables
+# ---------------------------------------------------------------------------
+
+def test_tables_returns_list(client):
+    tables = [{"table_name": "users", "schema": "public"}]
+    rc = {"ts": "2026-04-25T10:00:00+00:00", "value": 50000.0, "tags": None}
+    nr = {"ts": "2026-04-25T10:00:00+00:00", "value": 0.05, "tags": None}
+
+    with patch("app.api.list_tables", return_value=tables), \
+         patch("app.api.get_latest_metric", side_effect=[rc, nr]):
+        resp = client.get("/api/tables")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]["table_name"] == "users"
+    assert data[0]["row_count"] == 50000.0
+    assert data[0]["null_rate"] == 0.05
+    assert data[0]["last_check"] == "2026-04-25T10:00:00+00:00"
+
+
+def test_tables_no_metrics_returns_nulls(client):
+    tables = [{"table_name": "empty_table", "schema": "public"}]
+
+    with patch("app.api.list_tables", return_value=tables), \
+         patch("app.api.get_latest_metric", return_value=None):
+        resp = client.get("/api/tables")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data[0]["row_count"] is None
+    assert data[0]["null_rate"] is None
+    assert data[0]["last_check"] is None
+
+
+def test_tables_empty_db(client):
+    with patch("app.api.list_tables", return_value=[]), \
+         patch("app.api.get_latest_metric", return_value=None):
+        resp = client.get("/api/tables")
+
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/metrics/<table>
+# ---------------------------------------------------------------------------
+
+def test_metrics_default_params(client):
+    rows = [
+        {"ts": "2026-04-24T10:00:00+00:00", "value": 100.0, "tags": None},
+        {"ts": "2026-04-25T10:00:00+00:00", "value": 110.0, "tags": None},
+    ]
+    with patch("app.api.get_metrics", return_value=rows) as mock_get:
+        resp = client.get("/api/metrics/users")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 2
+    assert data[0] == {"ts": "2026-04-24T10:00:00+00:00", "value": 100.0}
+    from datetime import timedelta
+    mock_get.assert_called_once_with("users", "row_count", window=timedelta(hours=24))
+
+
+def test_metrics_custom_params(client):
+    with patch("app.api.get_metrics", return_value=[]) as mock_get:
+        resp = client.get("/api/metrics/orders?metric=null_rate&range=7d")
+
+    assert resp.status_code == 200
+    from datetime import timedelta
+    mock_get.assert_called_once_with("orders", "null_rate", window=timedelta(days=7))
+
+
+def test_metrics_invalid_metric(client):
+    resp = client.get("/api/metrics/users?metric=bad_metric")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_metrics_invalid_range(client):
+    resp = client.get("/api/metrics/users?range=999d")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/schema/<table>
+# ---------------------------------------------------------------------------
+
+def test_schema_returns_columns(client):
+    columns = [
+        {"name": "id", "type": "integer", "nullable": False},
+        {"name": "email", "type": "character varying", "nullable": True},
+    ]
+    with patch("app.api.table_schema", return_value=columns):
+        resp = client.get("/api/schema/users")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 2
+    assert data[0] == {"name": "id", "type": "integer", "nullable": False}
+    assert data[1]["nullable"] is True
+
+
+def test_schema_table_not_found(client):
+    with patch("app.api.table_schema", return_value=[]):
+        resp = client.get("/api/schema/nonexistent")
+
+    assert resp.status_code == 404
+    assert "error" in resp.get_json()


### PR DESCRIPTION
## Summary
- `GET /api/tables` — список отслеживаемых таблиц с текущими метриками (`row_count`, `null_rate`, `last_check`)
- `GET /api/metrics/<table>?metric=row_count&range=24h` — временной ряд `{ts, value}`, поддерживает `1h / 6h / 24h / 7d / 14d / 30d`
- `GET /api/schema/<table>` — snapshot схемы `{name, type, nullable}`, 404 если таблица не найдена
- Валидация `metric` и `range` вручную, невалидные значения → 400 с описанием ошибки

## Closes
Closes #11

## Test plan
- [x] Тесты проходят: `pytest tests/test_api.py` (9/9)
- [ ] `GET /api/tables` возвращает список таблиц с метриками
- [ ] `GET /api/metrics/users?metric=row_count&range=7d` возвращает временной ряд
- [ ] `GET /api/metrics/users?metric=bad` возвращает 400
- [ ] `GET /api/schema/users` возвращает колонки с типами
- [ ] `GET /api/schema/nonexistent` возвращает 404