### PR TITLE
feat: add dashboard history page (#41)

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -9,6 +9,9 @@ from app.metrics_storage import (
     get_latest_metric,
     get_latest_null_counts,
     get_schema_events,
+    get_history_daily,
+    get_history_insights,
+    get_history_runs,
 )
 
 _RECENT_SCHEMA_DAYS = 7
@@ -83,6 +86,19 @@ def _parse_event_ts(value: str) -> datetime:
     dt = datetime.fromisoformat(s)
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
+
+
+@bp.route("/history")
+def history_view():
+    runs = get_history_runs(limit=12)
+    daily_history = get_history_daily(days=14)
+    insights = get_history_insights()
+    return render_template(
+        "history.html",
+        runs=runs,
+        daily_history=daily_history,
+        insights=insights,
+    )
 
 @bp.route("/<table_name>")
 def table_detail(table_name: str):

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -9,9 +9,10 @@ from app.metrics_storage import (
     get_latest_metric,
     get_latest_null_counts,
     get_schema_events,
+    build_history_aggregate,
+    get_history_runs,
     get_history_daily,
     get_history_insights,
-    get_history_runs,
 )
 
 _RECENT_SCHEMA_DAYS = 7
@@ -90,9 +91,10 @@ def _parse_event_ts(value: str) -> datetime:
 
 @bp.route("/history")
 def history_view():
-    runs = get_history_runs(limit=12)
-    daily_history = get_history_daily(days=14)
-    insights = get_history_insights()
+    agg = build_history_aggregate()
+    runs = get_history_runs(agg, limit=12)
+    daily_history = get_history_daily(agg, days=14)
+    insights = get_history_insights(agg)
     return render_template(
         "history.html",
         runs=runs,

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -343,3 +343,269 @@ def _iso(value: datetime | str) -> str:
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc).isoformat(timespec="seconds")
+
+
+# --- History page helpers (#41) ---
+
+_PROBLEM_NULL_RATE = 0.10
+_CRITICAL_NULL_RATE = 0.30
+_ANOMALY_NULL_RATE_DELTA = 0.05
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "—"
+    # null_rate is stored as a fraction: 0.18 = 18%
+    return f"{value * 100:.1f}%" if value <= 1 else f"{value:.1f}%"
+
+
+def _short_ts(ts: str) -> str:
+    # 2026-05-05T17:20:00+00:00 -> 2026-05-05 17:20
+    return ts.replace("T", " ")[:16]
+
+
+def _metric_identity(table_name: str, tags_json: str | None) -> tuple[str, str]:
+    """Stable key for table-level or column-level metric."""
+    if not tags_json:
+        return table_name, ""
+    try:
+        tags = json.loads(tags_json)
+    except json.JSONDecodeError:
+        return table_name, tags_json
+    column = tags.get("column") if isinstance(tags, dict) else None
+    return table_name, column or ""
+
+
+def _metric_label(table_name: str, tags_json: str | None) -> str:
+    """Human-readable label: table or table.column."""
+    table, column = _metric_identity(table_name, tags_json)
+    return f"{table}.{column}" if column else table
+
+
+def _fetch_history_metric_rows(window: timedelta | None = timedelta(days=30)) -> list[dict]:
+    """Fetch row_count/null_rate rows used by the history page."""
+    params: dict[str, Any] = {}
+    where = "WHERE metric_name IN ('row_count', 'null_rate')"
+    if window is not None:
+        params["since"] = (datetime.now(timezone.utc) - window).isoformat()
+        where += " AND ts >= :since"
+
+    stmt = text(f"""
+        SELECT ts, table_name, metric_name, value, tags
+        FROM metrics
+        {where}
+        ORDER BY ts ASC
+    """)
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt, params).fetchall()
+
+    # If local seed data has timestamps outside the current window, fallback to all rows.
+    if not rows and window is not None:
+        return _fetch_history_metric_rows(window=None)
+
+    return [
+        {
+            "ts": r[0],
+            "table_name": r[1],
+            "metric_name": r[2],
+            "value": _safe_float(r[3]),
+            "tags": r[4],
+        }
+        for r in rows
+    ]
+
+
+def _history_aggregate(window: timedelta | None = timedelta(days=30)) -> dict:
+    """Build reusable aggregates from metrics table.
+
+    A collector run is represented by a timestamp `ts`.
+    Problems: null_rate >= 10%.
+    Anomalies: null_rate jump by >= 5 percentage points compared with the previous run
+    for the same table/column metric.
+    Coverage: checked tables / known tables.
+    """
+    rows = _fetch_history_metric_rows(window=window)
+
+    tables_by_ts: dict[str, set[str]] = {}
+    problems_by_ts: dict[str, int] = {}
+    anomalies_by_ts: dict[str, int] = {}
+    null_rates_by_identity: dict[tuple[str, str], list[tuple[str, float, str | None]]] = {}
+    timestamps: set[str] = set()
+    known_tables: set[str] = set()
+
+    for r in rows:
+        ts = r["ts"]
+        table_name = r["table_name"]
+        metric_name = r["metric_name"]
+        value = r["value"]
+        tags = r["tags"]
+
+        if not ts or not table_name or value is None:
+            continue
+
+        timestamps.add(ts)
+
+        if metric_name == "row_count":
+            known_tables.add(table_name)
+            tables_by_ts.setdefault(ts, set()).add(table_name)
+
+        if metric_name == "null_rate":
+            identity = _metric_identity(table_name, tags)
+            null_rates_by_identity.setdefault(identity, []).append((ts, value, tags))
+            if value >= _PROBLEM_NULL_RATE:
+                problems_by_ts[ts] = problems_by_ts.get(ts, 0) + 1
+
+    for values in null_rates_by_identity.values():
+        previous: float | None = None
+        for ts, value, _tags in sorted(values, key=lambda x: x[0]):
+            if previous is not None and (value - previous) >= _ANOMALY_NULL_RATE_DELTA:
+                anomalies_by_ts[ts] = anomalies_by_ts.get(ts, 0) + 1
+            previous = value
+
+    total_tables = len(known_tables)
+    sorted_timestamps = sorted(timestamps)
+
+    return {
+        "rows": rows,
+        "timestamps": sorted_timestamps,
+        "tables_by_ts": tables_by_ts,
+        "problems_by_ts": problems_by_ts,
+        "anomalies_by_ts": anomalies_by_ts,
+        "total_tables": total_tables,
+    }
+
+
+def get_history_runs(limit: int = 10) -> list[dict]:
+    """Return latest collector runs for the History page."""
+    agg = _history_aggregate(window=timedelta(days=30))
+    timestamps = list(reversed(agg["timestamps"]))[:limit]
+    total_tables = agg["total_tables"]
+
+    runs: list[dict] = []
+    for ts in timestamps:
+        checked_tables = len(agg["tables_by_ts"].get(ts, set()))
+        coverage_pct = round((checked_tables / total_tables) * 100, 1) if total_tables else 0.0
+        runs.append(
+            {
+                "ts": ts,
+                "ts_label": _short_ts(ts),
+                "tables_checked": checked_tables,
+                "problems": agg["problems_by_ts"].get(ts, 0),
+                "anomalies": agg["anomalies_by_ts"].get(ts, 0),
+                "coverage_pct": coverage_pct,
+            }
+        )
+    return runs
+
+
+def get_history_daily(days: int = 14) -> list[dict]:
+    """Return daily trend for problems, anomalies and coverage.
+
+    For each day we use the latest collector run of that day, so the chart shows
+    end-of-day state rather than a raw count of all hourly/15-min checks.
+    """
+    agg = _history_aggregate(window=timedelta(days=days))
+    total_tables = agg["total_tables"]
+    latest_ts_by_day: dict[str, str] = {}
+
+    for ts in agg["timestamps"]:
+        day = ts[:10]
+        latest_ts_by_day[day] = ts
+
+    daily: list[dict] = []
+    for day in sorted(latest_ts_by_day):
+        ts = latest_ts_by_day[day]
+        checked_tables = len(agg["tables_by_ts"].get(ts, set()))
+        coverage_pct = round((checked_tables / total_tables) * 100, 1) if total_tables else 0.0
+        daily.append(
+            {
+                "date": day,
+                "problems": agg["problems_by_ts"].get(ts, 0),
+                "anomalies": agg["anomalies_by_ts"].get(ts, 0),
+                "coverage_pct": coverage_pct,
+            }
+        )
+    return daily
+
+
+def get_history_insights() -> list[str]:
+    """Rule-based text conclusions for the History page."""
+    agg = _history_aggregate(window=timedelta(days=30))
+    timestamps = agg["timestamps"]
+    if not timestamps:
+        return ["Исторические метрики пока не собраны. Запустите коллектор или сидер истории."]
+
+    latest_ts = timestamps[-1]
+    previous_ts = timestamps[-2] if len(timestamps) > 1 else None
+    rows = agg["rows"]
+
+    latest_null_rates = [
+        r for r in rows
+        if r["ts"] == latest_ts
+        and r["metric_name"] == "null_rate"
+        and r["value"] is not None
+    ]
+
+    insights: list[str] = []
+
+    # Coverage insight
+    checked_tables = len(agg["tables_by_ts"].get(latest_ts, set()))
+    total_tables = agg["total_tables"]
+    coverage_pct = round((checked_tables / total_tables) * 100, 1) if total_tables else 0.0
+    insights.append(f"Покрытие последней проверки: {coverage_pct:.1f}% ({checked_tables} из {total_tables} таблиц).")
+
+    # Problem insight
+    latest_problems = agg["problems_by_ts"].get(latest_ts, 0)
+    if latest_problems:
+        insights.append(f"В последней проверке найдено проблемных NULL-метрик: {latest_problems}.")
+    else:
+        insights.append("В последней проверке критичных NULL-проблем по заданным порогам не обнаружено.")
+
+    # Biggest current risk
+    if latest_null_rates:
+        worst = max(latest_null_rates, key=lambda r: r["value"] or 0)
+        if worst["value"] is not None and worst["value"] >= _PROBLEM_NULL_RATE:
+            insights.append(
+                f"Таблица/поле { _metric_label(worst['table_name'], worst['tags']) } требует проверки: "
+                f"NULL rate сейчас {_pct(worst['value'])}."
+            )
+
+    # Growth insight compared to previous run
+    if previous_ts:
+        prev_by_key: dict[tuple[str, str], dict] = {}
+        latest_by_key: dict[tuple[str, str], dict] = {}
+
+        for r in rows:
+            if r["metric_name"] != "null_rate" or r["value"] is None:
+                continue
+            key = _metric_identity(r["table_name"], r["tags"])
+            if r["ts"] == previous_ts:
+                prev_by_key[key] = r
+            elif r["ts"] == latest_ts:
+                latest_by_key[key] = r
+
+        best_growth = None
+        for key, latest in latest_by_key.items():
+            prev = prev_by_key.get(key)
+            if not prev:
+                continue
+            delta = latest["value"] - prev["value"]
+            if best_growth is None or delta > best_growth[0]:
+                best_growth = (delta, prev, latest)
+
+        if best_growth and best_growth[0] >= 0.01:
+            _delta, prev, latest = best_growth
+            insights.append(
+                f"Самый заметный рост пропусков: { _metric_label(latest['table_name'], latest['tags']) } "
+                f"с {_pct(prev['value'])} до {_pct(latest['value'])}."
+            )
+
+    return insights[:4]
+

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -349,7 +349,7 @@ def _iso(value: datetime | str) -> str:
 
 _PROBLEM_NULL_RATE = 0.10
 _CRITICAL_NULL_RATE = 0.30
-_ANOMALY_NULL_RATE_DELTA = 0.05
+_NULL_SPIKE_DELTA = 0.05
 
 
 def _safe_float(value: Any) -> float | None:
@@ -427,15 +427,16 @@ def _history_aggregate(window: timedelta | None = timedelta(days=30)) -> dict:
 
     A collector run is represented by a timestamp `ts`.
     Problems: null_rate >= 10%.
-    Anomalies: null_rate jump by >= 5 percentage points compared with the previous run
-    for the same table/column metric.
+    Null spikes: null_rate jump by >= 5 pp compared with the previous run
+    for the same table/column metric. Not to be confused with Isolation Forest
+    anomaly scores stored in the anomaly_scores table.
     Coverage: checked tables / known tables.
     """
     rows = _fetch_history_metric_rows(window=window)
 
     tables_by_ts: dict[str, set[str]] = {}
     problems_by_ts: dict[str, int] = {}
-    anomalies_by_ts: dict[str, int] = {}
+    null_spikes_by_ts: dict[str, int] = {}
     null_rates_by_identity: dict[tuple[str, str], list[tuple[str, float, str | None]]] = {}
     timestamps: set[str] = set()
     known_tables: set[str] = set()
@@ -465,8 +466,8 @@ def _history_aggregate(window: timedelta | None = timedelta(days=30)) -> dict:
     for values in null_rates_by_identity.values():
         previous: float | None = None
         for ts, value, _tags in sorted(values, key=lambda x: x[0]):
-            if previous is not None and (value - previous) >= _ANOMALY_NULL_RATE_DELTA:
-                anomalies_by_ts[ts] = anomalies_by_ts.get(ts, 0) + 1
+            if previous is not None and (value - previous) >= _NULL_SPIKE_DELTA:
+                null_spikes_by_ts[ts] = null_spikes_by_ts.get(ts, 0) + 1
             previous = value
 
     total_tables = len(known_tables)
@@ -477,14 +478,22 @@ def _history_aggregate(window: timedelta | None = timedelta(days=30)) -> dict:
         "timestamps": sorted_timestamps,
         "tables_by_ts": tables_by_ts,
         "problems_by_ts": problems_by_ts,
-        "anomalies_by_ts": anomalies_by_ts,
+        "null_spikes_by_ts": null_spikes_by_ts,
         "total_tables": total_tables,
     }
 
 
-def get_history_runs(limit: int = 10) -> list[dict]:
+def build_history_aggregate(window: timedelta = timedelta(days=30)) -> dict:
+    """Compute a single aggregate for the History page.
+
+    Call once per request and pass the result to get_history_runs,
+    get_history_daily, and get_history_insights to avoid repeated DB queries.
+    """
+    return _history_aggregate(window=window)
+
+
+def get_history_runs(agg: dict, limit: int = 10) -> list[dict]:
     """Return latest collector runs for the History page."""
-    agg = _history_aggregate(window=timedelta(days=30))
     timestamps = list(reversed(agg["timestamps"]))[:limit]
     total_tables = agg["total_tables"]
 
@@ -498,26 +507,28 @@ def get_history_runs(limit: int = 10) -> list[dict]:
                 "ts_label": _short_ts(ts),
                 "tables_checked": checked_tables,
                 "problems": agg["problems_by_ts"].get(ts, 0),
-                "anomalies": agg["anomalies_by_ts"].get(ts, 0),
+                "null_spikes": agg["null_spikes_by_ts"].get(ts, 0),
                 "coverage_pct": coverage_pct,
             }
         )
     return runs
 
 
-def get_history_daily(days: int = 14) -> list[dict]:
-    """Return daily trend for problems, anomalies and coverage.
+def get_history_daily(agg: dict, days: int = 14) -> list[dict]:
+    """Return daily trend for problems, null spikes and coverage.
 
-    For each day we use the latest collector run of that day, so the chart shows
-    end-of-day state rather than a raw count of all hourly/15-min checks.
+    For each day we use the latest collector run of that day. `days` limits
+    how many recent days are shown — filters the already-built aggregate,
+    so no extra DB query is needed.
     """
-    agg = _history_aggregate(window=timedelta(days=days))
     total_tables = agg["total_tables"]
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).date().isoformat()
     latest_ts_by_day: dict[str, str] = {}
 
     for ts in agg["timestamps"]:
         day = ts[:10]
-        latest_ts_by_day[day] = ts
+        if day >= cutoff:
+            latest_ts_by_day[day] = ts
 
     daily: list[dict] = []
     for day in sorted(latest_ts_by_day):
@@ -528,16 +539,15 @@ def get_history_daily(days: int = 14) -> list[dict]:
             {
                 "date": day,
                 "problems": agg["problems_by_ts"].get(ts, 0),
-                "anomalies": agg["anomalies_by_ts"].get(ts, 0),
+                "null_spikes": agg["null_spikes_by_ts"].get(ts, 0),
                 "coverage_pct": coverage_pct,
             }
         )
     return daily
 
 
-def get_history_insights() -> list[str]:
+def get_history_insights(agg: dict) -> list[str]:
     """Rule-based text conclusions for the History page."""
-    agg = _history_aggregate(window=timedelta(days=30))
     timestamps = agg["timestamps"]
     if not timestamps:
         return ["Исторические метрики пока не собраны. Запустите коллектор или сидер истории."]
@@ -573,7 +583,7 @@ def get_history_insights() -> list[str]:
         worst = max(latest_null_rates, key=lambda r: r["value"] or 0)
         if worst["value"] is not None and worst["value"] >= _PROBLEM_NULL_RATE:
             insights.append(
-                f"Таблица/поле { _metric_label(worst['table_name'], worst['tags']) } требует проверки: "
+                f"Таблица/поле {_metric_label(worst['table_name'], worst['tags'])} требует проверки: "
                 f"NULL rate сейчас {_pct(worst['value'])}."
             )
 
@@ -592,19 +602,19 @@ def get_history_insights() -> list[str]:
                 latest_by_key[key] = r
 
         best_growth = None
-        for key, latest in latest_by_key.items():
+        for key, latest_r in latest_by_key.items():
             prev = prev_by_key.get(key)
             if not prev:
                 continue
-            delta = latest["value"] - prev["value"]
+            delta = latest_r["value"] - prev["value"]
             if best_growth is None or delta > best_growth[0]:
-                best_growth = (delta, prev, latest)
+                best_growth = (delta, prev, latest_r)
 
         if best_growth and best_growth[0] >= 0.01:
-            _delta, prev, latest = best_growth
+            _delta, prev, latest_r = best_growth
             insights.append(
-                f"Самый заметный рост пропусков: { _metric_label(latest['table_name'], latest['tags']) } "
-                f"с {_pct(prev['value'])} до {_pct(latest['value'])}."
+                f"Самый заметный рост пропусков: {_metric_label(latest_r['table_name'], latest_r['tags'])} "
+                f"с {_pct(prev['value'])} до {_pct(latest_r['value'])}."
             )
 
     return insights[:4]

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -348,7 +348,6 @@ def _iso(value: datetime | str) -> str:
 # --- History page helpers (#41) ---
 
 _PROBLEM_NULL_RATE = 0.10
-_CRITICAL_NULL_RATE = 0.30
 _NULL_SPIKE_DELTA = 0.05
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -51,6 +51,7 @@
           {% set sections = [
             ("/dashboard", "Обзор", "M3 12 12 3l9 9M5 10v10h14V10", "exact"),
             ("/dashboard/schema", "Схема", "M4 7h16M4 12h16M4 17h10", "exact"),
+            ("/dashboard/history", "История", "M12 8v4l3 3M4 4h16M4 20h16", "exact"),
           ] %}
           {% for url, label, path, mode in sections %}
             {% set active = (request.path == url) %}

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,170 @@
+{% extends "base.html" %}
+
+{% block title %}История проверок — DB Monitor{% endblock %}
+
+{% block breadcrumb %}
+  <a href="/dashboard" class="hover:text-slate-700 dark:hover:text-slate-200">Главная</a>
+  <span>/</span>
+  <span>История</span>
+{% endblock %}
+
+{% block content %}
+<div class="space-y-6">
+  <div>
+    <h1 class="text-2xl font-semibold tracking-tight">История проверок</h1>
+    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+      Динамика запусков коллектора, проблем качества данных, аномалий и покрытия мониторингом.
+    </p>
+  </div>
+
+  <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="mb-4 flex items-center justify-between">
+      <div>
+        <h2 class="text-lg font-semibold">Ключевые выводы</h2>
+        <p class="text-sm text-slate-500 dark:text-slate-400">Rule-based выводы по последним метрикам из хранилища.</p>
+      </div>
+    </div>
+
+    {% if insights %}
+      <ul class="space-y-3">
+        {% for insight in insights %}
+          <li class="flex gap-3 rounded-lg bg-slate-50 px-4 py-3 text-sm dark:bg-slate-800/70">
+            <span class="mt-1 h-2 w-2 shrink-0 rounded-full bg-accent"></span>
+            <span>{{ insight }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <div class="rounded-lg bg-slate-50 px-4 py-6 text-center text-sm text-slate-500 dark:bg-slate-800/70 dark:text-slate-400">
+        Нет выводов: исторические метрики пока не собраны.
+      </div>
+    {% endif %}
+  </section>
+
+  <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="mb-4 flex items-center justify-between">
+      <div>
+        <h2 class="text-lg font-semibold">Динамика по дням</h2>
+        <p class="text-sm text-slate-500 dark:text-slate-400">Проблемы, аномалии и процент покрытия по последнему запуску каждого дня.</p>
+      </div>
+    </div>
+
+    {% if daily_history %}
+      <div id="history-chart" class="h-80 w-full"></div>
+    {% else %}
+      <div class="flex h-80 items-center justify-center rounded-lg bg-slate-50 text-sm text-slate-500 dark:bg-slate-800/70 dark:text-slate-400">
+        Нет исторических метрик для построения графика.
+      </div>
+    {% endif %}
+  </section>
+
+  <section class="rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+      <div>
+        <h2 class="text-lg font-semibold">Последние запуски коллектора</h2>
+        <p class="text-sm text-slate-500 dark:text-slate-400">Последние проверки, рассчитанные по данным из таблицы metrics.</p>
+      </div>
+      <span class="text-sm text-slate-500 dark:text-slate-400">{{ runs|length }} запусков</span>
+    </div>
+
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+        <thead class="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-800/80 dark:text-slate-400">
+          <tr>
+            <th class="px-5 py-3 font-medium">Запуск</th>
+            <th class="px-5 py-3 font-medium">Таблиц проверено</th>
+            <th class="px-5 py-3 font-medium">Проблем</th>
+            <th class="px-5 py-3 font-medium">Аномалий</th>
+            <th class="px-5 py-3 font-medium">Покрытие</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+          {% for run in runs %}
+            <tr class="hover:bg-slate-50 dark:hover:bg-slate-800/60">
+              <td class="whitespace-nowrap px-5 py-4 font-medium">{{ run.ts_label }}</td>
+              <td class="px-5 py-4">{{ run.tables_checked }}</td>
+              <td class="px-5 py-4">
+                <span class="rounded-full px-2 py-1 text-xs font-medium {% if run.problems > 0 %}bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200{% else %}bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200{% endif %}">
+                  {{ run.problems }}
+                </span>
+              </td>
+              <td class="px-5 py-4">
+                <span class="rounded-full px-2 py-1 text-xs font-medium {% if run.anomalies > 0 %}bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200{% else %}bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300{% endif %}">
+                  {{ run.anomalies }}
+                </span>
+              </td>
+              <td class="px-5 py-4">{{ "%.1f"|format(run.coverage_pct) }}%</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="5" class="px-5 py-8 text-center text-slate-500 dark:text-slate-400">
+                Нет запусков коллектора. Запустите сбор метрик или сидер истории.
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if daily_history %}
+    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+    <script>
+      const historyData = {{ daily_history|tojson }};
+      const dates = historyData.map((item) => item.date);
+
+      const traces = [
+        {
+          name: "Проблемы",
+          x: dates,
+          y: historyData.map((item) => item.problems),
+          type: "scatter",
+          mode: "lines+markers"
+        },
+        {
+          name: "Аномалии",
+          x: dates,
+          y: historyData.map((item) => item.anomalies),
+          type: "scatter",
+          mode: "lines+markers"
+        },
+        {
+          name: "Покрытие, %",
+          x: dates,
+          y: historyData.map((item) => item.coverage_pct),
+          type: "scatter",
+          mode: "lines+markers",
+          yaxis: "y2"
+        }
+      ];
+
+      const isDark = document.documentElement.classList.contains("dark");
+      const layout = {
+        margin: { t: 20, r: 50, b: 40, l: 40 },
+        paper_bgcolor: "rgba(0,0,0,0)",
+        plot_bgcolor: "rgba(0,0,0,0)",
+        font: { color: isDark ? "#e2e8f0" : "#334155" },
+        xaxis: { gridcolor: isDark ? "#1e293b" : "#e2e8f0" },
+        yaxis: {
+          title: "Проблемы / аномалии",
+          rangemode: "tozero",
+          gridcolor: isDark ? "#1e293b" : "#e2e8f0"
+        },
+        yaxis2: {
+          title: "Покрытие, %",
+          overlaying: "y",
+          side: "right",
+          range: [0, 105],
+          gridcolor: "rgba(0,0,0,0)"
+        },
+        legend: { orientation: "h", y: 1.12 }
+      };
+
+      Plotly.newPlot("history-chart", traces, layout, { displayModeBar: false, responsive: true });
+    </script>
+  {% endif %}
+{% endblock %}

--- a/templates/history.html
+++ b/templates/history.html
@@ -13,7 +13,7 @@
   <div>
     <h1 class="text-2xl font-semibold tracking-tight">История проверок</h1>
     <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
-      Динамика запусков коллектора, проблем качества данных, аномалий и покрытия мониторингом.
+      Динамика запусков коллектора, проблем качества данных, выбросов NULL и покрытия мониторингом.
     </p>
   </div>
 
@@ -45,7 +45,7 @@
     <div class="mb-4 flex items-center justify-between">
       <div>
         <h2 class="text-lg font-semibold">Динамика по дням</h2>
-        <p class="text-sm text-slate-500 dark:text-slate-400">Проблемы, аномалии и процент покрытия по последнему запуску каждого дня.</p>
+        <p class="text-sm text-slate-500 dark:text-slate-400">Проблемы, выбросы NULL и процент покрытия по последнему запуску каждого дня.</p>
       </div>
     </div>
 
@@ -74,7 +74,7 @@
             <th class="px-5 py-3 font-medium">Запуск</th>
             <th class="px-5 py-3 font-medium">Таблиц проверено</th>
             <th class="px-5 py-3 font-medium">Проблем</th>
-            <th class="px-5 py-3 font-medium">Аномалий</th>
+            <th class="px-5 py-3 font-medium">Выбросы NULL</th>
             <th class="px-5 py-3 font-medium">Покрытие</th>
           </tr>
         </thead>
@@ -89,8 +89,8 @@
                 </span>
               </td>
               <td class="px-5 py-4">
-                <span class="rounded-full px-2 py-1 text-xs font-medium {% if run.anomalies > 0 %}bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200{% else %}bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300{% endif %}">
-                  {{ run.anomalies }}
+                <span class="rounded-full px-2 py-1 text-xs font-medium {% if run.null_spikes > 0 %}bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200{% else %}bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300{% endif %}">
+                  {{ run.null_spikes }}
                 </span>
               </td>
               <td class="px-5 py-4">{{ "%.1f"|format(run.coverage_pct) }}%</td>
@@ -126,9 +126,9 @@
           mode: "lines+markers"
         },
         {
-          name: "Аномалии",
+          name: "Выбросы NULL",
           x: dates,
-          y: historyData.map((item) => item.anomalies),
+          y: historyData.map((item) => item.null_spikes),
           type: "scatter",
           mode: "lines+markers"
         },
@@ -142,29 +142,36 @@
         }
       ];
 
-      const isDark = document.documentElement.classList.contains("dark");
-      const layout = {
-        margin: { t: 20, r: 50, b: 40, l: 40 },
-        paper_bgcolor: "rgba(0,0,0,0)",
-        plot_bgcolor: "rgba(0,0,0,0)",
-        font: { color: isDark ? "#e2e8f0" : "#334155" },
-        xaxis: { gridcolor: isDark ? "#1e293b" : "#e2e8f0" },
-        yaxis: {
-          title: "Проблемы / аномалии",
-          rangemode: "tozero",
-          gridcolor: isDark ? "#1e293b" : "#e2e8f0"
-        },
-        yaxis2: {
-          title: "Покрытие, %",
-          overlaying: "y",
-          side: "right",
-          range: [0, 105],
-          gridcolor: "rgba(0,0,0,0)"
-        },
-        legend: { orientation: "h", y: 1.12 }
-      };
+      function buildLayout(dark) {
+        return {
+          margin: { t: 20, r: 50, b: 40, l: 40 },
+          paper_bgcolor: "rgba(0,0,0,0)",
+          plot_bgcolor: "rgba(0,0,0,0)",
+          font: { color: dark ? "#e2e8f0" : "#334155" },
+          xaxis: { gridcolor: dark ? "#1e293b" : "#e2e8f0" },
+          yaxis: {
+            title: "Проблемы / выбросы NULL",
+            rangemode: "tozero",
+            gridcolor: dark ? "#1e293b" : "#e2e8f0"
+          },
+          yaxis2: {
+            title: "Покрытие, %",
+            overlaying: "y",
+            side: "right",
+            range: [0, 105],
+            gridcolor: "rgba(0,0,0,0)"
+          },
+          legend: { orientation: "h", y: 1.12 }
+        };
+      }
 
-      Plotly.newPlot("history-chart", traces, layout, { displayModeBar: false, responsive: true });
+      const isDark = document.documentElement.classList.contains("dark");
+      Plotly.newPlot("history-chart", traces, buildLayout(isDark), { displayModeBar: false, responsive: true });
+
+      new MutationObserver(() => {
+        const dark = document.documentElement.classList.contains("dark");
+        Plotly.relayout("history-chart", buildLayout(dark));
+      }).observe(document.documentElement, { attributeFilter: ["class"] });
     </script>
   {% endif %}
 {% endblock %}

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -54,8 +54,6 @@ def test_aggregate_detects_null_spikes(storage):
         {"ts": t1, "table": "orders", "metric": "null_rate", "value": 0.20},
     ])
     agg = storage.build_history_aggregate(window=timedelta(days=30))
-    ts1_str = t1.isoformat(timespec="seconds").replace("+00:00", "+00:00")
-    # t1 should be flagged as a null spike
     spike_ts = [ts for ts in agg["null_spikes_by_ts"] if agg["null_spikes_by_ts"][ts] > 0]
     assert len(spike_ts) == 1
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,185 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    """Fresh storage backed by a temporary SQLite file per test."""
+    db_path = tmp_path / "metrics.db"
+    import app.metrics_storage as storage_mod
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    return storage_mod
+
+
+def _ts(offset_hours: int = 0) -> datetime:
+    base = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+    return base + timedelta(hours=offset_hours)
+
+
+def _seed(storage, rows):
+    storage.save_metrics([
+        {"ts": r["ts"], "table_name": r["table"], "metric_name": r["metric"], "value": r["value"], "tags": r.get("tags")}
+        for r in rows
+    ])
+
+
+# ---------------------------------------------------------------------------
+# build_history_aggregate
+# ---------------------------------------------------------------------------
+
+def test_aggregate_empty_returns_empty_structure(storage):
+    agg = storage.build_history_aggregate()
+    assert agg["timestamps"] == []
+    assert agg["total_tables"] == 0
+    assert agg["rows"] == []
+
+
+def test_aggregate_counts_known_tables(storage):
+    _seed(storage, [
+        {"ts": _ts(0), "table": "users",  "metric": "row_count", "value": 100},
+        {"ts": _ts(0), "table": "orders", "metric": "row_count", "value": 200},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    assert agg["total_tables"] == 2
+
+
+def test_aggregate_detects_null_spikes(storage):
+    """null_rate jump of >=5 pp between two ticks must appear in null_spikes_by_ts."""
+    t0, t1 = _ts(0), _ts(1)
+    _seed(storage, [
+        {"ts": t0, "table": "orders", "metric": "null_rate", "value": 0.02},
+        {"ts": t1, "table": "orders", "metric": "null_rate", "value": 0.20},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    ts1_str = t1.isoformat(timespec="seconds").replace("+00:00", "+00:00")
+    # t1 should be flagged as a null spike
+    spike_ts = [ts for ts in agg["null_spikes_by_ts"] if agg["null_spikes_by_ts"][ts] > 0]
+    assert len(spike_ts) == 1
+
+
+def test_aggregate_no_spike_for_small_delta(storage):
+    t0, t1 = _ts(0), _ts(1)
+    _seed(storage, [
+        {"ts": t0, "table": "orders", "metric": "null_rate", "value": 0.02},
+        {"ts": t1, "table": "orders", "metric": "null_rate", "value": 0.03},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    assert sum(agg["null_spikes_by_ts"].values()) == 0
+
+
+# ---------------------------------------------------------------------------
+# get_history_runs
+# ---------------------------------------------------------------------------
+
+def test_get_history_runs_returns_correct_fields(storage):
+    _seed(storage, [
+        {"ts": _ts(0), "table": "users",  "metric": "row_count", "value": 100},
+        {"ts": _ts(0), "table": "orders", "metric": "row_count", "value": 200},
+        {"ts": _ts(0), "table": "orders", "metric": "null_rate",  "value": 0.02},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    runs = storage.get_history_runs(agg, limit=10)
+    assert len(runs) == 1
+    run = runs[0]
+    assert "ts_label" in run
+    assert "tables_checked" in run
+    assert "problems" in run
+    assert "null_spikes" in run
+    assert "coverage_pct" in run
+    assert run["tables_checked"] == 2
+    assert run["coverage_pct"] == 100.0
+
+
+def test_get_history_runs_limit(storage):
+    for h in range(5):
+        _seed(storage, [{"ts": _ts(h), "table": "users", "metric": "row_count", "value": 100 + h}])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    runs = storage.get_history_runs(agg, limit=3)
+    assert len(runs) == 3
+
+
+def test_get_history_runs_problems_counted(storage):
+    _seed(storage, [
+        {"ts": _ts(0), "table": "orders", "metric": "row_count", "value": 500},
+        {"ts": _ts(0), "table": "orders", "metric": "null_rate",  "value": 0.15},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    runs = storage.get_history_runs(agg)
+    assert runs[0]["problems"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_history_daily
+# ---------------------------------------------------------------------------
+
+def test_get_history_daily_returns_one_entry_per_day(storage):
+    # Two ticks on the same day — only the latest should appear
+    _seed(storage, [
+        {"ts": _ts(0), "table": "users", "metric": "row_count", "value": 100},
+        {"ts": _ts(1), "table": "users", "metric": "row_count", "value": 110},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    daily = storage.get_history_daily(agg, days=30)
+    assert len(daily) == 1
+    assert daily[0]["date"] == _ts(0).date().isoformat()
+
+
+def test_get_history_daily_filters_by_days(storage):
+    # Two entries on different days: one 20 days ago, one 3 days ago (relative to seed base)
+    old_ts = datetime.now(timezone.utc) - timedelta(days=20)
+    new_ts = datetime.now(timezone.utc) - timedelta(days=3)
+    storage.save_metrics([
+        {"ts": old_ts, "table_name": "users", "metric_name": "row_count", "value": 50, "tags": None},
+        {"ts": new_ts, "table_name": "users", "metric_name": "row_count", "value": 60, "tags": None},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    daily_7 = storage.get_history_daily(agg, days=7)
+    daily_30 = storage.get_history_daily(agg, days=30)
+    assert len(daily_7) == 1
+    assert len(daily_30) == 2
+
+
+# ---------------------------------------------------------------------------
+# get_history_insights
+# ---------------------------------------------------------------------------
+
+def test_get_history_insights_empty(storage):
+    agg = storage.build_history_aggregate()
+    insights = storage.get_history_insights(agg)
+    assert len(insights) == 1
+    assert "не собраны" in insights[0]
+
+
+def test_get_history_insights_returns_coverage(storage):
+    _seed(storage, [
+        {"ts": _ts(0), "table": "users",  "metric": "row_count", "value": 100},
+        {"ts": _ts(0), "table": "orders", "metric": "row_count", "value": 200},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    insights = storage.get_history_insights(agg)
+    assert any("Покрытие" in i for i in insights)
+
+
+def test_get_history_insights_flags_high_null_rate(storage):
+    _seed(storage, [
+        {"ts": _ts(0), "table": "orders", "metric": "row_count", "value": 500},
+        {"ts": _ts(0), "table": "orders", "metric": "null_rate",  "value": 0.25},
+    ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    insights = storage.get_history_insights(agg)
+    assert any("требует проверки" in i for i in insights)
+
+
+def test_get_history_insights_max_four(storage):
+    for h in range(3):
+        _seed(storage, [
+            {"ts": _ts(h),     "table": "a", "metric": "row_count", "value": 100},
+            {"ts": _ts(h),     "table": "a", "metric": "null_rate",  "value": 0.20 + h * 0.10},
+            {"ts": _ts(h),     "table": "b", "metric": "null_rate",  "value": 0.01},
+        ])
+    agg = storage.build_history_aggregate(window=timedelta(days=30))
+    insights = storage.get_history_insights(agg)
+    assert len(insights) <= 4


### PR DESCRIPTION
Реализована страница «История проверок» для Sprint 2 #41.

Что сделано:
- добавлен route /dashboard/history;
- добавлен пункт «История» в sidebar;
- создан templates/history.html;
- добавлена таблица последних запусков коллектора;
- добавлен график динамики по дням: проблемы, аномалии, покрытие;
- добавлены rule-based выводы по данным из metrics.