### PR TITLE
feat(anomaly): Sprint 2 — Anomaly detection via Isolation Forest (#33)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -4,6 +4,7 @@ from flask import Blueprint, jsonify, request
 
 from .db import list_tables, table_schema
 from .metrics_storage import (
+    get_anomaly_scores,
     get_changepoints,
     get_latest_metric,
     get_metrics,
@@ -135,6 +136,23 @@ def schema(table_name: str):
     if not columns:
         return jsonify({"error": "table not found"}), 404
     return jsonify(columns)
+
+
+@api.route("/anomalies/<table_name>")
+def anomalies(table_name: str):
+    """Anomaly scores for a table, oldest first.
+
+    Query params:
+      range — 1h | 6h | 24h | 7d (default) | 14d | 30d
+
+    Returns [{ts, score, is_anomaly}]. score is the raw IsolationForest
+    decision_function value; negative values indicate anomalies.
+    Returns [] when no scores have been computed yet (model not trained).
+    """
+    range_str = request.args.get("range", "7d")
+    if range_str not in _RANGES:
+        return jsonify({"error": f"range must be one of {sorted(_RANGES)}"}), 400
+    return jsonify(get_anomaly_scores(table_name, window=_RANGES[range_str]))
 
 
 @api.route("/schema/<table_name>/changes")

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -291,6 +291,43 @@ def get_schema_events(
     ]
 
 
+def save_anomaly_scores(rows: Iterable[dict]) -> int:
+    """Upsert anomaly scores. Each row: {ts, table_name, score, is_anomaly}."""
+    payload = []
+    for r in rows:
+        payload.append({
+            "ts": _iso(r["ts"]),
+            "table_name": r["table_name"],
+            "score": float(r["score"]),
+            "is_anomaly": int(r["is_anomaly"]),
+        })
+    if not payload:
+        return 0
+    stmt = text("""
+        INSERT OR REPLACE INTO anomaly_scores (ts, table_name, score, is_anomaly)
+        VALUES (:ts, :table_name, :score, :is_anomaly)
+    """)
+    with get_engine().begin() as conn:
+        conn.execute(stmt, payload)
+    return len(payload)
+
+
+def get_anomaly_scores(
+    table_name: str, window: timedelta = timedelta(days=7)
+) -> list[dict]:
+    """Return anomaly scores for a table within *window*, oldest first."""
+    since = _iso(datetime.now(timezone.utc) - window)
+    stmt = text("""
+        SELECT ts, score, is_anomaly
+        FROM anomaly_scores
+        WHERE table_name = :t AND ts >= :since
+        ORDER BY ts
+    """)
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt, {"t": table_name, "since": since}).fetchall()
+    return [{"ts": r[0], "score": r[1], "is_anomaly": r[2]} for r in rows]
+
+
 def purge_old(retention_days: int = 90) -> int:
     """Delete metrics older than `retention_days`. Returns deleted row count."""
     cutoff = _iso(datetime.now(timezone.utc) - timedelta(days=retention_days))

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -10,6 +10,7 @@ _scheduler: BackgroundScheduler | None = None
 JOB_ID = "collect_all_tables"
 FORECAST_JOB_ID = "retrain_forecasts"
 CHANGEPOINT_JOB_ID = "detect_changepoints"
+ANOMALY_JOB_ID = "retrain_anomaly_detectors"
 
 
 def start_scheduler(app) -> None:
@@ -44,6 +45,14 @@ def start_scheduler(app) -> None:
         id=CHANGEPOINT_JOB_ID,
         name=CHANGEPOINT_JOB_ID,
     )
+    _scheduler.add_job(
+        retrain_anomaly_detectors,
+        "cron",
+        hour=4,
+        minute=0,
+        id=ANOMALY_JOB_ID,
+        name=ANOMALY_JOB_ID,
+    )
     _scheduler.start()
     atexit.register(_scheduler.shutdown, wait=False)
     logger.info("Metrics scheduler started (interval=%d min)", interval)
@@ -75,6 +84,31 @@ def collect_all_tables() -> None:
     counts = collect_all_schemas()
     logger.info("Schema sweep finished: %s", counts)
 
+    if total_saved > 0:
+        _score_recent_anomalies()
+
+
+def _score_recent_anomalies() -> None:
+    """Score the last 24 h of metrics for each table using the persisted model.
+
+    Runs after every collection tick. Silently skips tables whose model has
+    not been trained yet — the nightly retrain job handles the initial scoring.
+    """
+    from ml.anomaly_detector import InsufficientDataError, score_table
+    from app.db import list_tables
+    from app.metrics_storage import save_anomaly_scores
+
+    for t in list_tables():
+        name = t["table_name"]
+        try:
+            scores = score_table(name, window_days=1)
+            if scores:
+                save_anomaly_scores([{**s, "table_name": name} for s in scores])
+        except InsufficientDataError:
+            pass
+        except Exception as exc:
+            logger.debug("Anomaly scoring skipped for %s: %s", name, exc)
+
 
 def retrain_forecasts() -> None:
     from ml.forecast import retrain_all
@@ -90,3 +124,29 @@ def detect_changepoints() -> None:
     logger.info("Job %s started", CHANGEPOINT_JOB_ID)
     counts = detect_all()
     logger.info("Job %s finished: %s", CHANGEPOINT_JOB_ID, counts)
+
+
+def retrain_anomaly_detectors() -> None:
+    from ml.anomaly_detector import InsufficientDataError, retrain_all, score_table
+    from app.db import list_tables
+    from app.metrics_storage import save_anomaly_scores
+
+    logger.info("Job %s started", ANOMALY_JOB_ID)
+    counts = retrain_all()
+    logger.info("Anomaly models retrained: %s", counts)
+
+    # After retraining, score the full 14-day history for every table so the
+    # dashboard has up-to-date annotations without waiting for collect ticks.
+    scored = 0
+    for t in list_tables():
+        name = t["table_name"]
+        try:
+            scores = score_table(name, window_days=14)
+            if scores:
+                save_anomaly_scores([{**s, "table_name": name} for s in scores])
+                scored += len(scores)
+        except InsufficientDataError:
+            pass
+        except Exception as exc:
+            logger.warning("Post-retrain scoring failed for %s: %s", name, exc)
+    logger.info("Job %s finished: %d scores saved", ANOMALY_JOB_ID, scored)

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -107,7 +107,7 @@ def _score_recent_anomalies() -> None:
         except InsufficientDataError:
             pass
         except Exception as exc:
-            logger.debug("Anomaly scoring skipped for %s: %s", name, exc)
+            logger.warning("Anomaly scoring skipped for %s: %s", name, exc)
 
 
 def retrain_forecasts() -> None:

--- a/ml/anomaly_detector.py
+++ b/ml/anomaly_detector.py
@@ -1,0 +1,223 @@
+"""Per-table anomaly detection using Isolation Forest.
+
+Features per tick: row_count, null_rate, Δrow_count, Δnull_rate (4-dim).
+Deltas make sudden spikes/drops stand out regardless of absolute scale.
+
+Model lifecycle
+---------------
+- ``train(table)``     — fit IsolationForest + StandardScaler on 60-day history,
+                         persist to ``models/<table>__anomaly.joblib``.
+- ``score_table(table, window_days)``
+                       — load persisted model, score every point in the window,
+                         return [{ts, score, is_anomaly}].
+- ``retrain_all()``    — train every monitored table; used by the nightly job.
+
+Anomaly threshold: ``decision_function(x) < 0``  (built-in IsolationForest
+convention). The raw score is stored as-is so the threshold stays stable
+across queries of different widths — unlike min-max normalisation which
+shifts with every request.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from app.metrics_storage import get_metrics
+
+
+try:
+    import numpy as np
+    from sklearn.ensemble import IsolationForest
+    from sklearn.preprocessing import StandardScaler
+    _HAS_SKLEARN = True
+except Exception:  # pragma: no cover
+    np = None  # type: ignore
+    IsolationForest = None  # type: ignore
+    StandardScaler = None  # type: ignore
+    _HAS_SKLEARN = False
+
+try:
+    import joblib as _joblib
+    _HAS_JOBLIB = True
+except Exception:  # pragma: no cover
+    _joblib = None  # type: ignore
+    _HAS_JOBLIB = False
+
+logger = logging.getLogger(__name__)
+
+MODELS_DIR = Path(__file__).resolve().parent.parent / "models"
+MIN_POINTS = 200
+TRAIN_WINDOW_DAYS = 60
+
+
+class InsufficientDataError(Exception):
+    """Raised when there is not enough history to train the model."""
+
+
+def _parse_ts(value: str | datetime) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _load_features(
+    table: str, window_days: int
+) -> tuple[list[datetime], "np.ndarray"]:
+    """Load (timestamps, feature_matrix) for *table* over *window_days*.
+
+    Features: [row_count, null_rate, Δrow_count, Δnull_rate].
+    Only ticks where BOTH row_count AND null_rate are available are kept.
+    The first tick is dropped after computing deltas, so n_rows = aligned - 1.
+    Raises InsufficientDataError when the result has fewer than MIN_POINTS rows.
+    """
+    if not _HAS_SKLEARN:
+        raise ImportError("scikit-learn is required for anomaly detection")
+
+    window = timedelta(days=window_days)
+    rc_rows = get_metrics(table, "row_count", window=window)
+    nr_rows = get_metrics(table, "null_rate", window=window)
+
+    rc_map = {r["ts"]: float(r["value"]) for r in rc_rows}
+    nr_map = {r["ts"]: float(r["value"]) for r in nr_rows}
+
+    # Inner join on timestamp — only ticks with both metrics present.
+    common_ts = sorted(set(rc_map) & set(nr_map))
+    if len(common_ts) < 2:
+        raise InsufficientDataError(
+            f"need at least 2 aligned ticks for {table}, got {len(common_ts)}"
+        )
+
+    rc_vals = [rc_map[ts] for ts in common_ts]
+    nr_vals = [nr_map[ts] for ts in common_ts]
+
+    # Compute deltas (drops first element).
+    d_rc = [rc_vals[i] - rc_vals[i - 1] for i in range(1, len(rc_vals))]
+    d_nr = [nr_vals[i] - nr_vals[i - 1] for i in range(1, len(nr_vals))]
+    timestamps = [_parse_ts(ts) for ts in common_ts[1:]]
+
+    X = np.array(
+        [[rc_vals[i + 1], nr_vals[i + 1], d_rc[i], d_nr[i]] for i in range(len(d_rc))],
+        dtype=float,
+    )
+    return timestamps, X
+
+
+def _model_path(table: str) -> Path:
+    safe = table.replace("/", "_").replace(" ", "_")
+    return MODELS_DIR / f"{safe}__anomaly.joblib"
+
+
+def train(table: str) -> dict[str, Any]:
+    """Fit and persist an anomaly-detection model for *table*.
+
+    Returns metadata dict: {n_points, trained_at}.
+    Raises InsufficientDataError when history is too short.
+    """
+    timestamps, X = _load_features(table, window_days=TRAIN_WINDOW_DAYS)
+    if len(timestamps) < MIN_POINTS:
+        raise InsufficientDataError(
+            f"need at least {MIN_POINTS} points for {table}, got {len(timestamps)}"
+        )
+
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+
+    # contamination=0.01 sets the decision threshold so that ≈1% of training
+    # data is flagged — conservative enough to keep FPR well below 5% on
+    # normal data, while still surfacing real anomalies.
+    model = IsolationForest(
+        n_estimators=100,
+        contamination=0.01,
+        random_state=42,
+    )
+    model.fit(X_scaled)
+
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "model": model,
+        "scaler": scaler,
+        "trained_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "n_points": len(timestamps),
+    }
+    if _HAS_JOBLIB:
+        try:
+            _joblib.dump(payload, _model_path(table))
+        except Exception as exc:
+            logger.warning("Failed to persist anomaly model for %s: %s", table, exc)
+
+    return {"n_points": len(timestamps), "trained_at": payload["trained_at"]}
+
+
+def _load_model(table: str) -> dict | None:
+    if not _HAS_JOBLIB:
+        return None
+    path = _model_path(table)
+    if not path.exists():
+        return None
+    try:
+        return _joblib.load(path)
+    except Exception as exc:
+        logger.warning("Failed to load anomaly model %s: %s", path, exc)
+        return None
+
+
+def score_table(
+    table: str,
+    window_days: int = 14,
+) -> list[dict]:
+    """Score every tick in *window_days* using the persisted model.
+
+    Returns [{ts (ISO str), score (float), is_anomaly (int 0|1)}].
+    score == decision_function value; negative means anomaly.
+
+    If no persisted model exists, attempts an on-demand train. Raises
+    InsufficientDataError when there is not enough data for training.
+    """
+    persisted = _load_model(table)
+    if persisted is None:
+        train(table)
+        persisted = _load_model(table)
+    if persisted is None:
+        raise InsufficientDataError(f"could not load or train model for {table}")
+
+    timestamps, X = _load_features(table, window_days=window_days)
+    if len(timestamps) == 0:
+        return []
+
+    scaler: StandardScaler = persisted["scaler"]
+    model: IsolationForest = persisted["model"]
+
+    X_scaled = scaler.transform(X)
+    raw_scores = model.decision_function(X_scaled)
+    predictions = model.predict(X_scaled)
+
+    return [
+        {
+            "ts": ts.isoformat(timespec="seconds"),
+            "score": round(float(raw_scores[i]), 6),
+            "is_anomaly": int(predictions[i] == -1),
+        }
+        for i, ts in enumerate(timestamps)
+    ]
+
+
+def retrain_all() -> dict[str, int]:
+    """Retrain anomaly models for every monitored table. Used by the nightly job."""
+    from app.db import list_tables
+
+    counts: dict[str, int] = {"trained": 0, "skipped": 0, "errors": 0}
+    for t in list_tables():
+        name = t["table_name"]
+        try:
+            train(name)
+            counts["trained"] += 1
+        except InsufficientDataError:
+            counts["skipped"] += 1
+        except Exception as exc:
+            logger.exception("Anomaly retrain failed for %s: %s", name, exc)
+            counts["errors"] += 1
+    logger.info("Anomaly detector retrain complete: %s", counts)
+    return counts

--- a/ml/anomaly_detector.py
+++ b/ml/anomaly_detector.py
@@ -181,7 +181,10 @@ def score_table(
         train(table)
         persisted = _load_model(table)
     if persisted is None:
-        raise InsufficientDataError(f"could not load or train model for {table}")
+        raise RuntimeError(
+            f"anomaly model for {table} was trained but could not be loaded — "
+            f"check write permissions on {MODELS_DIR}"
+        )
 
     timestamps, X = _load_features(table, window_days=window_days)
     if len(timestamps) == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ PyMySQL==1.1.1
 clickhouse-sqlalchemy==0.3.2
 pydantic==2.13.2
 ruptures==1.1.9
+scikit-learn==1.6.1
 pydantic-settings==2.13.1
 pydantic_core==2.46.2
 python-dotenv==1.2.2

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -51,3 +51,16 @@ CREATE TABLE IF NOT EXISTS schema_events (
 
 CREATE INDEX IF NOT EXISTS idx_schema_events_table_ts
     ON schema_events (table_name, ts);
+
+-- Anomaly scores from Isolation Forest — written by the collect tick and
+-- the nightly retrain job. One row per (ts, table); upsert on re-run.
+CREATE TABLE IF NOT EXISTS anomaly_scores (
+    ts          TEXT NOT NULL,
+    table_name  TEXT NOT NULL,
+    score       REAL NOT NULL,   -- raw decision_function value; < 0 means anomaly
+    is_anomaly  INTEGER NOT NULL, -- 1 if anomaly, 0 otherwise
+    PRIMARY KEY (ts, table_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_anomaly_scores_table_ts
+    ON anomaly_scores (table_name, ts);

--- a/scripts/reset_db.py
+++ b/scripts/reset_db.py
@@ -57,6 +57,7 @@ def _drop_monitor() -> None:
         conn.execute(text("DROP TABLE IF EXISTS changepoints"))
         conn.execute(text("DROP TABLE IF EXISTS schema_snapshots"))
         conn.execute(text("DROP TABLE IF EXISTS schema_events"))
+        conn.execute(text("DROP TABLE IF EXISTS anomaly_scores"))
     _apply_schema(get_engine())
     print("[2/5] monitor tables dropped + schema reapplied")
 

--- a/scripts/reset_db.py
+++ b/scripts/reset_db.py
@@ -25,22 +25,23 @@ import logging
 from sqlalchemy import text
 
 from app.metrics_storage import _apply_schema, get_engine
-from ml.forecast import MODELS_DIR
+from ml.anomaly_detector import MODELS_DIR as ANOMALY_MODELS_DIR
+from ml.forecast import MODELS_DIR as FORECAST_MODELS_DIR
 
 logger = logging.getLogger(__name__)
 
 
-def _clear_forecast_cache() -> None:
-    # Stale joblibs were trained against the previous data shape; the freshness
-    # check in ml.forecast only compares timestamps, not values, so it would
-    # happily serve nonsense predictions until the 03:00 retrain. Wipe them.
-    if not MODELS_DIR.exists():
-        return
+def _clear_model_cache() -> None:
+    # Stale joblibs were trained against the previous data shape. Clear both
+    # forecast and anomaly models so the nightly jobs retrain from scratch.
     removed = 0
-    for path in MODELS_DIR.glob("*.joblib"):
-        path.unlink()
-        removed += 1
-    print(f"[*] cleared {removed} stale forecast model(s) from {MODELS_DIR}")
+    for models_dir in {FORECAST_MODELS_DIR, ANOMALY_MODELS_DIR}:
+        if not models_dir.exists():
+            continue
+        for path in models_dir.glob("*.joblib"):
+            path.unlink()
+            removed += 1
+    print(f"[*] cleared {removed} stale model(s)")
 
 
 def _reset_target() -> None:
@@ -87,7 +88,7 @@ def _detect_changepoints() -> None:
 
 def main(local_only: bool = False) -> None:
     logging.basicConfig(level=logging.WARNING)
-    _clear_forecast_cache()
+    _clear_model_cache()
     if not local_only:
         _reset_target()
     _drop_monitor()

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -217,9 +217,14 @@
         } else {
           setMsg("");
         }
-        // Anomaly markers — overlay red dots on anomalous ticks.
+        // Anomaly markers — overlay red dots only on row_count chart.
+        // The model scores a combined 4-dim feature space, so pinning markers
+        // to row_count avoids misleading dots on null_rate when the anomaly
+        // was caused by a row spike (and vice versa).
         const seriesTsSet = new Set(series.map(p => p.ts));
-        const anomalyPts = anomaliesRaw.filter(a => a.is_anomaly && seriesTsSet.has(a.ts));
+        const anomalyPts = metric === "row_count"
+          ? anomaliesRaw.filter(a => a.is_anomaly && seriesTsSet.has(a.ts))
+          : [];
         if (anomalyPts.length) {
           const tsToValue = new Map(series.map(p => [p.ts, p.value]));
           traces.push({

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -21,7 +21,7 @@
     <span class="text-sm text-slate-500 dark:text-slate-400">{{ stats.schema }}</span>
   </div>
 
-  <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+  <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
     {% set kpis = [
       ("Строк", ("{:,}".format(stats.row_count).replace(",", " ") if stats.row_count is not none else "—")),
       ("Размер", ("{:,} KB".format((stats.size_bytes / 1024)|round|int).replace(",", " ") if stats.size_bytes is not none else "—")),
@@ -33,6 +33,10 @@
         <div class="mt-2 text-2xl font-semibold tracking-tight">{{ value }}</div>
       </div>
     {% endfor %}
+    <div id="anomaly-kpi-card" class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div class="text-sm text-slate-500 dark:text-slate-400">Аномалий (24ч)</div>
+      <div id="anomaly-kpi-value" class="mt-2 text-2xl font-semibold tracking-tight">—</div>
+    </div>
   </section>
 
   <div class="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
@@ -107,10 +111,11 @@
     (async function () {
       const tableName = {{ stats.table_name|tojson }};
       const enc = encodeURIComponent(tableName);
-      const [rowCount, nullRate, changepointsRaw] = await Promise.all([
+      const [rowCount, nullRate, changepointsRaw, anomaliesRaw] = await Promise.all([
         fetch(`/api/metrics/${enc}?metric=row_count&range=7d`).then(r => r.json()),
         fetch(`/api/metrics/${enc}?metric=null_rate&range=7d`).then(r => r.json()),
         fetch(`/api/changepoints/${enc}?range=7d`).then(r => r.ok ? r.json() : []),
+        fetch(`/api/anomalies/${enc}?range=7d`).then(r => r.ok ? r.json() : []),
       ]);
       const data = { row_count: rowCount, null_rate: nullRate };
       const changepointsByMetric = changepointsRaw.reduce((acc, cp) => {
@@ -122,6 +127,22 @@
         document.getElementById("chart").classList.add("hidden");
         document.getElementById("chart-empty").classList.remove("hidden");
         return;
+      }
+
+      // --- Anomaly KPI badge ------------------------------------------------
+      const kpiVal = document.getElementById("anomaly-kpi-value");
+      const kpiCard = document.getElementById("anomaly-kpi-card");
+      if (anomaliesRaw.length === 0) {
+        // No scores yet — model hasn't been trained (runs at 04:00).
+        kpiVal.textContent = "—";
+      } else {
+        const cutoff24h = Date.now() - 24 * 3600 * 1000;
+        const anomalyCount24h = anomaliesRaw.filter(a => a.is_anomaly && Date.parse(a.ts) >= cutoff24h).length;
+        kpiVal.textContent = anomalyCount24h;
+        if (anomalyCount24h > 0) {
+          kpiCard.classList.add("border-red-300", "dark:border-red-800");
+          kpiVal.classList.add("text-red-600", "dark:text-red-400");
+        }
       }
       const isDark = document.documentElement.classList.contains("dark");
       const layout = {
@@ -196,6 +217,22 @@
         } else {
           setMsg("");
         }
+        // Anomaly markers — overlay red dots on anomalous ticks.
+        const seriesTsSet = new Set(series.map(p => p.ts));
+        const anomalyPts = anomaliesRaw.filter(a => a.is_anomaly && seriesTsSet.has(a.ts));
+        if (anomalyPts.length) {
+          const tsToValue = new Map(series.map(p => [p.ts, p.value]));
+          traces.push({
+            x: anomalyPts.map(a => a.ts),
+            y: anomalyPts.map(a => tsToValue.get(a.ts)),
+            mode: "markers",
+            name: "Аномалия",
+            marker: { color: "#ef4444", size: 8, symbol: "circle" },
+            hovertemplate: "Аномалия<br>score: %{customdata:.4f}<extra></extra>",
+            customdata: anomalyPts.map(a => a.score),
+          });
+        }
+
         const cps = changepointsByMetric[metric] || [];
         const fmtPct = v => `${(Math.abs(v) * 100).toFixed(0)}%`;
         const fmtNum = v => v >= 1000 ? v.toLocaleString("ru-RU") : v.toFixed(2);

--- a/tests/test_anomaly_detector.py
+++ b/tests/test_anomaly_detector.py
@@ -1,0 +1,234 @@
+"""Tests for ml.anomaly_detector."""
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.app import create_app
+from ml import anomaly_detector as ad
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _series(n: int, step_minutes: int = 15, slope: float = 10.0, base: float = 1000.0):
+    """Return fake metrics rows for get_metrics mock."""
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return [
+        {
+            "ts": (t0 + timedelta(minutes=i * step_minutes)).isoformat(timespec="seconds"),
+            "value": base + slope * i,
+            "tags": None,
+        }
+        for i in range(n)
+    ]
+
+
+def _series_with_spike(n: int, spike_start: int, spike_end: int, spike_value: float = 0.5):
+    """null_rate series: near-zero with a clear spike in [spike_start, spike_end)."""
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    rows = []
+    for i in range(n):
+        v = spike_value if spike_start <= i < spike_end else 0.02
+        rows.append({
+            "ts": (t0 + timedelta(minutes=i * 15)).isoformat(timespec="seconds"),
+            "value": v,
+            "tags": None,
+        })
+    return rows
+
+
+def _make_side_effect(rc_rows, nr_rows):
+    """Return a side_effect for get_metrics that dispatches by metric_name."""
+    def _side_effect(table, metric_name, window=None):
+        if metric_name == "row_count":
+            return rc_rows
+        if metric_name == "null_rate":
+            return nr_rows
+        return []
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# _load_features
+# ---------------------------------------------------------------------------
+
+def test_load_features_raises_with_single_point():
+    # _load_features needs at least 2 aligned ticks to compute deltas.
+    rc = _series(1)
+    nr = _series(1)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        with pytest.raises(ad.InsufficientDataError):
+            ad._load_features("t", window_days=7)
+
+
+def test_load_features_returns_correct_shape():
+    n = 50
+    rc = _series(n)
+    nr = _series(n, base=0.05, slope=0.0)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        timestamps, X = ad._load_features("t", window_days=7)
+    assert len(timestamps) == n - 1  # first row dropped for delta
+    assert X.shape == (n - 1, 4)     # row_count, null_rate, Δrow_count, Δnull_rate
+
+
+# ---------------------------------------------------------------------------
+# train
+# ---------------------------------------------------------------------------
+
+def test_train_raises_when_too_few_points_after_delta(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "MODELS_DIR", tmp_path)
+    # 150 rows → 149 after delta, below MIN_POINTS=200
+    rc = _series(150)
+    nr = _series(150, base=0.05, slope=0.0)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        with pytest.raises(ad.InsufficientDataError):
+            ad.train("t")
+
+
+def test_train_persists_model(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(ad, "MIN_POINTS", 10)  # lower threshold for test speed
+    rc = _series(50)
+    nr = _series(50, base=0.05, slope=0.0)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        meta = ad.train("t")
+    assert (tmp_path / "t__anomaly.joblib").exists()
+    assert meta["n_points"] == 49
+
+
+def test_train_returns_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(ad, "MIN_POINTS", 10)
+    rc = _series(50)
+    nr = _series(50, base=0.02, slope=0.0)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        meta = ad.train("t")
+    assert "trained_at" in meta
+    assert meta["n_points"] > 0
+
+
+# ---------------------------------------------------------------------------
+# score_table
+# ---------------------------------------------------------------------------
+
+def test_score_table_returns_list_of_dicts(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(ad, "MIN_POINTS", 10)
+    n = 60
+    rc = _series(n)
+    nr = _series(n, base=0.02, slope=0.0)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        ad.train("t")
+        results = ad.score_table("t", window_days=14)
+    assert len(results) == n - 1
+    for r in results:
+        assert "ts" in r
+        assert "score" in r
+        assert r["is_anomaly"] in (0, 1)
+
+
+def test_score_table_detects_spike(tmp_path, monkeypatch):
+    """A clear null_rate spike should produce at least one is_anomaly=1 point."""
+    monkeypatch.setattr(ad, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(ad, "MIN_POINTS", 10)
+    n = 300
+    spike_start, spike_end = 250, 270
+    rc = _series(n)
+    nr = _series_with_spike(n, spike_start=spike_start, spike_end=spike_end)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        ad.train("t")
+        results = ad.score_table("t", window_days=60)
+    anomalous = [r for r in results if r["is_anomaly"] == 1]
+    assert len(anomalous) >= 1
+
+
+def test_score_table_low_fpr_on_stable_data(tmp_path, monkeypatch):
+    """On stable data, fewer than 5% of points should be flagged as anomalies."""
+    monkeypatch.setattr(ad, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(ad, "MIN_POINTS", 10)
+    n = 300
+    rc = _series(n, slope=10.0)
+    nr = _series(n, base=0.02, slope=0.0)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        ad.train("t")
+        results = ad.score_table("t", window_days=60)
+    fpr = sum(1 for r in results if r["is_anomaly"] == 1) / len(results)
+    assert fpr < 0.05
+
+
+def test_score_table_trains_on_demand_if_no_model(tmp_path, monkeypatch):
+    """score_table should train automatically when no persisted model exists."""
+    monkeypatch.setattr(ad, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(ad, "MIN_POINTS", 10)
+    n = 50
+    rc = _series(n)
+    nr = _series(n, base=0.02, slope=0.0)
+    with patch.object(ad, "get_metrics", side_effect=_make_side_effect(rc, nr)):
+        results = ad.score_table("t", window_days=14)
+    assert len(results) > 0
+
+
+# ---------------------------------------------------------------------------
+# retrain_all
+# ---------------------------------------------------------------------------
+
+def test_retrain_all_counts(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(ad, "MIN_POINTS", 10)
+    tables = [{"table_name": "a"}, {"table_name": "b"}, {"table_name": "c"}]
+    rc_long = _series(50)
+    nr_long = _series(50, base=0.02, slope=0.0)
+    rc_short = _series(5)
+    nr_short = _series(5, base=0.02, slope=0.0)
+
+    series_map = {
+        "a": (rc_long, nr_long),
+        "b": (rc_long, nr_long),
+        "c": (rc_short, nr_short),  # too short → skipped
+    }
+
+    def _get(table, metric, window=None):
+        rc, nr = series_map[table]
+        return rc if metric == "row_count" else nr
+
+    with patch.object(ad, "get_metrics", side_effect=_get), \
+         patch("app.db.list_tables", return_value=tables):
+        counts = ad.retrain_all()
+
+    assert counts["trained"] == 2
+    assert counts["skipped"] == 1
+    assert counts["errors"] == 0
+
+
+# ---------------------------------------------------------------------------
+# API endpoint
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client():
+    app = create_app({"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_anomalies_endpoint_returns_list(client):
+    payload = [{"ts": "2026-05-01T00:00:00", "score": -0.1, "is_anomaly": 1}]
+    with patch("app.api.get_anomaly_scores", return_value=payload):
+        resp = client.get("/api/anomalies/orders?range=7d")
+    assert resp.status_code == 200
+    assert resp.get_json() == payload
+
+
+def test_anomalies_endpoint_invalid_range(client):
+    resp = client.get("/api/anomalies/orders?range=99d")
+    assert resp.status_code == 400
+
+
+def test_anomalies_endpoint_returns_empty_list_when_no_data(client):
+    with patch("app.api.get_anomaly_scores", return_value=[]):
+        resp = client.get("/api/anomalies/orders")
+    assert resp.status_code == 200
+    assert resp.get_json() == []

--- a/tests/test_changepoint.py
+++ b/tests/test_changepoint.py
@@ -10,7 +10,8 @@ from ml import changepoint as cp_mod
 
 
 def _series(values, start=None, step_minutes=15):
-    base = start or datetime(2026, 4, 20, tzinfo=timezone.utc)
+    # Anchor to now so timestamps always fall within the default 14-day query window.
+    base = start or datetime.now(timezone.utc) - timedelta(minutes=step_minutes * len(values))
     return [
         {"ts": (base + timedelta(minutes=step_minutes * i)).isoformat(timespec="seconds"),
          "value": v, "tags": None}


### PR DESCRIPTION
## Что сделано

Реализована детекция аномалий на основе Isolation Forest (задача #33).

## Изменения

### Новый функционал
- **`ml/anomaly_detector.py`** — обучение IsolationForest + StandardScaler на 60-дневной истории, скоринг окна, joblib-персистенция моделей в `models/<table>__anomaly.joblib`
- **`scripts/metrics_schema.sql`** — новая таблица `anomaly_scores` (ts, table_name, score, is_anomaly) с upsert через PRIMARY KEY
- **`app/metrics_storage.py`** — `save_anomaly_scores()` и `get_anomaly_scores()`
- **`app/api.py`** — `GET /api/anomalies/<table>?range=7d`
- **`collectors/scheduler.py`** — ночной retrain (cron 04:00) + скоринг 24ч после каждого collect-тика
- **`templates/table_detail.html`** — KPI-бейдж «Аномалий (24ч)» + красные маркеры на графике
- **`requirements.txt`** — добавлен `scikit-learn==1.6.1`

### Исправления
- **`scripts/reset_db.py`** — добавлен `DROP TABLE IF EXISTS anomaly_scores` в `_drop_monitor()`
- **`tests/test_changepoint.py`** — исправлен hardcoded `datetime(2026, 4, 20)` в `_series()`, тест падал начиная с 2026-05-04
- **`tests/test_anomaly_detector.py`** — исправлен неверный таргет мока (`app.metrics_storage` → `app.api`)

## Тесты

- 13 новых тестов в `tests/test_anomaly_detector.py`
- Все 175 тестов пройдены (175 passed, 0 failed)

## Acceptance criteria

- FPR < 5% на стабильных данных ✓ (`contamination=0.01`)
- Детектирует spike в null_rate ✓ (`test_score_table_detects_spike`)
- Эндпоинт `/api/anomalies/<table>` ✓
- Dashboard: красные маркеры + KPI-бейдж ✓