### PR TITLE
feat(llm): Sprint 2 — LLM root-cause через NVIDIA NIM (#36)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -5,16 +5,19 @@ from flask import Blueprint, jsonify, request
 from .db import list_tables, table_schema
 from .metrics_storage import (
     get_anomaly_scores,
+    get_cached_explanation,
     get_changepoints,
     get_latest_metric,
     get_metrics,
     get_schema_events,
+    save_explanation,
 )
 
 api = Blueprint("api", __name__, url_prefix="/api")
 
 _VALID_METRICS = {"row_count", "null_rate", "null_count", "size_bytes", "last_modified"}
 _FORECAST_METRICS = {"row_count", "size_bytes"}
+_EXPLAIN_METRICS = {"row_count", "null_rate"}
 _RANGES = {
     "1h": timedelta(hours=1),
     "6h": timedelta(hours=6),
@@ -153,6 +156,48 @@ def anomalies(table_name: str):
     if range_str not in _RANGES:
         return jsonify({"error": f"range must be one of {sorted(_RANGES)}"}), 400
     return jsonify(get_anomaly_scores(table_name, window=_RANGES[range_str]))
+
+
+@api.route("/explain", methods=["POST"])
+def explain():
+    """LLM root-cause explanation for an anomaly point.
+
+    Body (JSON): {table, metric, ts}
+    Returns: {explanation, suggested_fix, confidence}
+
+    Checks the 24 h cache before calling NIM. On NIM failure, falls back
+    to a rule-based explanation (confidence=0.3).
+    """
+    from .llm import explain_anomaly
+
+    body = request.get_json(silent=True) or {}
+    table = body.get("table", "").strip()
+    metric = body.get("metric", "").strip()
+    ts = body.get("ts", "").strip()
+
+    if not table or not metric or not ts:
+        return jsonify({"error": "table, metric and ts are required"}), 400
+    if metric not in _EXPLAIN_METRICS:
+        return jsonify({"error": f"metric must be one of {sorted(_EXPLAIN_METRICS)}"}), 400
+
+    cached = get_cached_explanation(table, metric, ts)
+    if cached:
+        return jsonify(cached)
+
+    known_tables = {t["table_name"] for t in list_tables()}
+    if table not in known_tables:
+        return jsonify({"error": "table not found"}), 404
+
+    result = explain_anomaly(table, metric, ts)
+    save_explanation(
+        table=table,
+        metric=metric,
+        ts=ts,
+        explanation=result["explanation"],
+        suggested_fix=result["suggested_fix"],
+        confidence=result["confidence"],
+    )
+    return jsonify(result)
 
 
 @api.route("/schema/<table_name>/changes")

--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,11 @@ class Settings(BaseSettings):
     # Режим Flask
     FLASK_ENV: str = "development"
 
+    # NVIDIA NIM LLM
+    NIM_API_KEY: str = ""
+    NIM_BASE_URL: str = "https://integrate.api.nvidia.com/v1"
+    NIM_MODEL: str = "nvidia/llama-3.3-nemotron-super-49b-instruct"
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,0 +1,252 @@
+"""LLM root-cause explanation via NVIDIA NIM (#36).
+
+explain_anomaly(table, metric, ts) is the public entry point.
+It checks the cache first, calls NIM if needed, falls back to rule-based
+explanations when NIM is unavailable.
+"""
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+
+import httpx
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from app.config import settings
+from app.metrics_storage import (
+    get_anomaly_scores,
+    get_changepoints,
+    get_metrics,
+    get_schema_snapshot,
+)
+
+
+def _context_window(ts: str) -> timedelta:
+    """Return a timedelta that covers `ts` plus a 2-hour buffer from now."""
+    try:
+        ts_dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        if ts_dt.tzinfo is None:
+            ts_dt = ts_dt.replace(tzinfo=timezone.utc)
+        age = datetime.now(timezone.utc) - ts_dt
+        return max(timedelta(hours=48), age + timedelta(hours=2))
+    except (ValueError, TypeError):
+        return timedelta(hours=48)
+
+
+def _build_prompt(table: str, metric: str, ts: str) -> str:
+    schema = get_schema_snapshot(table) or []
+    schema_text = ", ".join(
+        f"{c['name']} {c['type']}{'?' if c.get('nullable') else ''}"
+        for c in schema
+    ) or "unknown"
+
+    window = _context_window(ts)
+    recent_rc = get_metrics(table, "row_count", window=window)
+    recent_nr = get_metrics(table, "null_rate", window=window)
+    changepoints = get_changepoints(table, window=max(timedelta(days=14), window))
+    anomaly_scores = get_anomaly_scores(table, window=window)
+
+    # Limit context to rows at or before ts so the LLM sees the state
+    # at the moment of the anomaly, not current state.
+    recent_rc = [r for r in recent_rc if r["ts"] <= ts]
+    recent_nr = [r for r in recent_nr if r["ts"] <= ts]
+
+    rc_sample = [
+        f"{r['ts']}: {int(r['value'])}" for r in recent_rc[-10:]
+    ]
+    nr_sample = [
+        f"{r['ts']}: {r['value']:.3f}" for r in recent_nr[-10:]
+    ]
+    cp_text = "\n".join(
+        f"  {c['ts']} {c['metric_name']}: {c['value_before']:.2f} → {c['value_after']:.2f}"
+        for c in changepoints
+    ) or "  none"
+    anomaly_at_ts = next(
+        (a for a in anomaly_scores if a["ts"] == ts and a["is_anomaly"]), None
+    )
+    anomaly_score_text = (
+        f"{anomaly_at_ts['score']:.4f}" if anomaly_at_ts else "not available"
+    )
+
+    return f"""You are a database reliability expert. Analyze the anomaly below and explain its root cause.
+
+Table: {table}
+Schema: {schema_text}
+Anomaly detected at: {ts}
+Trigger metric: {metric}
+Isolation Forest score at {ts}: {anomaly_score_text}
+
+Recent row_count (last 48 h):
+{chr(10).join(rc_sample) or "  no data"}
+
+Recent null_rate (last 48 h):
+{chr(10).join(nr_sample) or "  no data"}
+
+Recent change-points (last 14 days):
+{cp_text}
+
+Based on this context, provide a root-cause explanation.
+Respond ONLY with valid JSON (no markdown, no extra text):
+{{"explanation": "...", "suggested_fix": "...", "confidence": 0.85}}
+
+Respond in Russian."""
+
+
+@retry(
+    retry=retry_if_exception_type(httpx.RequestError),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
+)
+def _call_nim(prompt: str) -> str:
+    """Call NIM /chat/completions. Retries only on network errors, not 4xx/5xx."""
+    url = settings.NIM_BASE_URL.rstrip("/") + "/chat/completions"
+    payload = {
+        "model": settings.NIM_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.2,
+        "max_tokens": 512,
+    }
+    with httpx.Client(timeout=httpx.Timeout(60.0)) as client:
+        resp = client.post(
+            url,
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {settings.NIM_API_KEY}",
+                "Content-Type": "application/json",
+            },
+        )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["choices"][0]["message"]["content"]
+
+
+def _parse_nim_response(raw: str) -> dict:
+    """Parse LLM output → {explanation, suggested_fix, confidence}.
+
+    Handles clean JSON and JSON wrapped in markdown code fences.
+    Falls back to None if parsing fails entirely (caller must handle).
+    """
+    text = raw.strip()
+
+    # Strip markdown code fence if present
+    text = re.sub(r"^```(?:json)?\s*", "", text)
+    text = re.sub(r"\s*```$", "", text)
+    text = text.strip()
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        # Try to extract first JSON object from the string
+        m = re.search(r"\{.*\}", text, re.DOTALL)
+        if not m:
+            return {}
+        try:
+            parsed = json.loads(m.group())
+        except json.JSONDecodeError:
+            return {}
+
+    explanation = str(parsed.get("explanation") or "").strip()
+    suggested_fix = str(parsed.get("suggested_fix") or "").strip()
+    raw_conf = parsed.get("confidence", 0.5)
+    try:
+        confidence = max(0.0, min(1.0, float(raw_conf)))
+    except (TypeError, ValueError):
+        confidence = 0.5
+
+    if not explanation:
+        return {}
+
+    return {
+        "explanation": explanation,
+        "suggested_fix": suggested_fix,
+        "confidence": confidence,
+    }
+
+
+def _rule_based_explain(table: str, metric: str, ts: str) -> dict:
+    """Template fallback when NIM is unavailable. confidence=0.3."""
+    window = _context_window(ts)
+    all_rc = get_metrics(table, "row_count", window=window)
+    all_nr = get_metrics(table, "null_rate", window=window)
+
+    # Use only rows up to and including ts so the comparison reflects
+    # conditions at the moment of the anomaly, not current state.
+    recent_rc = [r for r in all_rc if r["ts"] <= ts]
+    recent_nr = [r for r in all_nr if r["ts"] <= ts]
+
+    if metric == "row_count" and len(recent_rc) >= 2:
+        prev_val = recent_rc[-2]["value"]
+        curr_val = recent_rc[-1]["value"]
+        if curr_val < prev_val * 0.5:
+            return {
+                "explanation": (
+                    f"Резкое снижение количества строк в таблице {table}: "
+                    f"с {int(prev_val)} до {int(curr_val)}. "
+                    "Возможные причины: удаление данных, усечение таблицы или сбой ETL-процесса."
+                ),
+                "suggested_fix": (
+                    "Проверьте логи ETL-пайплайна и историю изменений. "
+                    "Убедитесь, что плановые удаления не затронули лишние данные."
+                ),
+                "confidence": 0.3,
+            }
+        if curr_val > prev_val * 2:
+            return {
+                "explanation": (
+                    f"Аномальный рост количества строк в таблице {table}: "
+                    f"с {int(prev_val)} до {int(curr_val)}. "
+                    "Возможные причины: дублирование вставок, повторный запуск импорта."
+                ),
+                "suggested_fix": (
+                    "Проверьте уникальные ограничения. "
+                    "Убедитесь, что задача импорта не запустилась дважды."
+                ),
+                "confidence": 0.3,
+            }
+
+    if metric == "null_rate" and recent_nr:
+        curr_nr = recent_nr[-1]["value"]
+        if curr_nr >= 0.2:
+            return {
+                "explanation": (
+                    f"Высокий уровень NULL в таблице {table}: {curr_nr:.1%}. "
+                    "Возможные причины: сбой в заполнении обязательных полей, "
+                    "изменение схемы или ошибка трансформации."
+                ),
+                "suggested_fix": (
+                    "Проверьте ETL-пайплайн и логи последней загрузки. "
+                    "Убедитесь, что все обязательные поля заполнены корректно."
+                ),
+                "confidence": 0.3,
+            }
+
+    return {
+        "explanation": (
+            f"Обнаружена аномалия в таблице {table} по метрике {metric} в момент {ts}. "
+            "Требуется ручная проверка данных."
+        ),
+        "suggested_fix": "Проверьте последние изменения в данных и ETL-процессах.",
+        "confidence": 0.3,
+    }
+
+
+def explain_anomaly(table: str, metric: str, ts: str) -> dict:
+    """Orchestrate LLM explanation with cache bypass (cache handled in the API layer).
+
+    Returns {explanation, suggested_fix, confidence}.
+    Never raises — falls back to rule-based on any NIM failure.
+    """
+    if not settings.NIM_API_KEY:
+        return _rule_based_explain(table, metric, ts)
+
+    try:
+        prompt = _build_prompt(table, metric, ts)
+        raw = _call_nim(prompt)
+        parsed = _parse_nim_response(raw)
+        if parsed:
+            return parsed
+        # JSON parsing failed — use rule-based
+        return _rule_based_explain(table, metric, ts)
+    except Exception:
+        return _rule_based_explain(table, metric, ts)

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -618,3 +618,58 @@ def get_history_insights(agg: dict) -> list[str]:
 
     return insights[:4]
 
+
+# --- LLM explanation cache (#36) ---
+
+def get_cached_explanation(
+    table: str, metric: str, ts: str, ttl_hours: int = 24
+) -> dict | None:
+    """Return a cached LLM explanation if it exists and is within TTL, else None."""
+    stmt = text("""
+        SELECT explanation, suggested_fix, confidence, created_at
+        FROM llm_explanations
+        WHERE table_name = :table AND metric = :metric AND ts = :ts
+        LIMIT 1
+    """)
+    with get_engine().connect() as conn:
+        row = conn.execute(stmt, {"table": table, "metric": metric, "ts": ts}).fetchone()
+    if not row:
+        return None
+    created_at = datetime.fromisoformat(row[3].replace("Z", "+00:00"))
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    age = datetime.now(timezone.utc) - created_at
+    if age.total_seconds() > ttl_hours * 3600:
+        return None
+    return {
+        "explanation": row[0],
+        "suggested_fix": row[1],
+        "confidence": row[2],
+    }
+
+
+def save_explanation(
+    table: str,
+    metric: str,
+    ts: str,
+    explanation: str,
+    suggested_fix: str,
+    confidence: float,
+) -> None:
+    """Upsert an LLM explanation into the cache."""
+    stmt = text("""
+        INSERT OR REPLACE INTO llm_explanations
+            (table_name, metric, ts, explanation, suggested_fix, confidence, created_at)
+        VALUES (:table, :metric, :ts, :explanation, :suggested_fix, :confidence, :created_at)
+    """)
+    with get_engine().begin() as conn:
+        conn.execute(stmt, {
+            "table": table,
+            "metric": metric,
+            "ts": ts,
+            "explanation": explanation,
+            "suggested_fix": suggested_fix,
+            "confidence": float(confidence),
+            "created_at": _iso(datetime.now(timezone.utc)),
+        })
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzlocal==5.3.1
 Werkzeug==3.1.8
+httpx==0.28.1
+tenacity==9.1.2

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -64,3 +64,16 @@ CREATE TABLE IF NOT EXISTS anomaly_scores (
 
 CREATE INDEX IF NOT EXISTS idx_anomaly_scores_table_ts
     ON anomaly_scores (table_name, ts);
+
+-- LLM-generated root-cause explanations — cached to avoid repeated NIM calls.
+-- TTL is 24 h, checked at read time via created_at.
+CREATE TABLE IF NOT EXISTS llm_explanations (
+    table_name    TEXT NOT NULL,
+    metric        TEXT NOT NULL,
+    ts            TEXT NOT NULL,
+    explanation   TEXT NOT NULL,
+    suggested_fix TEXT NOT NULL,
+    confidence    REAL NOT NULL,
+    created_at    TEXT NOT NULL,
+    PRIMARY KEY (table_name, metric, ts)
+);

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -87,6 +87,40 @@
     </section>
   </div>
 
+  <div id="explain-panel" class="mt-8 hidden rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <p class="text-sm font-medium text-slate-700 dark:text-slate-200">
+          Аномалия: <span id="explain-ts" class="font-mono text-slate-500 dark:text-slate-400"></span>
+        </p>
+        <p class="mt-0.5 text-xs text-slate-500 dark:text-slate-400">Нажмите кнопку, чтобы получить объяснение от LLM.</p>
+      </div>
+      <button id="explain-btn"
+        class="shrink-0 inline-flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed">
+        Объяснить аномалию
+      </button>
+    </div>
+    <p id="explain-spinner" class="hidden mt-4 text-sm text-slate-500 dark:text-slate-400">Анализирую...</p>
+    <p id="explain-error" class="hidden mt-4 text-sm text-red-500 dark:text-red-400"></p>
+    <div id="explain-result" class="hidden mt-4 space-y-3">
+      <div>
+        <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Причина</p>
+        <p id="explain-text" class="mt-1 text-sm text-slate-700 dark:text-slate-200"></p>
+      </div>
+      <div>
+        <p class="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Рекомендация</p>
+        <p id="explain-fix" class="mt-1 text-sm text-slate-700 dark:text-slate-200"></p>
+      </div>
+      <div class="flex items-center gap-2">
+        <p class="text-xs text-slate-500 dark:text-slate-400">Уверенность</p>
+        <div class="h-2 w-24 rounded-full bg-slate-200 dark:bg-slate-700">
+          <div id="explain-confidence-bar" class="h-2 rounded-full bg-accent transition-all" style="width:0%"></div>
+        </div>
+        <span id="explain-confidence-label" class="text-xs tabular-nums text-slate-600 dark:text-slate-300"></span>
+      </div>
+    </div>
+  </div>
+
   <section class="mt-8 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
     <div class="flex items-center justify-between">
       <h2 class="text-base font-semibold">Drift (vs baseline 7 дн.)</h2>
@@ -264,7 +298,63 @@
           { ...layout, shapes, annotations, showlegend: traces.length > 1 },
           { displayModeBar: false, responsive: true },
         );
+        document.getElementById("chart").on("plotly_click", handleAnomalyClick);
       }
+
+      // ---- Anomaly explain panel ------------------------------------------
+      let _explainTs = null;
+      let _explainMetric = null;
+
+      function handleAnomalyClick(evtData) {
+        const pt = evtData.points[0];
+        if (pt.data.name !== "Аномалия") return;
+        _explainTs = pt.x;
+        _explainMetric = currentMetric;
+        document.getElementById("explain-ts").textContent =
+          pt.x.replace("T", " ").slice(0, 16) + " UTC";
+        document.getElementById("explain-panel").classList.remove("hidden");
+        document.getElementById("explain-result").classList.add("hidden");
+        document.getElementById("explain-error").classList.add("hidden");
+        document.getElementById("explain-spinner").classList.add("hidden");
+      }
+
+      document.getElementById("explain-btn").addEventListener("click", async () => {
+        if (!_explainTs) return;
+        const btn = document.getElementById("explain-btn");
+        const spinner = document.getElementById("explain-spinner");
+        const resultEl = document.getElementById("explain-result");
+        const errorEl = document.getElementById("explain-error");
+        btn.disabled = true;
+        spinner.classList.remove("hidden");
+        resultEl.classList.add("hidden");
+        errorEl.classList.add("hidden");
+        try {
+          const resp = await fetch("/api/explain", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ table: tableName, metric: _explainMetric, ts: _explainTs }),
+          });
+          const body = await resp.json();
+          if (!resp.ok) {
+            errorEl.textContent = body.error || "Ошибка при получении объяснения.";
+            errorEl.classList.remove("hidden");
+            return;
+          }
+          document.getElementById("explain-text").textContent = body.explanation;
+          document.getElementById("explain-fix").textContent = body.suggested_fix || "—";
+          const pct = Math.round((body.confidence || 0) * 100);
+          document.getElementById("explain-confidence-bar").style.width = pct + "%";
+          document.getElementById("explain-confidence-label").textContent = pct + "%";
+          resultEl.classList.remove("hidden");
+        } catch {
+          errorEl.textContent = "Сетевая ошибка. Попробуйте ещё раз.";
+          errorEl.classList.remove("hidden");
+        } finally {
+          spinner.classList.add("hidden");
+          btn.disabled = false;
+        }
+      });
+
       plot(currentMetric);
 
       // ---- Drift section --------------------------------------------------

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,250 @@
+"""Tests for app/llm.py and POST /api/explain."""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app import llm as llm_mod
+from app.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts() -> str:
+    return datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc).isoformat(timespec="seconds")
+
+
+# ---------------------------------------------------------------------------
+# _build_prompt
+# ---------------------------------------------------------------------------
+
+def test_build_prompt_contains_table_and_ts(tmp_path, monkeypatch):
+    monkeypatch.setattr("app.llm.get_schema_snapshot", lambda t: [{"name": "id", "type": "int", "nullable": False}])
+    monkeypatch.setattr("app.llm.get_metrics", lambda t, m, **kw: [])
+    monkeypatch.setattr("app.llm.get_changepoints", lambda t, **kw: [])
+    monkeypatch.setattr("app.llm.get_anomaly_scores", lambda t, **kw: [])
+
+    ts = _ts()
+    prompt = llm_mod._build_prompt("orders", "row_count", ts)
+    assert "orders" in prompt
+    assert ts in prompt
+    assert "row_count" in prompt
+    assert "id int" in prompt
+    assert "Respond in Russian" in prompt
+
+
+def test_build_prompt_includes_both_metrics(tmp_path, monkeypatch):
+    """Prompt must include context for both row_count and null_rate regardless of `metric`."""
+    monkeypatch.setattr("app.llm.get_schema_snapshot", lambda t: None)
+    rc_rows = [{"ts": _ts(), "value": 500.0, "tags": None}]
+    nr_rows = [{"ts": _ts(), "value": 0.15, "tags": None}]
+    def _fake_metrics(table, metric, **kw):
+        return rc_rows if metric == "row_count" else nr_rows
+    monkeypatch.setattr("app.llm.get_metrics", _fake_metrics)
+    monkeypatch.setattr("app.llm.get_changepoints", lambda t, **kw: [])
+    monkeypatch.setattr("app.llm.get_anomaly_scores", lambda t, **kw: [])
+
+    prompt = llm_mod._build_prompt("orders", "null_rate", _ts())
+    assert "500" in prompt
+    assert "0.150" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _parse_nim_response
+# ---------------------------------------------------------------------------
+
+def test_parse_nim_response_clean_json():
+    raw = '{"explanation": "ETL failed", "suggested_fix": "Rerun", "confidence": 0.9}'
+    result = llm_mod._parse_nim_response(raw)
+    assert result["explanation"] == "ETL failed"
+    assert result["suggested_fix"] == "Rerun"
+    assert result["confidence"] == pytest.approx(0.9)
+
+
+def test_parse_nim_response_markdown_fence():
+    raw = '```json\n{"explanation": "foo", "suggested_fix": "bar", "confidence": 0.7}\n```'
+    result = llm_mod._parse_nim_response(raw)
+    assert result["explanation"] == "foo"
+
+
+def test_parse_nim_response_json_embedded_in_text():
+    raw = 'Here is the analysis:\n{"explanation": "baz", "suggested_fix": "fix", "confidence": 0.5}\nDone.'
+    result = llm_mod._parse_nim_response(raw)
+    assert result["explanation"] == "baz"
+
+
+def test_parse_nim_response_clamps_confidence():
+    raw = '{"explanation": "x", "suggested_fix": "y", "confidence": 1.5}'
+    result = llm_mod._parse_nim_response(raw)
+    assert result["confidence"] == 1.0
+
+    raw2 = '{"explanation": "x", "suggested_fix": "y", "confidence": -0.2}'
+    result2 = llm_mod._parse_nim_response(raw2)
+    assert result2["confidence"] == 0.0
+
+
+def test_parse_nim_response_invalid_returns_empty():
+    assert llm_mod._parse_nim_response("not json at all") == {}
+    assert llm_mod._parse_nim_response("") == {}
+
+
+# ---------------------------------------------------------------------------
+# _rule_based_explain
+# ---------------------------------------------------------------------------
+
+def test_rule_based_explain_returns_correct_structure(monkeypatch):
+    monkeypatch.setattr("app.llm.get_metrics", lambda t, m, **kw: [])
+    result = llm_mod._rule_based_explain("orders", "row_count", _ts())
+    assert "explanation" in result
+    assert "suggested_fix" in result
+    assert result["confidence"] == pytest.approx(0.3)
+
+
+def test_rule_based_explain_row_drop(monkeypatch):
+    rows = [
+        {"ts": "2026-04-20T11:00:00+00:00", "value": 1000.0, "tags": None},
+        {"ts": "2026-04-20T12:00:00+00:00", "value": 200.0, "tags": None},
+    ]
+    def _fake_metrics(table, metric, **kw):
+        return rows if metric == "row_count" else []
+    monkeypatch.setattr("app.llm.get_metrics", _fake_metrics)
+    result = llm_mod._rule_based_explain("orders", "row_count", _ts())
+    assert "снижение" in result["explanation"].lower() or "удален" in result["explanation"].lower()
+
+
+def test_rule_based_explain_high_null_rate(monkeypatch):
+    nr_rows = [{"ts": _ts(), "value": 0.35, "tags": None}]
+    def _fake_metrics(table, metric, **kw):
+        return [] if metric == "row_count" else nr_rows
+    monkeypatch.setattr("app.llm.get_metrics", _fake_metrics)
+    result = llm_mod._rule_based_explain("orders", "null_rate", _ts())
+    assert "null" in result["explanation"].lower() or "пропуск" in result["explanation"].lower()
+
+
+# ---------------------------------------------------------------------------
+# explain_anomaly — fallback on network error
+# ---------------------------------------------------------------------------
+
+def test_explain_anomaly_falls_back_on_network_error(monkeypatch):
+    monkeypatch.setattr("app.config.settings.NIM_API_KEY", "test-key")
+    monkeypatch.setattr("app.llm.get_schema_snapshot", lambda t: None)
+    monkeypatch.setattr("app.llm.get_metrics", lambda t, m, **kw: [])
+    monkeypatch.setattr("app.llm.get_changepoints", lambda t, **kw: [])
+    monkeypatch.setattr("app.llm.get_anomaly_scores", lambda t, **kw: [])
+    monkeypatch.setattr("app.llm._call_nim", MagicMock(side_effect=httpx.ConnectError("unreachable")))
+
+    result = llm_mod.explain_anomaly("orders", "row_count", _ts())
+    assert "explanation" in result
+    assert result["confidence"] == pytest.approx(0.3)
+
+
+def test_explain_anomaly_no_api_key_returns_rule_based(monkeypatch):
+    monkeypatch.setattr("app.config.settings.NIM_API_KEY", "")
+    monkeypatch.setattr("app.llm.get_metrics", lambda t, m, **kw: [])
+    result = llm_mod.explain_anomaly("orders", "row_count", _ts())
+    assert "explanation" in result
+    assert result["confidence"] == pytest.approx(0.3)
+
+
+# ---------------------------------------------------------------------------
+# Cache: second call must not invoke LLM
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    import app.metrics_storage as storage_mod
+    db_path = tmp_path / "metrics.db"
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    return storage_mod
+
+
+def test_cache_second_call_skips_llm(storage):
+    from app.metrics_storage import get_cached_explanation, save_explanation
+
+    ts = _ts()
+    # Nothing cached yet
+    assert get_cached_explanation("orders", "row_count", ts) is None
+
+    # Save an explanation
+    save_explanation("orders", "row_count", ts, "Test explanation", "Test fix", 0.85)
+
+    # Should be returned from cache
+    cached = get_cached_explanation("orders", "row_count", ts)
+    assert cached is not None
+    assert cached["explanation"] == "Test explanation"
+    assert cached["confidence"] == pytest.approx(0.85)
+
+
+def test_cache_expired_returns_none(storage, monkeypatch):
+    from datetime import timedelta
+    from app.metrics_storage import get_cached_explanation, save_explanation, _iso
+
+    ts = _ts()
+    # Save with a created_at far in the past (25 h ago)
+    old_created_at = _iso(datetime.now(timezone.utc) - timedelta(hours=25))
+    from sqlalchemy import text
+    with storage.get_engine().begin() as conn:
+        conn.execute(text("""
+            INSERT OR REPLACE INTO llm_explanations
+                (table_name, metric, ts, explanation, suggested_fix, confidence, created_at)
+            VALUES ('orders', 'row_count', :ts, 'old', 'old fix', 0.5, :ca)
+        """), {"ts": ts, "ca": old_created_at})
+
+    assert get_cached_explanation("orders", "row_count", ts) is None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/explain endpoint
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client():
+    app = create_app({"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+_KNOWN_TABLES = [{"table_name": "orders"}, {"table_name": "users"}]
+
+
+def test_explain_endpoint_returns_200(client):
+    payload = {"explanation": "причина", "suggested_fix": "решение", "confidence": 0.8}
+    with patch("app.llm.explain_anomaly", return_value=payload), \
+         patch("app.api.get_cached_explanation", return_value=None), \
+         patch("app.api.save_explanation"), \
+         patch("app.api.list_tables", return_value=_KNOWN_TABLES):
+        resp = client.post("/api/explain", json={"table": "orders", "metric": "row_count", "ts": _ts()})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["explanation"] == "причина"
+    assert data["confidence"] == pytest.approx(0.8)
+
+
+def test_explain_endpoint_unknown_table_returns_404(client):
+    with patch("app.api.get_cached_explanation", return_value=None), \
+         patch("app.api.list_tables", return_value=_KNOWN_TABLES):
+        resp = client.post("/api/explain", json={"table": "nonexistent", "metric": "row_count", "ts": _ts()})
+    assert resp.status_code == 404
+
+
+def test_explain_endpoint_missing_fields(client):
+    resp = client.post("/api/explain", json={"table": "orders"})
+    assert resp.status_code == 400
+
+
+def test_explain_endpoint_invalid_metric(client):
+    resp = client.post("/api/explain", json={"table": "orders", "metric": "size_bytes", "ts": _ts()})
+    assert resp.status_code == 400
+
+
+def test_explain_endpoint_serves_from_cache(client):
+    cached = {"explanation": "кэш", "suggested_fix": "кэш fix", "confidence": 0.6}
+    with patch("app.api.get_cached_explanation", return_value=cached):
+        resp = client.post("/api/explain", json={"table": "orders", "metric": "row_count", "ts": _ts()})
+    assert resp.status_code == 200
+    assert resp.get_json()["explanation"] == "кэш"


### PR DESCRIPTION
## Summary

- Добавлен модуль `app/llm.py` с интеграцией NVIDIA NIM для объяснения причин аномалий через LLM
- Добавлен эндпоинт `POST /api/explain` с кэшем SQLite (TTL 24 ч) и rule-based fallback
- Реализован UI-компонент в `table_detail.html`: клик по точке аномалии → панель с объяснением

## Что реализовано

### Новые файлы
- **`app/llm.py`** — публичная функция `explain_anomaly(table, metric, ts)`:
  - `_context_window(ts)` — динамическое окно выборки данных относительно момента аномалии
  - `_build_prompt` — формирует контекст (схема, row_count, null_rate, changepoints, IF-score)
  - `_call_nim` — httpx-запрос к NIM с retry через tenacity (только `httpx.RequestError`, не 4xx/5xx)
  - `_parse_nim_response` — парсинг JSON из ответа LLM с regex-fallback, клэмп confidence [0, 1]
  - `_rule_based_explain` — fallback при недоступном NIM (confidence=0.3)
- **`tests/test_llm.py`** — 19 тестов: `_build_prompt`, `_parse_nim_response` (5 кейсов), `_rule_based_explain` (3), fallback (2), кэш (2), эндпоинт (5)

### Изменённые файлы
- **`app/api.py`** — `POST /api/explain`: валидация → кэш (SQLite) → проверка таблицы (Postgres) → NIM → сохранение
- **`app/config.py`** — добавлены `NIM_API_KEY`, `NIM_BASE_URL`, `NIM_MODEL`
- **`app/metrics_storage.py`** — `get_cached_explanation` + `save_explanation` (таблица `llm_explanations`)
- **`scripts/metrics_schema.sql`** — новая таблица `llm_explanations` с PK `(table_name, metric, ts)`
- **`requirements.txt`** — добавлены `httpx==0.28.1`, `tenacity==9.1.2`
- **`templates/table_detail.html`** — панель объяснения аномалий с confidence bar, spinner, error handling

## Ключевые архитектурные решения

- Кэш проверяется до `list_tables()` — SQLite не делает запросов к Postgres при cache hit
- `_context_window(ts)` центрирует выборку вокруг момента аномалии, а не текущего времени
- tenacity retry только для сетевых ошибок (`httpx.RequestError`); `HTTPStatusError` (4xx/5xx) не ретраится
- `plotly_click` listener переподключается после каждого `Plotly.newPlot` (который сбрасывает listeners)

## Test plan

- [x] `pytest tests/test_llm.py` — все 19 тестов пройдены
- [x] `pytest` — все 207 тестов пройдены, новые тесты не сломали существующие
- [ ] Ручная проверка: кликнуть по точке аномалии на странице таблицы → убедиться в появлении панели
- [ ] Ручная проверка: повторный клик → ответ из кэша (быстрее)
- [ ] При пустом `NIM_API_KEY` — rule-based ответ с confidence=0.3