### PR TITLE
fix(forecast): CI уходит в минус — floor + обучение от последнего changepoint

### DIFF
--- a/ml/forecast.py
+++ b/ml/forecast.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from app.metrics_storage import get_metrics
+from app.metrics_storage import get_changepoints, get_metrics
 
 try:  # pragma: no cover - optional heavy dep
     from prophet import Prophet  # type: ignore
@@ -115,7 +115,7 @@ def _predict_prophet(model, horizon_days: int) -> list[dict]:  # pragma: no cove
         out.append({
             "ts": ds.replace(tzinfo=timezone.utc).isoformat(timespec="seconds"),
             "yhat": float(row["yhat"]),
-            "yhat_lower": float(row["yhat_lower"]),
+            "yhat_lower": max(0.0, float(row["yhat_lower"])),
             "yhat_upper": float(row["yhat_upper"]),
         })
     return out
@@ -129,7 +129,7 @@ def _predict_linear(model: LinearModel, last_ts: datetime, horizon_days: int) ->
         out.append({
             "ts": ts.astimezone(timezone.utc).isoformat(timespec="seconds"),
             "yhat": yhat,
-            "yhat_lower": lo,
+            "yhat_lower": max(0.0, lo),
             "yhat_upper": hi,
         })
     return out
@@ -142,7 +142,20 @@ def _model_path(table: str, metric: str) -> Path:
 
 def train(table: str, metric: str = "row_count") -> dict[str, Any]:
     """Fit a forecast model for (table, metric), persist it, return metadata."""
-    points = _load_history(table, metric)
+    cps = get_changepoints(table, metric, window=timedelta(days=60))
+    last_cp_ts: str | None = cps[-1]["ts"] if cps else None
+
+    if last_cp_ts is not None:
+        since = _parse_ts(last_cp_ts)
+        days_since = max(1, int((datetime.now(timezone.utc) - since).total_seconds() / 86400) + 1)
+        points = _load_history(table, metric, days=days_since)
+        if len(points) < MIN_POINTS:
+            # Not enough post-changepoint data — fall back to full window.
+            # Keep last_cp_ts so forecast() doesn't retrain on the next request.
+            points = _load_history(table, metric)
+    else:
+        points = _load_history(table, metric)
+
     if len(points) < MIN_POINTS:
         raise InsufficientDataError(
             f"need at least {MIN_POINTS} points for {table}/{metric}, got {len(points)}"
@@ -160,6 +173,7 @@ def train(table: str, metric: str = "row_count") -> dict[str, Any]:
         "kind": kind,
         "model": model,
         "last_ts": points[-1][0].isoformat(),
+        "last_changepoint_ts": last_cp_ts,
         "trained_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
     }
     if _HAS_JOBLIB:
@@ -201,10 +215,14 @@ def forecast(
         )
     last_ts = points[-1][0]
 
+    cps = get_changepoints(table, metric, window=timedelta(days=60))
+    last_cp_ts = cps[-1]["ts"] if cps else None
+
     persisted = _load_persisted(table, metric)
     fresh = (
         persisted is not None
         and _parse_ts(persisted["last_ts"]) >= last_ts - timedelta(hours=1)
+        and persisted.get("last_changepoint_ts") == last_cp_ts
     )
     if not fresh:
         train(table, metric)

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -25,7 +25,8 @@ def test_forecast_uses_linear_fallback_for_short_history(tmp_path, monkeypatch):
     monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
     monkeypatch.setattr(fc_mod, "_HAS_PROPHET", False)
     rows = _series(10, step_hours=1, slope=5.0, start=0.0)
-    with patch.object(fc_mod, "get_metrics", return_value=rows):
+    with patch.object(fc_mod, "get_metrics", return_value=rows), \
+         patch.object(fc_mod, "get_changepoints", return_value=[]):
         out = fc_mod.forecast("t", "row_count", horizon_days=1)
     assert len(out) == 24
     for p in out:
@@ -37,7 +38,8 @@ def test_forecast_uses_linear_fallback_for_short_history(tmp_path, monkeypatch):
 
 def test_forecast_raises_when_too_few_points(tmp_path, monkeypatch):
     monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
-    with patch.object(fc_mod, "get_metrics", return_value=_series(1)):
+    with patch.object(fc_mod, "get_metrics", return_value=_series(1)), \
+         patch.object(fc_mod, "get_changepoints", return_value=[]):
         with pytest.raises(fc_mod.InsufficientDataError):
             fc_mod.forecast("t", "row_count")
 
@@ -48,6 +50,7 @@ def test_retrain_all_skips_empty_tables(tmp_path, monkeypatch):
     tables = [{"table_name": "a"}, {"table_name": "b"}]
     series_map = {"a": _series(5), "b": _series(1)}
     with patch.object(fc_mod, "get_metrics", side_effect=lambda t, m, **_: series_map[t]), \
+         patch.object(fc_mod, "get_changepoints", return_value=[]), \
          patch("app.db.list_tables", return_value=tables):
         counts = fc_mod.retrain_all()
     assert counts["trained"] == 1
@@ -88,3 +91,69 @@ def test_forecast_endpoint_insufficient_data(client):
         resp = client.get("/api/forecast/users")
     assert resp.status_code == 422
     assert resp.get_json()["error"] == "insufficient_data"
+
+
+# ---------------------------------------------------------------------------
+# Changepoint-aware training and cache invalidation
+# ---------------------------------------------------------------------------
+
+def test_train_uses_post_changepoint_window(tmp_path, monkeypatch):
+    """train() should load only the post-changepoint window when a cp exists."""
+    monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(fc_mod, "_HAS_PROPHET", False)
+
+    cp_ts = (datetime.now(timezone.utc).replace(microsecond=0) - timedelta(days=7)).isoformat()
+    fake_cp = [{"ts": cp_ts, "metric_name": "row_count", "score": 10.0,
+                "value_before": 100.0, "value_after": 200.0}]
+
+    captured_windows = []
+
+    def fake_get_metrics(table, metric, window):
+        captured_windows.append(window)
+        # return enough points for any window size
+        return _series(10, step_hours=1, slope=1.0, start=200.0)
+
+    with patch.object(fc_mod, "get_changepoints", return_value=fake_cp), \
+         patch.object(fc_mod, "get_metrics", side_effect=fake_get_metrics):
+        fc_mod.train("t", "row_count")
+
+    # The window used must be shorter than the full 60-day default
+    assert len(captured_windows) == 1
+    assert captured_windows[0] < timedelta(days=60)
+
+
+def test_forecast_invalidates_cache_on_new_changepoint(tmp_path, monkeypatch):
+    """forecast() must retrain when a new changepoint appears since last train."""
+    monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(fc_mod, "_HAS_PROPHET", False)
+
+    rows = _series(10, step_hours=1, slope=1.0, start=100.0)
+
+    # Persist a model that was trained with no changepoint
+    old_model = fc_mod._fit_linear([(fc_mod._parse_ts(r["ts"]), float(r["value"])) for r in rows])
+    import joblib as _jl
+    _jl.dump({
+        "kind": "linear",
+        "model": old_model,
+        "last_ts": rows[-1]["ts"],
+        "last_changepoint_ts": None,
+        "trained_at": "2026-04-01T00:00:00",
+    }, fc_mod._model_path("t", "row_count"))
+
+    # Now a changepoint has appeared
+    new_cp = [{"ts": rows[5]["ts"], "metric_name": "row_count", "score": 5.0,
+               "value_before": 100.0, "value_after": 150.0}]
+
+    train_calls = []
+
+    original_train = fc_mod.train
+    def spy_train(table, metric="row_count"):
+        train_calls.append((table, metric))
+        return original_train(table, metric)
+
+    with patch.object(fc_mod, "get_metrics", return_value=rows), \
+         patch.object(fc_mod, "get_changepoints", return_value=new_cp), \
+         patch.object(fc_mod, "train", side_effect=spy_train):
+        fc_mod.forecast("t", "row_count", horizon_days=1)
+
+    assert len(train_calls) == 1, "forecast() must retrain when changepoint is new"


### PR DESCRIPTION
Closes #63

## Проблема

`train()` обучался на полном 60-дневном окне, включающем структурные скачки (резкий рост users, дроп products). Высокая дисперсия остатков → σ≫0 → нижняя граница CI = `yhat − 1.96σ` уходила в отрицательные значения. Модуль `ml/forecast.py` и changepoint-детектор существовали независимо.

## Решение — три слоя

**1. Floor для нижней границы CI** (`_predict_linear`, `_predict_prophet`):
```python
"yhat_lower": max(0.0, lo)
```
Гарантирует неотрицательность для счётных метрик.

**2. Пост-changepoint окно обучения** (`train()`):
Перед фитом запрашивается `get_changepoints()`. Если есть CP — загружается только история от последнего перелома (`days_since = now − last_cp_ts + 1`). Убирает аномальные переходы из выборки → σ реалистична.
Fallback: если после CP меньше `MIN_POINTS` точек — полное 60-дневное окно.

**3. Инвалидация кэша при новом changepoint** (`forecast()`):
Добавлено третье условие свежести:
```python
persisted.get("last_changepoint_ts") == last_cp_ts
```
Если changepoint появился после обучения — `forecast()` автоматически вызывает `train()`.

**Исправлена ошибка fallback-логики:** при fallback на полное окно `last_cp_ts` сохраняется в payload (а не `None`), иначе `forecast()` ретрейнил бы на каждый запрос.

## Тесты

- `test_train_uses_post_changepoint_window` — window < 60 дней при наличии CP
- `test_forecast_invalidates_cache_on_new_changepoint` — ровно 1 вызов `train()` при новом CP
- 3 существующих теста дополнены `patch(get_changepoints, return_value=[])`
- Убрана хардкодная дата → `datetime.now() - timedelta(days=7)`
- **177/177 тестов проходят**

🤖 Generated with [Claude Code](https://claude.com/claude-code)