### PR TITLE
feat: APScheduler job naming, logging, and /admin/jobs endpoint (#10)

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -9,6 +9,10 @@ bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 @bp.route("/jobs")
 def list_jobs():
+    """Return all scheduled jobs with id, name, next_run_time, and trigger.
+
+    Returns an empty list if the scheduler is not running.
+    """
     scheduler = get_scheduler()
     if scheduler is None:
         return jsonify([])
@@ -26,6 +30,10 @@ def list_jobs():
 
 @bp.route("/jobs/<job_id>/run", methods=["POST"])
 def run_job(job_id: str):
+    """Trigger a job immediately by setting its next_run_time to now.
+
+    Returns 503 if the scheduler is not running, 404 if job_id is not found.
+    """
     scheduler = get_scheduler()
     if scheduler is None:
         return jsonify({"error": "scheduler not running"}), 503
@@ -35,4 +43,8 @@ def run_job(job_id: str):
         return jsonify({"error": f"job '{job_id}' not found"}), 404
 
     job.modify(next_run_time=datetime.now(timezone.utc))
-    return jsonify({"status": "triggered", "job_id": job_id})
+    return jsonify({
+        "status": "triggered",
+        "job_id": job_id,
+        "next_run_time": job.next_run_time.isoformat() if job.next_run_time else None,
+    })

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify
+
+from collectors.scheduler import get_scheduler
+
+bp = Blueprint("admin", __name__, url_prefix="/admin")
+
+
+@bp.route("/jobs")
+def list_jobs():
+    scheduler = get_scheduler()
+    if scheduler is None:
+        return jsonify([])
+
+    return jsonify([
+        {
+            "id": job.id,
+            "name": job.name,
+            "next_run_time": job.next_run_time.isoformat() if job.next_run_time else None,
+            "trigger": str(job.trigger),
+        }
+        for job in scheduler.get_jobs()
+    ])
+
+
+@bp.route("/jobs/<job_id>/run", methods=["POST"])
+def run_job(job_id: str):
+    scheduler = get_scheduler()
+    if scheduler is None:
+        return jsonify({"error": "scheduler not running"}), 503
+
+    job = scheduler.get_job(job_id)
+    if job is None:
+        return jsonify({"error": f"job '{job_id}' not found"}), 404
+
+    job.modify(next_run_time=datetime.now(timezone.utc))
+    return jsonify({"status": "triggered", "job_id": job_id})

--- a/app/api.py
+++ b/app/api.py
@@ -7,7 +7,7 @@ from .metrics_storage import get_latest_metric, get_metrics
 
 api = Blueprint("api", __name__, url_prefix="/api")
 
-_VALID_METRICS = {"row_count", "null_rate"}
+_VALID_METRICS = {"row_count", "null_rate", "null_count", "size_bytes", "last_modified"}
 _RANGES = {
     "1h": timedelta(hours=1),
     "6h": timedelta(hours=6),

--- a/app/app.py
+++ b/app/app.py
@@ -1,18 +1,31 @@
+import os
+
 from flask import Flask, jsonify
 
 from .api import api
 from .config import settings
 
 
-def create_app():
+def create_app(config: dict | None = None):
     app = Flask(__name__)
     app.config["SECRET_KEY"] = settings.SECRET_KEY
+    app.config["COLLECT_INTERVAL_MINUTES"] = settings.COLLECT_INTERVAL_MINUTES
+
+    if config:
+        app.config.update(config)
 
     app.register_blueprint(api)
 
     @app.route("/healthz")
     def health():
         return jsonify({"status": "ok"})
+
+    if not app.config.get("TESTING"):
+        # In debug mode the Werkzeug reloader forks the process; only start
+        # the scheduler in the child (worker) process, not the parent.
+        if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
+            from collectors.scheduler import start_scheduler
+            start_scheduler(app)
 
     return app
 

--- a/app/app.py
+++ b/app/app.py
@@ -2,6 +2,7 @@ import os
 
 from flask import Flask, jsonify
 
+from .admin import bp as admin_bp
 from .api import api
 from .config import settings
 
@@ -15,6 +16,7 @@ def create_app(config: dict | None = None):
         app.config.update(config)
 
     app.register_blueprint(api)
+    app.register_blueprint(admin_bp)
 
     @app.route("/healthz")
     def health():

--- a/app/config.py
+++ b/app/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     # Секрет для Flask-сессий/CSRF
     SECRET_KEY: str = "dev-secret"
 
+    # Интервал сбора метрик (минуты)
+    COLLECT_INTERVAL_MINUTES: int = 15
+
     # Уровень логирования
     LOG_LEVEL: str = "INFO"
 

--- a/collectors/metrics_collector.py
+++ b/collectors/metrics_collector.py
@@ -1,0 +1,74 @@
+import logging
+from datetime import datetime, timezone
+
+from app import db
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsCollector:
+    def __init__(self, schema: str | None = None):
+        self.schema = schema
+
+    def collect(self, table_name: str) -> list[dict]:
+        ts = datetime.now(timezone.utc)
+        rows = []
+
+        try:
+            stats = db.table_stats(table_name, schema=self.schema)
+        except Exception as exc:
+            logger.error("Failed to collect stats for table %s: %s", table_name, exc)
+            return []
+
+        if stats is None:
+            logger.warning("Table %s not found in schema %s, skipping", table_name, self.schema)
+            return []
+
+        rows.append({"ts": ts, "table_name": table_name, "metric_name": "row_count", "value": stats["row_count"]})
+        rows.append({"ts": ts, "table_name": table_name, "metric_name": "size_bytes", "value": stats["size_bytes"]})
+
+        last_modified = _to_epoch(stats.get("last_analyze"))
+        if last_modified is not None:
+            rows.append({"ts": ts, "table_name": table_name, "metric_name": "last_modified", "value": last_modified})
+
+        try:
+            null_stats = db.column_nulls(table_name, schema=self.schema)
+        except Exception as exc:
+            logger.error(
+                "Failed to collect null stats for table %s: %s — "
+                "returning partial snapshot (row_count/size_bytes only)",
+                table_name, exc,
+            )
+            return rows
+
+        for col in null_stats:
+            rows.append({
+                "ts": ts,
+                "table_name": table_name,
+                "metric_name": "null_count",
+                "value": col["null_count"],
+                "tags": {"column": col["column"]},
+            })
+
+        if null_stats:
+            avg_rate = sum(c["null_rate"] for c in null_stats) / len(null_stats)
+            rows.append({
+                "ts": ts,
+                "table_name": table_name,
+                "metric_name": "null_rate",
+                "value": round(avg_rate, 4),
+            })
+
+        return rows
+
+
+def _to_epoch(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return None

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 
 _scheduler: BackgroundScheduler | None = None
 
+JOB_ID = "collect_all_tables"
+
 
 def start_scheduler(app) -> None:
     global _scheduler
@@ -18,20 +20,34 @@ def start_scheduler(app) -> None:
     interval = app.config.get("COLLECT_INTERVAL_MINUTES", 15)
 
     _scheduler = BackgroundScheduler()
-    _scheduler.add_job(_collect_all, "interval", minutes=interval)
+    _scheduler.add_job(
+        collect_all_tables,
+        "interval",
+        minutes=interval,
+        id=JOB_ID,
+        name=JOB_ID,
+    )
     _scheduler.start()
     atexit.register(_scheduler.shutdown, wait=False)
     logger.info("Metrics scheduler started (interval=%d min)", interval)
 
 
-def _collect_all() -> None:
+def get_scheduler() -> BackgroundScheduler | None:
+    return _scheduler
+
+
+def collect_all_tables() -> None:
     from app.db import list_tables
     from app.metrics_storage import save_metrics
     from collectors.metrics_collector import MetricsCollector
 
+    logger.info("Job %s started", JOB_ID)
     collector = MetricsCollector()
+    total_saved = 0
     for table in list_tables():
         rows = collector.collect(table["table_name"])
         if rows:
             saved = save_metrics(rows)
+            total_saved += saved
             logger.debug("Saved %d metrics for table %s", saved, table["table_name"])
+    logger.info("Job %s finished: %d metrics saved across all tables", JOB_ID, total_saved)

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -1,0 +1,37 @@
+import atexit
+import logging
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+logger = logging.getLogger(__name__)
+
+_scheduler: BackgroundScheduler | None = None
+
+
+def start_scheduler(app) -> None:
+    global _scheduler
+
+    if _scheduler is not None and _scheduler.running:
+        logger.debug("Scheduler already running, skipping second start")
+        return
+
+    interval = app.config.get("COLLECT_INTERVAL_MINUTES", 15)
+
+    _scheduler = BackgroundScheduler()
+    _scheduler.add_job(_collect_all, "interval", minutes=interval)
+    _scheduler.start()
+    atexit.register(_scheduler.shutdown, wait=False)
+    logger.info("Metrics scheduler started (interval=%d min)", interval)
+
+
+def _collect_all() -> None:
+    from app.db import list_tables
+    from app.metrics_storage import save_metrics
+    from collectors.metrics_collector import MetricsCollector
+
+    collector = MetricsCollector()
+    for table in list_tables():
+        rows = collector.collect(table["table_name"])
+        if rows:
+            saved = save_metrics(rows)
+            logger.debug("Saved %d metrics for table %s", saved, table["table_name"])

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -85,6 +85,7 @@ def test_run_job_triggers_immediately(client, monkeypatch, fake_job):
     data = resp.get_json()
     assert data["status"] == "triggered"
     assert data["job_id"] == "collect_all_tables"
+    assert data["next_run_time"] is not None
     fake_job.modify.assert_called_once()
     _, kwargs = fake_job.modify.call_args
     assert isinstance(kwargs["next_run_time"], datetime)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,112 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.app import create_app
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import collectors.scheduler as sched_mod
+    monkeypatch.setattr(sched_mod, "_scheduler", None)
+    app = create_app({"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture
+def fake_job():
+    job = MagicMock()
+    job.id = "collect_all_tables"
+    job.name = "collect_all_tables"
+    job.next_run_time = datetime(2026, 4, 25, 10, 15, tzinfo=timezone.utc)
+    job.trigger = MagicMock(__str__=lambda self: "interval[0:15:00]")
+    return job
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/jobs
+# ---------------------------------------------------------------------------
+
+def test_list_jobs_returns_job_info(client, monkeypatch, fake_job):
+    import collectors.scheduler as sched_mod
+    fake_scheduler = MagicMock()
+    fake_scheduler.get_jobs.return_value = [fake_job]
+    monkeypatch.setattr(sched_mod, "_scheduler", fake_scheduler)
+
+    resp = client.get("/admin/jobs")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]["id"] == "collect_all_tables"
+    assert data[0]["name"] == "collect_all_tables"
+    assert data[0]["next_run_time"] == "2026-04-25T10:15:00+00:00"
+    assert data[0]["trigger"] == "interval[0:15:00]"
+
+
+def test_list_jobs_when_scheduler_not_running(client, monkeypatch):
+    import collectors.scheduler as sched_mod
+    monkeypatch.setattr(sched_mod, "_scheduler", None)
+
+    resp = client.get("/admin/jobs")
+
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_list_jobs_next_run_time_none(client, monkeypatch, fake_job):
+    import collectors.scheduler as sched_mod
+    fake_job.next_run_time = None
+    fake_scheduler = MagicMock()
+    fake_scheduler.get_jobs.return_value = [fake_job]
+    monkeypatch.setattr(sched_mod, "_scheduler", fake_scheduler)
+
+    resp = client.get("/admin/jobs")
+
+    assert resp.status_code == 200
+    assert resp.get_json()[0]["next_run_time"] is None
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/jobs/<job_id>/run
+# ---------------------------------------------------------------------------
+
+def test_run_job_triggers_immediately(client, monkeypatch, fake_job):
+    import collectors.scheduler as sched_mod
+    fake_scheduler = MagicMock()
+    fake_scheduler.get_job.return_value = fake_job
+    monkeypatch.setattr(sched_mod, "_scheduler", fake_scheduler)
+
+    resp = client.post("/admin/jobs/collect_all_tables/run")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "triggered"
+    assert data["job_id"] == "collect_all_tables"
+    fake_job.modify.assert_called_once()
+    _, kwargs = fake_job.modify.call_args
+    assert isinstance(kwargs["next_run_time"], datetime)
+
+
+def test_run_job_scheduler_not_running(client, monkeypatch):
+    import collectors.scheduler as sched_mod
+    monkeypatch.setattr(sched_mod, "_scheduler", None)
+
+    resp = client.post("/admin/jobs/collect_all_tables/run")
+
+    assert resp.status_code == 503
+    assert "error" in resp.get_json()
+
+
+def test_run_job_not_found(client, monkeypatch):
+    import collectors.scheduler as sched_mod
+    fake_scheduler = MagicMock()
+    fake_scheduler.get_job.return_value = None
+    monkeypatch.setattr(sched_mod, "_scheduler", fake_scheduler)
+
+    resp = client.post("/admin/jobs/unknown_job/run")
+
+    assert resp.status_code == 404
+    assert "error" in resp.get_json()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,8 +8,7 @@ from app.app import create_app
 
 @pytest.fixture
 def client():
-    app = create_app()
-    app.config["TESTING"] = True
+    app = create_app({"TESTING": True})
     with app.test_client() as c:
         yield c
 

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -1,0 +1,234 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from collectors.metrics_collector import MetricsCollector, _to_epoch
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# Uses the master-branch column_nulls() shape (includes data_type)
+# ---------------------------------------------------------------------------
+
+FAKE_STATS = {
+    "table_name": "users",
+    "schema": "public",
+    "row_count": 1500,
+    "size_bytes": 65536,
+    "last_analyze": "2026-04-24 03:00:00",
+}
+
+FAKE_STATS_NO_ANALYZE = {**FAKE_STATS, "last_analyze": None}
+
+FAKE_COLS = [
+    {"column": "email", "data_type": "text", "null_count": 75, "null_rate": 0.05},
+    {"column": "age", "data_type": "integer", "null_count": 0, "null_rate": 0.0},
+]
+
+
+@pytest.fixture
+def collector():
+    return MetricsCollector(schema="public")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — MetricsCollector.collect()
+# ---------------------------------------------------------------------------
+
+def test_collect_emits_all_expected_metric_names(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    names = {r["metric_name"] for r in rows}
+    assert names == {"row_count", "size_bytes", "last_modified", "null_count", "null_rate"}
+
+
+def test_collect_row_count_and_size_bytes_values(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    untagged = {r["metric_name"]: r for r in rows if "tags" not in r}
+    assert untagged["row_count"]["value"] == 1500
+    assert untagged["size_bytes"]["value"] == 65536
+
+
+def test_collect_null_count_emitted_per_column_with_tags(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    null_counts = [r for r in rows if r["metric_name"] == "null_count"]
+    assert len(null_counts) == 2
+    assert {r["tags"]["column"] for r in null_counts} == {"email", "age"}
+    email_row = next(r for r in null_counts if r["tags"]["column"] == "email")
+    assert email_row["value"] == 75
+
+
+def test_collect_null_rate_is_aggregate_without_tags(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    null_rate_rows = [r for r in rows if r["metric_name"] == "null_rate"]
+    assert len(null_rate_rows) == 1
+    assert "tags" not in null_rate_rows[0]
+    # avg(0.05, 0.0) = 0.025
+    assert null_rate_rows[0]["value"] == pytest.approx(0.025, abs=1e-4)
+
+
+def test_collect_last_modified_is_epoch_float(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    lm = next(r for r in rows if r["metric_name"] == "last_modified")
+    assert isinstance(lm["value"], float)
+    assert lm["value"] > 0
+
+
+def test_collect_skips_last_modified_when_analyze_is_none(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS_NO_ANALYZE), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    assert not any(r["metric_name"] == "last_modified" for r in rows)
+
+
+def test_collect_table_not_found_returns_empty_list(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=None):
+        rows = collector.collect("nonexistent")
+
+    assert rows == []
+
+
+def test_collect_connection_error_on_stats_returns_empty_list(collector):
+    with patch("collectors.metrics_collector.db.table_stats",
+               side_effect=OperationalError("conn", {}, None)):
+        rows = collector.collect("users")
+
+    assert rows == []
+
+
+def test_collect_no_columns_omits_null_metrics(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=[]):
+        rows = collector.collect("users")
+
+    names = {r["metric_name"] for r in rows}
+    assert "null_count" not in names
+    assert "null_rate" not in names
+    assert "row_count" in names
+    assert "size_bytes" in names
+
+
+def test_collect_column_nulls_error_returns_partial_rows(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls",
+               side_effect=OperationalError("conn", {}, None)):
+        rows = collector.collect("users")
+
+    names = {r["metric_name"] for r in rows}
+    assert "row_count" in names
+    assert "size_bytes" in names
+    assert "null_count" not in names
+    assert "null_rate" not in names
+
+
+def test_collect_all_rows_share_same_timestamp(collector):
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    timestamps = {r["ts"] for r in rows}
+    assert len(timestamps) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _to_epoch()
+# ---------------------------------------------------------------------------
+
+def test_to_epoch_converts_datetime_string_to_float():
+    result = _to_epoch("2026-04-24 03:00:00")
+    assert isinstance(result, float)
+    assert result > 0
+
+
+def test_to_epoch_returns_none_for_none():
+    assert _to_epoch(None) is None
+
+
+def test_to_epoch_returns_none_for_invalid_string():
+    assert _to_epoch("not-a-date") is None
+
+
+def test_to_epoch_handles_tz_aware_string():
+    result = _to_epoch("2026-04-24T03:00:00+00:00")
+    assert isinstance(result, float)
+
+
+# ---------------------------------------------------------------------------
+# Integration test — collect → save_metrics → get_metrics round-trip
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    db_path = tmp_path / "metrics.db"
+    import app.metrics_storage as storage_mod
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    return storage_mod
+
+
+def test_integration_collect_and_save_round_trip(storage):
+    collector = MetricsCollector(schema="public")
+
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users")
+
+    assert storage.save_metrics(rows) == len(rows)
+
+    rc = storage.get_metrics("users", "row_count", window=timedelta(minutes=5))
+    assert len(rc) == 1
+    assert rc[0]["value"] == 1500.0
+
+    nr = storage.get_metrics("users", "null_rate", window=timedelta(minutes=5))
+    assert len(nr) == 1
+    assert nr[0]["tags"] is None
+    assert nr[0]["value"] == pytest.approx(0.025, abs=1e-4)
+
+    nc = storage.get_metrics("users", "null_count", window=timedelta(minutes=5))
+    assert len(nc) == 2
+    assert {r["tags"]["column"] for r in nc} == {"email", "age"}
+
+
+# ---------------------------------------------------------------------------
+# Scheduler — double-start guard
+# ---------------------------------------------------------------------------
+
+def test_scheduler_does_not_start_twice(monkeypatch):
+    import collectors.scheduler as sched_mod
+    from unittest.mock import MagicMock
+
+    fake_scheduler = MagicMock()
+    fake_scheduler.running = False
+
+    monkeypatch.setattr(sched_mod, "_scheduler", None)
+    monkeypatch.setattr("collectors.scheduler.BackgroundScheduler", lambda: fake_scheduler)
+
+    fake_app = MagicMock()
+    fake_app.config.get.return_value = 15
+
+    sched_mod.start_scheduler(fake_app)
+    assert fake_scheduler.start.call_count == 1
+
+    # Simulate second call — scheduler is now marked as running
+    fake_scheduler.running = True
+    monkeypatch.setattr(sched_mod, "_scheduler", fake_scheduler)
+    sched_mod.start_scheduler(fake_app)
+
+    assert fake_scheduler.start.call_count == 1  # still 1, not 2


### PR DESCRIPTION
## Closes
Closes #10

## Что сделано в задаче #10

Задача #10 частично реализована в PR #29 (issue #8 — MetricsCollector). Ниже разбивка по пунктам:

### ✅ Сделано в #8 (PR #29)
- **Инициализация APScheduler внутри Flask-процесса** — `BackgroundScheduler` стартует в `create_app()` через `collectors/scheduler.py`; защищён от двойного старта (Werkzeug reloader + module-level guard) и корректно останавливается через `atexit`
- **Job `collect_all_tables` каждые 15 минут** — `add_job(..., "interval", minutes=COLLECT_INTERVAL_MINUTES)`, интервал конфигурируется через `.env`
- **Логирование запусков и ошибок** — `logger.error` в `MetricsCollector.collect()` при сбоях подключения и недоступных таблицах; `logger.info` при старте планировщика

### ✅ Сделано в этом PR
- **Явный `id="collect_all_tables"` и `name="collect_all_tables"`** для job — APScheduler теперь идентифицирует job по имени, а не по автоматическому id
- **Логирование каждого тика** — `logger.info("Job started")` в начале и `logger.info("Job finished: N metrics saved")` в конце каждого запуска
- **Endpoint `GET /admin/jobs`** — список всех job с `id`, `name`, `next_run_time`, `trigger`
- **Endpoint `POST /admin/jobs/<job_id>/run`** — немедленный запуск job через `job.modify(next_run_time=now)`; возвращает 503 если scheduler не запущен, 404 если job не найден
- **`get_scheduler()`** — публичный аксессор, admin blueprint не обращается к приватному состоянию напрямую

## Результаты тестов

```
collected 46 items

tests/test_admin.py::test_list_jobs_returns_job_info PASSED
tests/test_admin.py::test_list_jobs_when_scheduler_not_running PASSED
tests/test_admin.py::test_list_jobs_next_run_time_none PASSED
tests/test_admin.py::test_run_job_triggers_immediately PASSED
tests/test_admin.py::test_run_job_scheduler_not_running PASSED
tests/test_admin.py::test_run_job_not_found PASSED
tests/test_api.py ......... (9 passed)
tests/test_db_utils.py ...... (6 passed)
tests/test_metrics_collector.py ................. (17 passed)
tests/test_metrics_storage.py ........ (8 passed)

46 passed in 0.52s
```

## Test plan
- [x] `GET /admin/jobs` возвращает список job с `id`, `name`, `next_run_time`, `trigger`
- [x] `GET /admin/jobs` возвращает `[]` если scheduler не запущен (TESTING режим)
- [x] `POST /admin/jobs/collect_all_tables/run` → 200 `{"status": "triggered"}`
- [x] `POST /admin/jobs/collect_all_tables/run` → 503 если scheduler не запущен
- [x] `POST /admin/jobs/unknown/run` → 404
- [x] Все 46 тестов проходят