### PR TITLE
feat: metrics collector for basic table quality metrics (#8)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -7,7 +7,7 @@ from .metrics_storage import get_latest_metric, get_metrics
 
 api = Blueprint("api", __name__, url_prefix="/api")
 
-_VALID_METRICS = {"row_count", "null_rate"}
+_VALID_METRICS = {"row_count", "null_rate", "null_count", "size_bytes", "last_modified"}
 _RANGES = {
     "1h": timedelta(hours=1),
     "6h": timedelta(hours=6),

--- a/app/app.py
+++ b/app/app.py
@@ -1,18 +1,31 @@
+import os
+
 from flask import Flask, jsonify
 
 from .api import api
 from .config import settings
 
 
-def create_app():
+def create_app(config: dict | None = None):
     app = Flask(__name__)
     app.config["SECRET_KEY"] = settings.SECRET_KEY
+    app.config["COLLECT_INTERVAL_MINUTES"] = settings.COLLECT_INTERVAL_MINUTES
+
+    if config:
+        app.config.update(config)
 
     app.register_blueprint(api)
 
     @app.route("/healthz")
     def health():
         return jsonify({"status": "ok"})
+
+    if not app.config.get("TESTING"):
+        # In debug mode the Werkzeug reloader forks the process; only start
+        # the scheduler in the child (worker) process, not the parent.
+        if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
+            from collectors.scheduler import start_scheduler
+            start_scheduler(app)
 
     return app
 

--- a/app/config.py
+++ b/app/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     # Секрет для Flask-сессий/CSRF
     SECRET_KEY: str = "dev-secret"
 
+    # Интервал сбора метрик (минуты)
+    COLLECT_INTERVAL_MINUTES: int = 15
+
     # Уровень логирования
     LOG_LEVEL: str = "INFO"
 

--- a/collectors/metrics_collector.py
+++ b/collectors/metrics_collector.py
@@ -10,8 +10,8 @@ class MetricsCollector:
     def __init__(self, schema: str | None = None):
         self.schema = schema
 
-    def collect(self, table_name: str) -> list[dict]:
-        ts = datetime.now(timezone.utc)
+    def collect(self, table_name: str, ts: datetime | None = None) -> list[dict]:
+        ts = ts or datetime.now(timezone.utc)
         rows = []
 
         try:

--- a/collectors/metrics_collector.py
+++ b/collectors/metrics_collector.py
@@ -1,0 +1,74 @@
+import logging
+from datetime import datetime, timezone
+
+from app import db
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsCollector:
+    def __init__(self, schema: str | None = None):
+        self.schema = schema
+
+    def collect(self, table_name: str) -> list[dict]:
+        ts = datetime.now(timezone.utc)
+        rows = []
+
+        try:
+            stats = db.table_stats(table_name, schema=self.schema)
+        except Exception as exc:
+            logger.error("Failed to collect stats for table %s: %s", table_name, exc)
+            return []
+
+        if stats is None:
+            logger.warning("Table %s not found in schema %s, skipping", table_name, self.schema)
+            return []
+
+        rows.append({"ts": ts, "table_name": table_name, "metric_name": "row_count", "value": stats["row_count"]})
+        rows.append({"ts": ts, "table_name": table_name, "metric_name": "size_bytes", "value": stats["size_bytes"]})
+
+        last_modified = _to_epoch(stats.get("last_analyze"))
+        if last_modified is not None:
+            rows.append({"ts": ts, "table_name": table_name, "metric_name": "last_modified", "value": last_modified})
+
+        try:
+            null_stats = db.column_nulls(table_name, schema=self.schema)
+        except Exception as exc:
+            logger.error(
+                "Failed to collect null stats for table %s: %s — "
+                "returning partial snapshot (row_count/size_bytes only)",
+                table_name, exc,
+            )
+            return rows
+
+        for col in null_stats:
+            rows.append({
+                "ts": ts,
+                "table_name": table_name,
+                "metric_name": "null_count",
+                "value": col["null_count"],
+                "tags": {"column": col["column"]},
+            })
+
+        if null_stats:
+            avg_rate = sum(c["null_rate"] for c in null_stats) / len(null_stats)
+            rows.append({
+                "ts": ts,
+                "table_name": table_name,
+                "metric_name": "null_rate",
+                "value": round(avg_rate, 4),
+            })
+
+        return rows
+
+
+def _to_epoch(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return None

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -1,0 +1,37 @@
+import atexit
+import logging
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+logger = logging.getLogger(__name__)
+
+_scheduler: BackgroundScheduler | None = None
+
+
+def start_scheduler(app) -> None:
+    global _scheduler
+
+    if _scheduler is not None and _scheduler.running:
+        logger.debug("Scheduler already running, skipping second start")
+        return
+
+    interval = app.config.get("COLLECT_INTERVAL_MINUTES", 15)
+
+    _scheduler = BackgroundScheduler()
+    _scheduler.add_job(_collect_all, "interval", minutes=interval)
+    _scheduler.start()
+    atexit.register(_scheduler.shutdown, wait=False)
+    logger.info("Metrics scheduler started (interval=%d min)", interval)
+
+
+def _collect_all() -> None:
+    from app.db import list_tables
+    from app.metrics_storage import save_metrics
+    from collectors.metrics_collector import MetricsCollector
+
+    collector = MetricsCollector()
+    for table in list_tables():
+        rows = collector.collect(table["table_name"])
+        if rows:
+            saved = save_metrics(rows)
+            logger.debug("Saved %d metrics for table %s", saved, table["table_name"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,8 +8,7 @@ from app.app import create_app
 
 @pytest.fixture
 def client():
-    app = create_app()
-    app.config["TESTING"] = True
+    app = create_app({"TESTING": True})
     with app.test_client() as c:
         yield c
 

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -1,0 +1,234 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from collectors.metrics_collector import MetricsCollector, _to_epoch
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# Uses the master-branch column_nulls() shape (includes data_type)
+# ---------------------------------------------------------------------------
+
+FAKE_STATS = {
+    "table_name": "users",
+    "schema": "public",
+    "row_count": 1500,
+    "size_bytes": 65536,
+    "last_analyze": "2026-04-24 03:00:00",
+}
+
+FAKE_STATS_NO_ANALYZE = {**FAKE_STATS, "last_analyze": None}
+
+FAKE_COLS = [
+    {"column": "email", "data_type": "text", "null_count": 75, "null_rate": 0.05},
+    {"column": "age", "data_type": "integer", "null_count": 0, "null_rate": 0.0},
+]
+
+
+@pytest.fixture
+def collector():
+    return MetricsCollector(schema="public")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — MetricsCollector.collect()
+# ---------------------------------------------------------------------------
+
+def test_collect_emits_all_expected_metric_names(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    names = {r["metric_name"] for r in rows}
+    assert names == {"row_count", "size_bytes", "last_modified", "null_count", "null_rate"}
+
+
+def test_collect_row_count_and_size_bytes_values(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    untagged = {r["metric_name"]: r for r in rows if "tags" not in r}
+    assert untagged["row_count"]["value"] == 1500
+    assert untagged["size_bytes"]["value"] == 65536
+
+
+def test_collect_null_count_emitted_per_column_with_tags(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    null_counts = [r for r in rows if r["metric_name"] == "null_count"]
+    assert len(null_counts) == 2
+    assert {r["tags"]["column"] for r in null_counts} == {"email", "age"}
+    email_row = next(r for r in null_counts if r["tags"]["column"] == "email")
+    assert email_row["value"] == 75
+
+
+def test_collect_null_rate_is_aggregate_without_tags(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    null_rate_rows = [r for r in rows if r["metric_name"] == "null_rate"]
+    assert len(null_rate_rows) == 1
+    assert "tags" not in null_rate_rows[0]
+    # avg(0.05, 0.0) = 0.025
+    assert null_rate_rows[0]["value"] == pytest.approx(0.025, abs=1e-4)
+
+
+def test_collect_last_modified_is_epoch_float(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    lm = next(r for r in rows if r["metric_name"] == "last_modified")
+    assert isinstance(lm["value"], float)
+    assert lm["value"] > 0
+
+
+def test_collect_skips_last_modified_when_analyze_is_none(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS_NO_ANALYZE), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    assert not any(r["metric_name"] == "last_modified" for r in rows)
+
+
+def test_collect_table_not_found_returns_empty_list(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=None):
+        rows = collector.collect("nonexistent")
+
+    assert rows == []
+
+
+def test_collect_connection_error_on_stats_returns_empty_list(collector):
+    with patch("collectors.metrics_collector.db.table_stats",
+               side_effect=OperationalError("conn", {}, None)):
+        rows = collector.collect("users")
+
+    assert rows == []
+
+
+def test_collect_no_columns_omits_null_metrics(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=[]):
+        rows = collector.collect("users")
+
+    names = {r["metric_name"] for r in rows}
+    assert "null_count" not in names
+    assert "null_rate" not in names
+    assert "row_count" in names
+    assert "size_bytes" in names
+
+
+def test_collect_column_nulls_error_returns_partial_rows(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls",
+               side_effect=OperationalError("conn", {}, None)):
+        rows = collector.collect("users")
+
+    names = {r["metric_name"] for r in rows}
+    assert "row_count" in names
+    assert "size_bytes" in names
+    assert "null_count" not in names
+    assert "null_rate" not in names
+
+
+def test_collect_all_rows_share_same_timestamp(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    timestamps = {r["ts"] for r in rows}
+    assert len(timestamps) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _to_epoch()
+# ---------------------------------------------------------------------------
+
+def test_to_epoch_converts_datetime_string_to_float():
+    result = _to_epoch("2026-04-24 03:00:00")
+    assert isinstance(result, float)
+    assert result > 0
+
+
+def test_to_epoch_returns_none_for_none():
+    assert _to_epoch(None) is None
+
+
+def test_to_epoch_returns_none_for_invalid_string():
+    assert _to_epoch("not-a-date") is None
+
+
+def test_to_epoch_handles_tz_aware_string():
+    result = _to_epoch("2026-04-24T03:00:00+00:00")
+    assert isinstance(result, float)
+
+
+# ---------------------------------------------------------------------------
+# Integration test — collect → save_metrics → get_metrics round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    db_path = tmp_path / "metrics.db"
+    import app.metrics_storage as storage_mod
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    return storage_mod
+
+
+def test_integration_collect_and_save_round_trip(storage):
+    collector = MetricsCollector(schema="public")
+
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    assert storage.save_metrics(rows) == len(rows)
+
+    rc = storage.get_metrics("users", "row_count", window=timedelta(minutes=5))
+    assert len(rc) == 1
+    assert rc[0]["value"] == 1500.0
+
+    nr = storage.get_metrics("users", "null_rate", window=timedelta(minutes=5))
+    assert len(nr) == 1
+    assert nr[0]["tags"] is None
+    assert nr[0]["value"] == pytest.approx(0.025, abs=1e-4)
+
+    nc = storage.get_metrics("users", "null_count", window=timedelta(minutes=5))
+    assert len(nc) == 2
+    assert {r["tags"]["column"] for r in nc} == {"email", "age"}
+
+
+# ---------------------------------------------------------------------------
+# Scheduler — double-start guard
+# ---------------------------------------------------------------------------
+
+def test_scheduler_does_not_start_twice(monkeypatch):
+    import collectors.scheduler as sched_mod
+    from unittest.mock import MagicMock
+
+    fake_scheduler = MagicMock()
+    fake_scheduler.running = False
+
+    monkeypatch.setattr(sched_mod, "_scheduler", None)
+    monkeypatch.setattr("collectors.scheduler.BackgroundScheduler", lambda: fake_scheduler)
+
+    fake_app = MagicMock()
+    fake_app.config.get.return_value = 15
+
+    sched_mod.start_scheduler(fake_app)
+    assert fake_scheduler.start.call_count == 1
+
+    # Simulate second call — scheduler is now marked as running
+    fake_scheduler.running = True
+    monkeypatch.setattr(sched_mod, "_scheduler", fake_scheduler)
+    sched_mod.start_scheduler(fake_app)
+
+    assert fake_scheduler.start.call_count == 1  # still 1, not 2

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -138,12 +138,12 @@ def test_collect_column_nulls_error_returns_partial_rows(collector):
 
 
 def test_collect_all_rows_share_same_timestamp(collector):
+    fixed_ts = datetime(2026, 4, 25, 10, 0, 0, tzinfo=timezone.utc)
     with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
          patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
-        rows = collector.collect("users")
+        rows = collector.collect("users", ts=fixed_ts)
 
-    timestamps = {r["ts"] for r in rows}
-    assert len(timestamps) == 1
+    assert all(r["ts"] == fixed_ts for r in rows)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `MetricsCollector.collect(table_name)` собирает по каждой таблице: `row_count`, `size_bytes`, `last_modified` (unix epoch float), `null_count` per-column (тег `{"column": col}`), агрегированный `null_rate` (среднее по колонкам, без тегов — совместимо с API и дашбордом)
- Graceful skip + лог на двух уровнях: полный пропуск при сбое `table_stats`, частичный snapshot при сбое `column_nulls`
- APScheduler-обвязка: `start_scheduler(app)` с guard на двойной старт и `atexit.shutdown(wait=False)`
- `create_app()` принимает `config dict` — scheduler не стартует при `TESTING=True`
- `_VALID_METRICS` расширен: `size_bytes`, `null_count`, `last_modified` доступны через `GET /api/metrics/<table>`

## Closes
Closes #8

## Test plan
- [x] 40/40 тестов проходят (`pytest tests/`)
- [x] Unit: все ветки ошибок (`table_stats=None`, `OperationalError` на stats и на column_nulls, пустая таблица)
- [x] `null_rate` хранится как агрегат без тегов → `get_latest_metric` и `/api/tables` работают корректно
- [x] `last_modified=None` → метрика пропускается, не падает
- [x] Scheduler: guard на double-start проверен тестом
- [x] Интеграционный тест: collect → save_metrics → get_metrics round-trip на реальном SQLite
- [x] Тесты используют актуальную сигнатуру `column_nulls()` с полем `data_type` (из master)