### PR TITLE
ci: GitHub Actions для тестов и coverage (#43)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+source = app, collectors
+branch = true
+omit =
+    tests/*
+    */__init__.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+    raise NotImplementedError
+show_missing = true
+skip_covered = false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run tests with coverage
+        env:
+          SECRET_KEY: test-secret
+          DATABASE_URL: postgresql://test:test@localhost/test
+        run: |
+          coverage run -m pytest -v
+          coverage report -m
+          coverage xml
+
+      - name: Upload coverage artifact
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 monitor.db
 .DS_Store
 .pytest_cache/
+.coverage
+coverage.xml
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Веб-приложение на Flask, которое подключается к базе данных, автоматически собирает метрики качества данных (количество записей, пропуски, ошибки), визуализирует их на дашбордах и уведомляет об аномалиях. Включает ML-детекцию аномалий и timeseries forecasting (прогноз роста таблиц, сезонность, change-point detection).
 
-[![Python](https://img.shields.io/badge/python-3.12-blue)](https://www.python.org/)
+[![tests](https://github.com/aleksandr-novikov/db-monitoring/actions/workflows/tests.yml/badge.svg)](https://github.com/aleksandr-novikov/db-monitoring/actions/workflows/tests.yml)
+[![Python](https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13-blue)](https://www.python.org/)
 [![Flask](https://img.shields.io/badge/flask-3.1-green)](https://flask.palletsprojects.com/)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)]()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+coverage==7.13.5


### PR DESCRIPTION
Closes #43

## Что сделано

- `.github/workflows/tests.yml` — pytest + coverage на каждый push в master и любой PR
- Матрица Python 3.11 / 3.12 / 3.13
- `requirements-dev.txt` с pytest и coverage (зафиксированы версии: 8.3.4 / 7.13.5)
- `.coveragerc` — конфиг coverage (source: app+collectors, branch coverage)
- Coverage XML загружается как артефакт workflow (retention 14 дней)
- Бейдж tests в README

## Локально проверено

```
57 passed in 0.82s
TOTAL 372 stmts, 89% coverage (с branch coverage)
```

## Test plan

- [ ] Workflow зелёный на этом PR (Python 3.11, 3.12, 3.13)
- [ ] Артефакт `coverage-report` доступен на странице workflow
- [ ] Бейдж в README показывает passing после мерджа