### PR TITLE
feat: drift detection — PSI/KS на rolling 7-day baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ PORT  ?= 5001
 build:
 	docker build -t $(IMAGE) .
 
-server:
-	docker run --rm -p $(PORT):$(PORT) \
+server: build
+	docker run --rm -it --init -p $(PORT):$(PORT) \
 		--env-file .env \
 		-v $(CURDIR)/monitor.db:/app/monitor.db \
 		-v $(CURDIR)/models:/app/models \

--- a/app/api.py
+++ b/app/api.py
@@ -91,6 +91,17 @@ def forecast_endpoint(table_name: str):
     return jsonify(points)
 
 
+@api.route("/drift/<table_name>")
+def drift(table_name: str):
+    """Per-column drift report against the rolling 7-day baseline.
+
+    Returns [{column, data_type, psi, ks_pvalue, is_drift, severity}].
+    """
+    from ml.drift import compute_drift
+
+    return jsonify(compute_drift(table_name))
+
+
 @api.route("/schema/<table_name>")
 def schema(table_name: str):
     """Return column schema for a table: [{name, type, nullable}].

--- a/app/db.py
+++ b/app/db.py
@@ -58,6 +58,18 @@ class DBAdapter(ABC):
     @abstractmethod
     def column_nulls(self, table_name: str, schema: str) -> list[dict]: ...
 
+    def column_distribution(
+        self, table_name: str, schema: str, top_n: int = 20
+    ) -> list[dict]:
+        """Top-N value frequencies per column. Default uses dialect-agnostic SQL.
+
+        Returns a list of {column, data_type, total, buckets: [{value, count}, ...]}.
+        Columns with types unsuitable for grouping (text, json, blob, bytea) are
+        skipped — drift on free-form text rarely makes sense and the GROUP BY
+        cost grows with cardinality.
+        """
+        return _column_distribution_generic(self, table_name, schema, top_n)
+
 
 def _column_nulls_generic(
     adapter: DBAdapter, table_name: str, schema: str
@@ -90,6 +102,57 @@ def _column_nulls_generic(
         }
         for i, c in enumerate(cols)
     ]
+
+
+_SKIP_DIST_TYPE_FRAGMENTS = (
+    "text", "json", "jsonb", "bytea", "blob", "clob", "xml", "array",
+)
+
+
+def _is_distribution_skippable(data_type: str | None) -> bool:
+    if not data_type:
+        return True
+    t = data_type.lower()
+    return any(frag in t for frag in _SKIP_DIST_TYPE_FRAGMENTS)
+
+
+def _column_distribution_generic(
+    adapter: "DBAdapter", table_name: str, schema: str, top_n: int = 20
+) -> list[dict]:
+    cols = adapter.table_schema(table_name, schema)
+    if not cols:
+        return []
+    fqn = f"{adapter.quote_ident(schema)}.{adapter.quote_ident(table_name)}"
+    out: list[dict] = []
+    with get_engine().connect() as conn:
+        for c in cols:
+            if _is_distribution_skippable(c.get("type")):
+                continue
+            qname = adapter.quote_ident(c["name"])
+            query = text(
+                f"SELECT {qname} AS v, COUNT(*) AS c FROM {fqn} "
+                f"WHERE {qname} IS NOT NULL "
+                f"GROUP BY {qname} ORDER BY c DESC LIMIT :top_n"
+            )
+            try:
+                rows = conn.execute(query, {"top_n": top_n}).fetchall()
+            except Exception:  # pragma: no cover - dialect-specific failures
+                continue
+            buckets = [{"value": _to_str(r[0]), "count": int(r[1])} for r in rows]
+            total = sum(b["count"] for b in buckets)
+            out.append({
+                "column": c["name"],
+                "data_type": c["type"],
+                "total": total,
+                "buckets": buckets,
+            })
+    return out
+
+
+def _to_str(v) -> str:
+    if v is None:
+        return ""
+    return str(v)
 
 
 class PostgresAdapter(DBAdapter):
@@ -356,3 +419,11 @@ def table_schema(table_name: str, schema: str | None = None) -> list[dict]:
 
 def column_nulls(table_name: str, schema: str | None = None) -> list[dict]:
     return get_adapter().column_nulls(table_name, schema or settings.MONITORED_SCHEMA)
+
+
+def column_distribution(
+    table_name: str, schema: str | None = None, top_n: int = 20
+) -> list[dict]:
+    return get_adapter().column_distribution(
+        table_name, schema or settings.MONITORED_SCHEMA, top_n
+    )

--- a/collectors/metrics_collector.py
+++ b/collectors/metrics_collector.py
@@ -59,6 +59,28 @@ class MetricsCollector:
                 "value": round(avg_rate, 4),
             })
 
+        try:
+            distributions = db.column_distribution(table_name, schema=self.schema)
+        except Exception as exc:
+            logger.error(
+                "Failed to collect column distributions for table %s: %s",
+                table_name, exc,
+            )
+            distributions = []
+
+        for dist in distributions:
+            rows.append({
+                "ts": ts,
+                "table_name": table_name,
+                "metric_name": "column_distribution",
+                "value": float(dist["total"]),
+                "tags": {
+                    "column": dist["column"],
+                    "data_type": dist["data_type"],
+                    "buckets": dist["buckets"],
+                },
+            })
+
         return rows
 
 

--- a/ml/drift.py
+++ b/ml/drift.py
@@ -1,0 +1,229 @@
+"""Distribution-drift detection for monitored columns.
+
+Compares the most recent ``column_distribution`` snapshot (current window)
+against the oldest snapshot in the rolling 7-day baseline. Two metrics:
+
+- **PSI** (Population Stability Index) — categorical columns. PSI = Σ (c-b) * ln(c/b)
+  over aligned bins, with Laplace smoothing so missing buckets don't blow up
+  the log. Industry-standard thresholds: 0.1 stable, 0.2 warn, 0.25 critical.
+- **KS** (two-sample Kolmogorov–Smirnov) — numeric columns. We work from the
+  binned (value, count) sketches we store, not raw samples, so KS here is the
+  empirical-CDF distance between two weighted ECDFs. The p-value uses the
+  asymptotic two-sample formula `p = 2·exp(-2·D²·n_eff)`.
+
+No scipy dependency — both metrics are short and self-contained.
+"""
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import text
+
+from app.metrics_storage import get_engine
+
+# PSI thresholds — see docstring above.
+PSI_WARN = 0.2
+PSI_CRITICAL = 0.25
+KS_PVALUE_THRESHOLD = 0.05
+BASELINE_DAYS = 7
+SMOOTHING = 1e-4
+
+_NUMERIC_TYPE_FRAGMENTS = (
+    "int", "numeric", "decimal", "real", "double", "float",
+    "money", "serial", "bigserial",
+)
+
+
+def _is_numeric(data_type: str | None) -> bool:
+    if not data_type:
+        return False
+    t = data_type.lower()
+    return any(frag in t for frag in _NUMERIC_TYPE_FRAGMENTS)
+
+
+def psi(baseline: dict[str, float], current: dict[str, float]) -> float:
+    """Population Stability Index over aligned categorical bins.
+
+    Inputs are {value: proportion} dicts (proportions sum to ~1). Missing
+    keys are treated as zero and smoothed so the log stays finite. Returns
+    a non-negative float; 0 means identical distributions.
+    """
+    keys = set(baseline) | set(current)
+    if not keys:
+        return 0.0
+    out = 0.0
+    for k in keys:
+        b = baseline.get(k, 0.0) or 0.0
+        c = current.get(k, 0.0) or 0.0
+        if b <= 0:
+            b = SMOOTHING
+        if c <= 0:
+            c = SMOOTHING
+        out += (c - b) * math.log(c / b)
+    return out
+
+
+def ks_two_sample(
+    baseline: list[tuple[float, int]],
+    current: list[tuple[float, int]],
+) -> tuple[float, float]:
+    """Weighted two-sample KS distance + asymptotic p-value.
+
+    Each input is a list of (numeric_value, count) pairs (the binned sketch we
+    persist). Returns (D, p_value). Returns (0.0, 1.0) for empty inputs.
+    """
+    if not baseline or not current:
+        return 0.0, 1.0
+    n1 = sum(c for _, c in baseline)
+    n2 = sum(c for _, c in current)
+    if n1 == 0 or n2 == 0:
+        return 0.0, 1.0
+
+    xs = sorted({v for v, _ in baseline} | {v for v, _ in current})
+    b_map: dict[float, int] = {}
+    c_map: dict[float, int] = {}
+    for v, c in baseline:
+        b_map[v] = b_map.get(v, 0) + c
+    for v, c in current:
+        c_map[v] = c_map.get(v, 0) + c
+
+    cum_b = cum_c = 0
+    d = 0.0
+    for x in xs:
+        cum_b += b_map.get(x, 0)
+        cum_c += c_map.get(x, 0)
+        d = max(d, abs(cum_b / n1 - cum_c / n2))
+
+    n_eff = (n1 * n2) / (n1 + n2)
+    p = math.exp(-2.0 * d * d * n_eff)  # one-sided
+    p = min(1.0, 2.0 * p)               # two-sided approximation
+    return d, p
+
+
+def _severity(psi_value: float) -> str:
+    if psi_value > PSI_CRITICAL:
+        return "critical"
+    if psi_value > PSI_WARN:
+        return "warn"
+    return "ok"
+
+
+def _load_distributions(table_name: str, since: datetime) -> list[dict]:
+    """Pull every column_distribution snapshot for a table since `since`.
+
+    Decodes JSON tags eagerly so callers can iterate without re-parsing.
+    """
+    stmt = text("""
+        SELECT ts, tags
+        FROM metrics
+        WHERE table_name = :table_name
+          AND metric_name = 'column_distribution'
+          AND ts >= :since
+        ORDER BY ts
+    """)
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt, {
+            "table_name": table_name,
+            "since": since.isoformat(timespec="seconds"),
+        }).fetchall()
+    out = []
+    for ts, tags in rows:
+        if not tags:
+            continue
+        try:
+            t = json.loads(tags)
+        except (TypeError, ValueError):
+            continue
+        out.append({"ts": ts, **t})
+    return out
+
+
+def _split_baseline_current(
+    snapshots: list[dict],
+) -> tuple[dict[str, dict], dict[str, dict]]:
+    """Per-column: pick the oldest snapshot as baseline, newest as current."""
+    by_col: dict[str, list[dict]] = {}
+    for s in snapshots:
+        by_col.setdefault(s["column"], []).append(s)
+    baseline: dict[str, dict] = {}
+    current: dict[str, dict] = {}
+    for col, snaps in by_col.items():
+        snaps.sort(key=lambda x: x["ts"])
+        baseline[col] = snaps[0]
+        current[col] = snaps[-1]
+    return baseline, current
+
+
+def _to_proportions(buckets: list[dict]) -> dict[str, float]:
+    total = sum(b.get("count", 0) for b in buckets)
+    if total == 0:
+        return {}
+    return {b["value"]: b["count"] / total for b in buckets}
+
+
+def _numeric_pairs(buckets: list[dict]) -> list[tuple[float, int]]:
+    out = []
+    for b in buckets:
+        try:
+            out.append((float(b["value"]), int(b["count"])))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def compute_drift(
+    table_name: str, baseline_days: int = BASELINE_DAYS
+) -> list[dict]:
+    """Return per-column drift report for `table_name`.
+
+    Each entry: {column, data_type, psi, ks_pvalue, is_drift, severity}.
+    Columns missing from baseline OR current are omitted (no comparison
+    possible). When fewer than 2 snapshots exist for a column, severity is
+    "insufficient_data" and is_drift is False.
+    """
+    since = datetime.now(timezone.utc) - timedelta(days=baseline_days)
+    snapshots = _load_distributions(table_name, since)
+    if not snapshots:
+        return []
+    baseline, current = _split_baseline_current(snapshots)
+
+    out: list[dict] = []
+    for column, cur in current.items():
+        base = baseline.get(column)
+        if base is None or base["ts"] == cur["ts"]:
+            out.append({
+                "column": column,
+                "data_type": cur.get("data_type"),
+                "psi": None,
+                "ks_pvalue": None,
+                "is_drift": False,
+                "severity": "insufficient_data",
+            })
+            continue
+
+        cur_buckets = cur.get("buckets") or []
+        base_buckets = base.get("buckets") or []
+        psi_val = psi(_to_proportions(base_buckets), _to_proportions(cur_buckets))
+
+        ks_p: float | None = None
+        if _is_numeric(cur.get("data_type")):
+            _, ks_p = ks_two_sample(
+                _numeric_pairs(base_buckets), _numeric_pairs(cur_buckets)
+            )
+
+        severity = _severity(psi_val)
+        is_drift = severity != "ok" or (ks_p is not None and ks_p < KS_PVALUE_THRESHOLD)
+        out.append({
+            "column": column,
+            "data_type": cur.get("data_type"),
+            "psi": round(psi_val, 4),
+            "ks_pvalue": round(ks_p, 4) if ks_p is not None else None,
+            "is_drift": is_drift,
+            "severity": severity,
+        })
+
+    out.sort(key=lambda r: -(r["psi"] or 0))
+    return out

--- a/scripts/seed_metrics_history.py
+++ b/scripts/seed_metrics_history.py
@@ -1,15 +1,33 @@
 """
-Seed 14 days of synthetic metric history (every 15 min) for demo dashboards.
+Seed 14 days of synthetic monitoring history into the monitor DB.
 
-Writes to the monitoring DB (MONITOR_DB_URL) via app.metrics_storage.
-Includes 3 anomalies visible on charts:
-  1. null_rate spike in orders   — day 6–7  (simulates a bad data load)
-  2. null_rate step-up in events.ip_address — last 7 days (simulates a logging regression)
-  3. sudden row_count drop in products  — day 10 (simulates an accidental DELETE)
+One command populates everything the demo dashboards need:
+  - row_count + null_rate every 15 min   → chart "Динамика за 7 дней", forecast
+  - column_distribution once per day     → drift detection (PSI/KS)
+
+Writes to MONITOR_DB_URL via app.metrics_storage. Idempotent in the sense
+that re-running adds new snapshots (timestamps differ each run); wipe with
+`sqlite3 monitor.db "DELETE FROM metrics"` if you need a clean slate.
+
+Anomalies on chart metrics:
+  1. orders.null_rate spike            — days 6–7  (bad data load)
+  2. events.ip_address null step-up    — last 7 days (logging regression)
+  3. products row_count drop           — day 10 (accidental DELETE)
+
+Drift scenarios on column_distribution:
+  4. users.signup_source               — gradual web→mobile (last 7 days)
+  5. orders.shipping_country           — sudden US lurch (last ~3 days)
+  6. orders.amount                     — numeric mean shift ($400 → $1500)
+  7. events.server_id                  — load skew toward server-1 (last 7 days)
+
+Stable controls (severity=ok, PSI < 0.01):
+  users.country, orders.status, events.device_type, products.category
 
 Usage:
     python -m scripts.seed_metrics_history
 """
+from __future__ import annotations
+
 import math
 import random
 from datetime import datetime, timedelta, timezone
@@ -19,25 +37,11 @@ from app.metrics_storage import save_metrics
 TABLES = ["users", "products", "orders", "events"]
 DAYS = 14
 INTERVAL_MINUTES = 15
+DRIFT_SNAPSHOT_TOTAL = 1_000  # synthetic per-snapshot row count for distributions
 
-_BASE_ROWS = {
-    "users": 50_000,
-    "products": 1_000,
-    "orders": 100_000,
-    "events": 200_000,
-}
-_GROWTH_PER_DAY = {
-    "users": 150,
-    "products": 2,
-    "orders": 600,
-    "events": 3_000,
-}
-_BASE_NULL_RATE = {
-    "users": 0.05,
-    "products": 0.01,
-    "orders": 0.02,
-    "events": 0.02,
-}
+_BASE_ROWS = {"users": 50_000, "products": 1_000, "orders": 100_000, "events": 200_000}
+_GROWTH_PER_DAY = {"users": 150, "products": 2, "orders": 600, "events": 3_000}
+_BASE_NULL_RATE = {"users": 0.05, "products": 0.01, "orders": 0.02, "events": 0.02}
 _NULL_COLUMN = {
     "users": "email",
     "products": "price_updated_at",
@@ -46,12 +50,14 @@ _NULL_COLUMN = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Row-count + null-rate (chart + forecast input)
+# ---------------------------------------------------------------------------
+
 def _row_count(table: str, days_passed: float, ts: datetime) -> float:
     base = _BASE_ROWS[table] + _GROWTH_PER_DAY[table] * days_passed
-    # daily seasonality ±8%, peak at 14:00 UTC
     seasonality = 1 + 0.08 * math.sin((ts.hour - 14) / 24 * 2 * math.pi)
     noise = 1 + random.uniform(-0.01, 0.01)
-    # anomaly 3: sudden drop in products on day 10 (accidental delete)
     if table == "products" and 9.9 < days_passed < 10.9:
         base *= 0.4
     return base * seasonality * noise
@@ -59,36 +65,127 @@ def _row_count(table: str, days_passed: float, ts: datetime) -> float:
 
 def _null_rate(table: str, days_passed: float) -> float:
     rate = max(0.0, random.gauss(_BASE_NULL_RATE[table], 0.003))
-    # anomaly 1: null_rate spike in orders around day 6–7
     if table == "orders" and 5.8 < days_passed < 7.2:
         rate += 0.18
-    # anomaly 2: step-up in events.ip_address null_rate over last 7 days (~25%)
-    # mirrors seed_target_db._seed_events: null_prob=0.25 for age_days < 7
     if table == "events" and days_passed > DAYS - 7:
         rate = max(rate, 0.25)
     return round(min(rate, 1.0), 4)
 
 
+# ---------------------------------------------------------------------------
+# Column-distribution generators (drift input). Each returns {value: weight}.
+# `progress` ranges 0.0 (window start) → 1.0 (window end).
+# ---------------------------------------------------------------------------
+
+def _users_signup_source(progress: float) -> dict[str, float]:
+    if progress < 0.5:
+        return {"web": 0.60, "mobile": 0.30, "api": 0.07, "referral": 0.03}
+    p = (progress - 0.5) * 2
+    return {"web": 0.60 - 0.45 * p, "mobile": 0.30 + 0.45 * p,
+            "api": 0.07, "referral": 0.03}
+
+
+def _users_country(_: float) -> dict[str, float]:
+    return {"RU": 0.30, "US": 0.25, "DE": 0.15, "GB": 0.12,
+            "FR": 0.08, "CN": 0.06, "BR": 0.04}
+
+
+def _orders_status(_: float) -> dict[str, float]:
+    return {"delivered": 0.45, "shipped": 0.20, "confirmed": 0.18,
+            "pending": 0.10, "cancelled": 0.07}
+
+
+def _orders_shipping_country(progress: float) -> dict[str, float]:
+    if progress < 0.8:
+        return {"RU": 0.25, "US": 0.20, "DE": 0.15, "GB": 0.15,
+                "FR": 0.10, "CN": 0.10, "BR": 0.05}
+    return {"RU": 0.10, "US": 0.65, "DE": 0.07, "GB": 0.07,
+            "FR": 0.04, "CN": 0.04, "BR": 0.03}
+
+
+def _orders_amount(progress: float) -> dict[str, float]:
+    centers = [50 + 100 * i for i in range(20)]
+    mean = 400 + 1100 * progress
+    std = 200 + 400 * progress
+    weights = {str(c): math.exp(-((c - mean) ** 2) / (2 * std * std)) for c in centers}
+    s = sum(weights.values()) or 1.0
+    return {k: v / s for k, v in weights.items()}
+
+
+def _events_server_id(progress: float) -> dict[str, float]:
+    p = max(0.0, (progress - 0.5) * 2)
+    s1 = 0.34 + 0.45 * p
+    rest = (1 - s1) / 2
+    return {"server-1": s1, "server-2": rest, "server-3": rest}
+
+
+def _events_device_type(_: float) -> dict[str, float]:
+    return {"mobile": 0.55, "desktop": 0.35, "tablet": 0.10}
+
+
+def _products_category(_: float) -> dict[str, float]:
+    return {"Electronics": 0.22, "Clothing": 0.20, "Food": 0.18,
+            "Books": 0.15, "Home": 0.15, "Sports": 0.10}
+
+
+# (table, column, data_type, generator)
+_DRIFT_COLUMNS = [
+    ("users",    "signup_source",    "varchar", _users_signup_source),
+    ("users",    "country",          "varchar", _users_country),
+    ("orders",   "status",           "varchar", _orders_status),
+    ("orders",   "shipping_country", "varchar", _orders_shipping_country),
+    ("orders",   "amount",           "numeric", _orders_amount),
+    ("events",   "server_id",        "varchar", _events_server_id),
+    ("events",   "device_type",      "varchar", _events_device_type),
+    ("products", "category",         "varchar", _products_category),
+]
+
+
+def _to_buckets(weights: dict[str, float], total: int = DRIFT_SNAPSHOT_TOTAL) -> list[dict]:
+    raw = [(v, max(0.0, w + random.gauss(0, 0.005))) for v, w in weights.items()]
+    s = sum(c for _, c in raw) or 1.0
+    buckets = [{"value": v, "count": int(round(c / s * total))} for v, c in raw]
+    buckets = [b for b in buckets if b["count"] > 0]
+    buckets.sort(key=lambda b: -b["count"])
+    return buckets
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
 def _generate():
     now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
     start = now - timedelta(days=DAYS)
     t = start
+    last_drift_day = -1
     while t <= now:
         days_passed = (t - start).total_seconds() / 86400
         for table in TABLES:
             yield {
-                "ts": t,
-                "table_name": table,
+                "ts": t, "table_name": table,
                 "metric_name": "row_count",
                 "value": int(_row_count(table, days_passed, t)),
             }
             yield {
-                "ts": t,
-                "table_name": table,
+                "ts": t, "table_name": table,
                 "metric_name": "null_rate",
                 "value": _null_rate(table, days_passed),
                 "tags": {"column": _NULL_COLUMN[table]},
             }
+        # Distribution snapshot once per day at the first tick of that day.
+        current_day = int(days_passed)
+        if current_day != last_drift_day:
+            last_drift_day = current_day
+            progress = days_passed / DAYS
+            for table, column, dtype, gen in _DRIFT_COLUMNS:
+                buckets = _to_buckets(gen(progress))
+                yield {
+                    "ts": t, "table_name": table,
+                    "metric_name": "column_distribution",
+                    "value": float(sum(b["count"] for b in buckets)),
+                    "tags": {"column": column, "data_type": dtype, "buckets": buckets},
+                }
         t += timedelta(minutes=INTERVAL_MINUTES)
 
 
@@ -104,12 +201,19 @@ def main() -> None:
     total += save_metrics(batch)
 
     ticks = DAYS * 24 * 60 // INTERVAL_MINUTES
-    print(f"Seeded {total:,} metric rows:")
-    print(f"  {len(TABLES)} tables × 2 metrics × ~{ticks} ticks = ~{len(TABLES) * 2 * ticks:,} rows")
-    print("Anomalies injected:")
-    print("  orders   null_rate spike      — days 6–7")
-    print("  events   null_rate step-up    — last 7 days")
-    print("  products row_count drop       — day 10")
+    drift_snaps = (DAYS + 1) * len(_DRIFT_COLUMNS)
+    print(f"Seeded {total:,} metric rows into MONITOR_DB_URL:")
+    print(f"  row_count + null_rate     — {len(TABLES)} tables × 2 × ~{ticks} ticks")
+    print(f"  column_distribution        — {drift_snaps} snapshots ({len(_DRIFT_COLUMNS)} cols × {DAYS + 1} days)")
+    print("Chart anomalies:")
+    print("  orders.null_rate spike     — days 6–7")
+    print("  events.ip_address step-up  — last 7 days")
+    print("  products row_count drop    — day 10")
+    print("Drift scenarios:")
+    print("  users.signup_source        — gradual web→mobile (last 7 days)")
+    print("  orders.shipping_country    — sudden US lurch (last ~3 days)")
+    print("  orders.amount              — numeric mean shift ($400 → $1500)")
+    print("  events.server_id           — server-1 load skew (last 7 days)")
 
 
 if __name__ == "__main__":

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -77,6 +77,15 @@
       </div>
     </section>
   </div>
+
+  <section class="mt-8 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="flex items-center justify-between">
+      <h2 class="text-base font-semibold">Drift (vs baseline 7 дн.)</h2>
+      <span class="text-xs text-slate-500 dark:text-slate-400">PSI &gt; 0.2 — warn, &gt; 0.25 — critical</span>
+    </div>
+    <div id="drift-list" class="mt-4 space-y-2"></div>
+    <p id="drift-empty" class="hidden py-6 text-center text-sm text-slate-500 dark:text-slate-400">Недостаточно данных для оценки drift. Нужно ≥ 2 снимков column_distribution.</p>
+  </section>
 {% endblock %}
 
 {% block scripts %}
@@ -172,6 +181,39 @@
                        { displayModeBar: false, responsive: true });
       }
       plot(currentMetric);
+
+      // ---- Drift section --------------------------------------------------
+      const driftBox = document.getElementById("drift-list");
+      const driftEmpty = document.getElementById("drift-empty");
+      const drift = await fetch(`/api/drift/${enc}`).then(r => r.ok ? r.json() : []);
+      if (!drift.length) {
+        driftEmpty.classList.remove("hidden");
+      } else {
+        const sevColor = { critical: "rose", warn: "amber", ok: "emerald", insufficient_data: "slate" };
+        const sevLabel = { critical: "Critical", warn: "Warn", ok: "OK", insufficient_data: "Нет данных" };
+        driftBox.innerHTML = drift.map(d => {
+          const c = sevColor[d.severity] || "slate";
+          const psiText = d.psi === null ? "—" : Number(d.psi).toFixed(3);
+          const ksText = d.ks_pvalue === null ? "—" : `p=${Number(d.ks_pvalue).toFixed(3)}`;
+          return `
+            <div class="flex items-center justify-between rounded-md border border-slate-100 px-3 py-2 dark:border-slate-800">
+              <div class="min-w-0">
+                <div class="font-medium">${d.column}</div>
+                <div class="text-xs text-slate-500 dark:text-slate-400">
+                  <span class="font-mono">${d.data_type || "—"}</span>
+                  <span class="px-1">·</span>
+                  <span>KS ${ksText}</span>
+                </div>
+              </div>
+              <span class="inline-flex items-center gap-1.5 text-sm tabular-nums">
+                <span class="h-2 w-2 rounded-full bg-${c}-500"></span>
+                <span>PSI ${psiText}</span>
+                <span class="ml-2 rounded bg-${c}-100 px-1.5 py-0.5 text-xs text-${c}-700 dark:bg-${c}-900/40 dark:text-${c}-300">${sevLabel[d.severity] || d.severity}</span>
+              </span>
+            </div>`;
+        }).join("");
+      }
+
       document.querySelectorAll("#chart-tabs button").forEach(btn => {
         btn.addEventListener("click", () => {
           document.querySelectorAll("#chart-tabs button").forEach(b => {

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -191,7 +191,8 @@
       } else {
         const sevColor = { critical: "rose", warn: "amber", ok: "emerald", insufficient_data: "slate" };
         const sevLabel = { critical: "Critical", warn: "Warn", ok: "OK", insufficient_data: "Нет данных" };
-        driftBox.innerHTML = drift.map(d => {
+        const isQuiet = d => d.severity === "ok" || d.severity === "insufficient_data";
+        const renderRow = d => {
           const c = sevColor[d.severity] || "slate";
           const psiText = d.psi === null ? "—" : Number(d.psi).toFixed(3);
           const ksText = d.ks_pvalue === null ? "—" : `p=${Number(d.ks_pvalue).toFixed(3)}`;
@@ -211,7 +212,24 @@
                 <span class="ml-2 rounded bg-${c}-100 px-1.5 py-0.5 text-xs text-${c}-700 dark:bg-${c}-900/40 dark:text-${c}-300">${sevLabel[d.severity] || d.severity}</span>
               </span>
             </div>`;
-        }).join("");
+        };
+        const noisy = drift.filter(d => !isQuiet(d));
+        const quiet = drift.filter(isQuiet);
+        const noisyHtml = noisy.map(renderRow).join("");
+        const summaryHtml = noisy.length === 0
+          ? `<div class="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-900/20 dark:text-emerald-300">
+               ✓ Drift не обнаружен — стабильно ${quiet.length} колонок (baseline 7 дн.)
+             </div>`
+          : "";
+        const quietHtml = quiet.length
+          ? `<details class="mt-2">
+               <summary class="cursor-pointer text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200">
+                 + ещё ${quiet.length} стабильных колонок
+               </summary>
+               <div class="mt-2 space-y-2">${quiet.map(renderRow).join("")}</div>
+             </details>`
+          : "";
+        driftBox.innerHTML = summaryHtml + noisyHtml + quietHtml;
       }
 
       document.querySelectorAll("#chart-tabs button").forEach(btn => {

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,164 @@
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+
+from app.app import create_app
+from app.metrics_storage import get_engine
+from ml import drift as drift_mod
+from ml.drift import (
+    compute_drift,
+    ks_two_sample,
+    psi,
+)
+
+
+# ---------------------------------------------------------------------------
+# PSI
+# ---------------------------------------------------------------------------
+
+def test_psi_zero_for_identical_distributions():
+    p = {"a": 0.5, "b": 0.3, "c": 0.2}
+    assert psi(p, p) < 1e-9
+
+
+def test_psi_low_for_minor_shift():
+    base = {"a": 0.5, "b": 0.3, "c": 0.2}
+    cur = {"a": 0.48, "b": 0.32, "c": 0.20}
+    assert psi(base, cur) < 0.1
+
+
+def test_psi_above_critical_for_major_shift():
+    base = {"a": 0.7, "b": 0.2, "c": 0.1}
+    cur = {"a": 0.2, "b": 0.3, "c": 0.5}
+    assert psi(base, cur) > drift_mod.PSI_CRITICAL
+
+
+def test_psi_handles_new_categories_via_smoothing():
+    base = {"a": 1.0}
+    cur = {"a": 0.5, "b": 0.5}  # brand-new bucket "b"
+    val = psi(base, cur)
+    assert val > 0
+    assert math_isfinite(val)
+
+
+# ---------------------------------------------------------------------------
+# KS
+# ---------------------------------------------------------------------------
+
+def test_ks_zero_distance_for_identical_samples():
+    pairs = [(1.0, 100), (2.0, 200), (3.0, 50)]
+    d, p = ks_two_sample(pairs, pairs)
+    assert d == 0.0
+    assert p == 1.0
+
+
+def test_ks_detects_shifted_numeric_distribution():
+    base = [(1.0, 500), (2.0, 500)]
+    cur = [(10.0, 500), (20.0, 500)]
+    d, p = ks_two_sample(base, cur)
+    assert d == 1.0
+    assert p < 0.05
+
+
+def test_ks_empty_inputs_return_no_evidence():
+    d, p = ks_two_sample([], [(1.0, 10)])
+    assert d == 0.0 and p == 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_drift integration (via the real metrics SQLite engine)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def clean_metrics(tmp_path, monkeypatch):
+    # Settings is loaded once at import; patch the live value instead of the
+    # env var so a fresh sqlite file backs each test.
+    from app.config import settings
+    monkeypatch.setattr(settings, "MONITOR_DB_URL", f"sqlite:///{tmp_path/'m.db'}")
+    import app.metrics_storage as ms
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    yield
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+
+
+def _seed(table: str, column: str, dtype: str, ts: datetime, buckets: list[dict]):
+    tags = json.dumps({"column": column, "data_type": dtype, "buckets": buckets})
+    total = float(sum(b["count"] for b in buckets))
+    with get_engine().begin() as conn:
+        conn.execute(
+            text("""INSERT INTO metrics (ts, table_name, metric_name, value, tags)
+                    VALUES (:ts, :t, 'column_distribution', :v, :tags)"""),
+            {"ts": ts.isoformat(timespec="seconds"), "t": table, "v": total, "tags": tags},
+        )
+
+
+def test_compute_drift_flags_shifted_column(clean_metrics):
+    now = datetime.now(timezone.utc)
+    _seed("orders", "source", "varchar", now - timedelta(days=5),
+          [{"value": "ads", "count": 700}, {"value": "organic", "count": 300}])
+    _seed("orders", "source", "varchar", now,
+          [{"value": "ads", "count": 200}, {"value": "organic", "count": 800}])
+    report = compute_drift("orders")
+    assert len(report) == 1
+    row = report[0]
+    assert row["column"] == "source"
+    assert row["is_drift"] is True
+    assert row["severity"] == "critical"
+    assert row["psi"] > drift_mod.PSI_CRITICAL
+
+
+def test_compute_drift_clean_for_stable_column(clean_metrics):
+    now = datetime.now(timezone.utc)
+    buckets = [{"value": "ads", "count": 700}, {"value": "organic", "count": 300}]
+    _seed("orders", "source", "varchar", now - timedelta(days=5), buckets)
+    _seed("orders", "source", "varchar", now, buckets)
+    report = compute_drift("orders")
+    assert report[0]["severity"] == "ok"
+    assert report[0]["is_drift"] is False
+    assert report[0]["psi"] < 0.1
+
+
+def test_compute_drift_marks_insufficient_data(clean_metrics):
+    now = datetime.now(timezone.utc)
+    _seed("orders", "source", "varchar", now,
+          [{"value": "ads", "count": 100}])
+    report = compute_drift("orders")
+    assert report[0]["severity"] == "insufficient_data"
+    assert report[0]["is_drift"] is False
+
+
+# ---------------------------------------------------------------------------
+# /api/drift/<table>
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client():
+    app = create_app({"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_drift_endpoint_returns_payload(client):
+    payload = [{"column": "source", "data_type": "varchar", "psi": 0.3,
+                "ks_pvalue": None, "is_drift": True, "severity": "critical"}]
+    with patch("ml.drift.compute_drift", return_value=payload):
+        resp = client.get("/api/drift/orders")
+    assert resp.status_code == 200
+    assert resp.get_json() == payload
+
+
+def test_drift_endpoint_empty_when_no_snapshots(client):
+    with patch("ml.drift.compute_drift", return_value=[]):
+        resp = client.get("/api/drift/orders")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def math_isfinite(x: float) -> bool:
+    import math
+    return math.isfinite(x)

--- a/tests/test_seed_metrics_history.py
+++ b/tests/test_seed_metrics_history.py
@@ -7,6 +7,7 @@ from scripts.seed_metrics_history import (
     DAYS,
     INTERVAL_MINUTES,
     TABLES,
+    _DRIFT_COLUMNS,
     _null_rate,
     _row_count,
     _generate,
@@ -83,13 +84,26 @@ def test_generate_covers_all_tables(all_rows):
     assert {r["table_name"] for r in all_rows} == set(TABLES)
 
 
-def test_generate_both_metrics(all_rows):
-    assert {r["metric_name"] for r in all_rows} == {"row_count", "null_rate"}
+def test_generate_emits_all_metric_types(all_rows):
+    assert {r["metric_name"] for r in all_rows} == {
+        "row_count", "null_rate", "column_distribution",
+    }
 
 
 def test_generate_approx_row_count(all_rows):
-    expected = DAYS * 24 * 60 // INTERVAL_MINUTES * len(TABLES) * 2
-    assert abs(len(all_rows) - expected) <= len(TABLES) * 4
+    ts_count = DAYS * 24 * 60 // INTERVAL_MINUTES
+    expected_chart = ts_count * len(TABLES) * 2
+    expected_drift = (DAYS + 1) * len(_DRIFT_COLUMNS)
+    expected = expected_chart + expected_drift
+    assert abs(len(all_rows) - expected) <= len(TABLES) * 4 + len(_DRIFT_COLUMNS)
+
+
+def test_generate_distribution_rows_have_buckets(all_rows):
+    dist = [r for r in all_rows if r["metric_name"] == "column_distribution"]
+    assert dist, "no distribution rows generated"
+    for r in dist:
+        assert "buckets" in r["tags"]
+        assert all("value" in b and "count" in b for b in r["tags"]["buckets"])
 
 
 def test_generate_null_rate_rows_have_column_tag(all_rows):
@@ -164,5 +178,6 @@ def test_main_calls_save_metrics():
 
     assert saved_counts, "save_metrics was never called"
     total_saved = sum(saved_counts)
-    expected = DAYS * 24 * 60 // INTERVAL_MINUTES * len(TABLES) * 2
-    assert abs(total_saved - expected) <= len(TABLES) * 4
+    ts_count = DAYS * 24 * 60 // INTERVAL_MINUTES
+    expected = ts_count * len(TABLES) * 2 + (DAYS + 1) * len(_DRIFT_COLUMNS)
+    assert abs(total_saved - expected) <= len(TABLES) * 4 + len(_DRIFT_COLUMNS)


### PR DESCRIPTION
Closes #34

## Summary
- `ml/drift.py` — PSI для категориальных, двухвыборочный KS для числовых; pure-Python, без scipy
- `app/db.py` — `DBAdapter.column_distribution`: top-N (value, count) на колонку (generic SQL для PG/MySQL/CH, пропускает text/json/blob)
- Коллектор сохраняет `column_distribution` снапшоты в `metrics.tags` (JSON) на каждом ране
- `GET /api/drift/<table>` → `[{column, data_type, psi, ks_pvalue, is_drift, severity}]`
- Секция «Drift» на странице таблицы с цветовой индикацией severity
- Пороги per spec: PSI > 0.2 → warn, > 0.25 → critical

## Acceptance (из issue)
- [x] Тест с искусственным сдвигом распределения (`test_compute_drift_flags_shifted_column`) → severity=critical, is_drift=True
- [x] Стабильные данные (`test_compute_drift_clean_for_stable_column`) → PSI < 0.1, severity=ok
- [x] Insufficient data → отдельный severity, без ложного срабатывания

## Test plan
- [x] `pytest` — 130 passed (12 новых в `tests/test_drift.py`)
- [ ] Запустить коллектор дважды (≥2 снапшота) → `curl /api/drift/orders` возвращает per-column отчёт
- [ ] Открыть `/dashboard/table/orders` → секция «Drift» отрисована, есть цветные бейджи
- [ ] Подменить distribution в БД и убедиться, что severity=critical отображается красным

## Зависимости
PR независим от #58 (forecasting). Оба PR создают `ml/__init__.py` — merge-конфликт ожидаем, разрешается тривиально (оставить пустой файл).

🤖 Generated with [Claude Code](https://claude.com/claude-code)