### PR TITLE
feat(notifications): persist Telegram alerts and add UI history (#76)

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -4,11 +4,13 @@ from flask import Blueprint, jsonify, request
 
 from .db import list_tables, table_schema
 from .metrics_storage import (
+    count_notifications,
     get_anomaly_scores,
     get_cached_explanation,
     get_changepoints,
     get_latest_metric,
     get_metrics,
+    get_notifications,
     get_schema_events,
     save_explanation,
 )
@@ -27,6 +29,11 @@ _RANGES = {
     "30d": timedelta(days=30),
 }
 _HORIZONS = {"1d": 1, "3d": 3, "7d": 7, "14d": 14, "30d": 30}
+_NOTIFICATION_EVENT_TYPES = {
+    "anomaly", "schema_drift", "changepoint", "forecast", "root_cause",
+}
+_NOTIFICATION_STATUSES = {"sent", "failed"}
+_MAX_NOTIFICATIONS_LIMIT = 200
 
 
 @api.route("/tables")
@@ -213,6 +220,58 @@ def explain():
         confidence=result["confidence"],
     )
     return jsonify(result)
+
+
+@api.route("/notifications")
+def notifications():
+    """Return Telegram notification history with pagination + filters (#76).
+
+    Query params:
+      event_type — anomaly | schema_drift | changepoint | forecast | root_cause
+      table      — filter by table_name
+      status     — sent | failed
+      range      — 1h | 6h | 24h | 7d | 14d | 30d (optional time window)
+      limit      — page size, 1..200 (default 50)
+      offset     — pagination offset (default 0)
+
+    Response: {items: [...], total, limit, offset}.
+    """
+    event_type = request.args.get("event_type")
+    table = request.args.get("table")
+    status = request.args.get("status")
+    range_str = request.args.get("range")
+
+    if event_type and event_type not in _NOTIFICATION_EVENT_TYPES:
+        return jsonify({"error": f"event_type must be one of {sorted(_NOTIFICATION_EVENT_TYPES)}"}), 400
+    if status and status not in _NOTIFICATION_STATUSES:
+        return jsonify({"error": f"status must be one of {sorted(_NOTIFICATION_STATUSES)}"}), 400
+    if range_str and range_str not in _RANGES:
+        return jsonify({"error": f"range must be one of {sorted(_RANGES)}"}), 400
+
+    try:
+        limit = int(request.args.get("limit", 50))
+        offset = int(request.args.get("offset", 0))
+    except ValueError:
+        return jsonify({"error": "limit and offset must be integers"}), 400
+    if limit < 1 or limit > _MAX_NOTIFICATIONS_LIMIT:
+        return jsonify({"error": f"limit must be 1..{_MAX_NOTIFICATIONS_LIMIT}"}), 400
+    if offset < 0:
+        return jsonify({"error": "offset must be >= 0"}), 400
+
+    since = None
+    if range_str:
+        from datetime import datetime, timezone
+        since = datetime.now(timezone.utc) - _RANGES[range_str]
+
+    filters = {
+        "event_type": event_type,
+        "table_name": table,
+        "status": status,
+        "since": since,
+    }
+    items = get_notifications(limit=limit, offset=offset, **filters)
+    total = count_notifications(**filters)
+    return jsonify({"items": items, "total": total, "limit": limit, "offset": offset})
 
 
 @api.route("/schema/<table_name>/changes")

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -6,14 +6,25 @@ from datetime import datetime, timedelta, timezone
 
 from app import db
 from app.metrics_storage import (
+    count_notifications,
     get_latest_metric,
     get_latest_null_counts,
+    get_notifications,
     get_schema_events,
     build_history_aggregate,
     get_history_runs,
     get_history_daily,
     get_history_insights,
 )
+
+_NOTIFICATION_EVENT_LABELS = {
+    "anomaly": "Аномалия",
+    "schema_drift": "Дрейф схемы",
+    "changepoint": "Change-point",
+    "forecast": "Прогноз",
+    "root_cause": "Root cause",
+}
+_NOTIFICATION_PAGE_SIZE = 25
 
 _RECENT_SCHEMA_DAYS = 7
 
@@ -137,6 +148,42 @@ def history_view():
         daily_history=daily_history,
         insights=insights,
     )
+
+@bp.route("/notifications")
+def notifications_view():
+    """История Telegram-уведомлений с фильтрами и пагинацией (#76)."""
+    from flask import request
+
+    event_type = request.args.get("event_type") or None
+    status = request.args.get("status") or None
+    table = request.args.get("table") or None
+    if event_type and event_type not in _NOTIFICATION_EVENT_LABELS:
+        event_type = None
+    if status and status not in {"sent", "failed"}:
+        status = None
+
+    try:
+        page = max(1, int(request.args.get("page", 1)))
+    except ValueError:
+        page = 1
+
+    offset = (page - 1) * _NOTIFICATION_PAGE_SIZE
+    filters = {"event_type": event_type, "status": status, "table_name": table}
+    items = get_notifications(limit=_NOTIFICATION_PAGE_SIZE, offset=offset, **filters)
+    total = count_notifications(**filters)
+    pages = max(1, (total + _NOTIFICATION_PAGE_SIZE - 1) // _NOTIFICATION_PAGE_SIZE)
+
+    return render_template(
+        "notifications.html",
+        items=items,
+        total=total,
+        page=page,
+        pages=pages,
+        page_size=_NOTIFICATION_PAGE_SIZE,
+        filters={"event_type": event_type or "", "status": status or "", "table": table or ""},
+        event_labels=_NOTIFICATION_EVENT_LABELS,
+    )
+
 
 @bp.route("/<table_name>")
 def table_detail(table_name: str):

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -742,6 +742,142 @@ def update_throttle(table: str, event_key: str) -> None:
         })
 
 
+# --- Notification history (#76) ---
+
+_NOTIFICATION_EVENT_TYPES = {
+    "anomaly", "schema_drift", "changepoint", "forecast", "root_cause",
+}
+
+
+def save_notification(
+    *,
+    event_type: str,
+    message: str,
+    status: str,
+    table_name: str | None = None,
+    metric_name: str | None = None,
+    error: str | None = None,
+    chat_id: str | None = None,
+    ts: datetime | str | None = None,
+) -> int:
+    """Store a Telegram notification record. Returns the new row id.
+
+    Called from notify_* helpers regardless of delivery outcome — failures are
+    persisted with status='failed' so the UI can show a complete audit trail.
+    """
+    payload = {
+        "ts": _iso(ts or datetime.now(timezone.utc)),
+        "event_type": event_type,
+        "table_name": table_name,
+        "metric_name": metric_name,
+        "message": message,
+        "status": status,
+        "error": error,
+        "chat_id": str(chat_id) if chat_id is not None else None,
+    }
+    stmt = text("""
+        INSERT INTO notifications
+            (ts, event_type, table_name, metric_name, message, status, error, chat_id)
+        VALUES
+            (:ts, :event_type, :table_name, :metric_name, :message, :status, :error, :chat_id)
+    """)
+    with get_engine().begin() as conn:
+        result = conn.execute(stmt, payload)
+        try:
+            return int(result.lastrowid or 0)
+        except AttributeError:
+            return 0
+
+
+def get_notifications(
+    *,
+    event_type: str | None = None,
+    table_name: str | None = None,
+    status: str | None = None,
+    since: datetime | str | None = None,
+    until: datetime | str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
+    """Return notification history, newest first, with optional filters.
+
+    Pagination via limit/offset; defaults give a sane single-page response for
+    the UI without scanning the full table.
+    """
+    where = ["1=1"]
+    params: dict[str, Any] = {"limit": int(limit), "offset": int(offset)}
+    if event_type:
+        where.append("event_type = :event_type")
+        params["event_type"] = event_type
+    if table_name:
+        where.append("table_name = :table_name")
+        params["table_name"] = table_name
+    if status:
+        where.append("status = :status")
+        params["status"] = status
+    if since is not None:
+        where.append("ts >= :since")
+        params["since"] = _iso(since)
+    if until is not None:
+        where.append("ts <= :until")
+        params["until"] = _iso(until)
+
+    stmt = text(f"""
+        SELECT id, ts, event_type, table_name, metric_name, message, status, error, chat_id
+        FROM notifications
+        WHERE {' AND '.join(where)}
+        ORDER BY ts DESC, id DESC
+        LIMIT :limit OFFSET :offset
+    """)
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt, params).fetchall()
+    return [
+        {
+            "id": r[0],
+            "ts": r[1],
+            "event_type": r[2],
+            "table_name": r[3],
+            "metric_name": r[4],
+            "message": r[5],
+            "status": r[6],
+            "error": r[7],
+            "chat_id": r[8],
+        }
+        for r in rows
+    ]
+
+
+def count_notifications(
+    *,
+    event_type: str | None = None,
+    table_name: str | None = None,
+    status: str | None = None,
+    since: datetime | str | None = None,
+    until: datetime | str | None = None,
+) -> int:
+    """Total notifications matching filters — used for pagination metadata."""
+    where = ["1=1"]
+    params: dict[str, Any] = {}
+    if event_type:
+        where.append("event_type = :event_type")
+        params["event_type"] = event_type
+    if table_name:
+        where.append("table_name = :table_name")
+        params["table_name"] = table_name
+    if status:
+        where.append("status = :status")
+        params["status"] = status
+    if since is not None:
+        where.append("ts >= :since")
+        params["since"] = _iso(since)
+    if until is not None:
+        where.append("ts <= :until")
+        params["until"] = _iso(until)
+    stmt = text(f"SELECT COUNT(*) FROM notifications WHERE {' AND '.join(where)}")
+    with get_engine().connect() as conn:
+        return int(conn.execute(stmt, params).scalar() or 0)
+
+
 # --- LLM explanation cache (#36) ---
 
 def get_cached_explanation(

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -6,7 +6,8 @@ Public entry points called from collectors/scheduler.py:
   notify_changepoint(table, metric, value_before, value_after, ts)
 
 All functions are silent on errors — notification failures never propagate
-to the caller.
+to the caller. Each delivery attempt (success or failure) is persisted via
+metrics_storage.save_notification so the UI can show a full audit trail (#76).
 """
 
 import asyncio
@@ -17,18 +18,24 @@ from telegram.error import TelegramError
 
 from app.config import settings
 from app.llm import explain_anomaly
-from app.metrics_storage import is_throttled, update_throttle
+from app.metrics_storage import is_throttled, save_notification, update_throttle
 
 logger = logging.getLogger(__name__)
 
 
-def send_message(text: str) -> bool:
-    """Send a plain-text message via Bot API. Returns True on success."""
+def send_message(text: str) -> tuple[bool, str | None]:
+    """Send a plain-text message via Bot API.
+
+    Returns (ok, error). When ok is False, error is a short reason string
+    suitable for storing alongside the notification record. Returns
+    (False, "not_configured") if token/chat are not set — the call is still
+    audited as a failed attempt by the caller.
+    """
     token = settings.TELEGRAM_BOT_TOKEN
     chat_id = settings.TELEGRAM_CHAT_ID
     if not token or not chat_id:
         logger.debug("Telegram not configured, skipping")
-        return False
+        return False, "not_configured"
 
     async def _send() -> None:
         async with Bot(token) as bot:
@@ -36,13 +43,37 @@ def send_message(text: str) -> bool:
 
     try:
         asyncio.run(_send())
-        return True
+        return True, None
     except TelegramError as exc:
         logger.warning("Telegram send failed: %s", exc)
-        return False
+        return False, f"telegram_error: {exc}"
     except Exception as exc:
         logger.warning("Telegram send error: %s", exc)
-        return False
+        return False, f"error: {exc}"
+
+
+def _record(
+    *,
+    event_type: str,
+    message: str,
+    ok: bool,
+    error: str | None,
+    table: str | None = None,
+    metric: str | None = None,
+) -> None:
+    """Persist a notification attempt. Never raises — auditing is best-effort."""
+    try:
+        save_notification(
+            event_type=event_type,
+            message=message,
+            status="sent" if ok else "failed",
+            table_name=table,
+            metric_name=metric,
+            error=error,
+            chat_id=settings.TELEGRAM_CHAT_ID or None,
+        )
+    except Exception as exc:  # pragma: no cover - storage failure shouldn't break alerts
+        logger.warning("Failed to persist notification audit: %s", exc)
 
 
 def notify_anomaly(table: str, ts: str, score: float) -> None:
@@ -58,7 +89,10 @@ def notify_anomaly(table: str, ts: str, score: float) -> None:
         f"\U0001f6a8 [{table}] Аномалия (score: {score:.4f})\n"
         f"Объяснение: {explanation}"
     )
-    if send_message(text):
+    ok, error = send_message(text)
+    _record(event_type="anomaly", message=text, ok=ok, error=error,
+            table=table, metric="row_count")
+    if ok:
         update_throttle(table, event_key)
 
 
@@ -85,7 +119,9 @@ def notify_schema_drift(table: str, events: list[dict]) -> None:
         lines.append(line)
 
     text = f"\U0001f4cb [{table}] Дрейф схемы:\n" + "\n".join(lines)
-    if send_message(text):
+    ok, error = send_message(text)
+    _record(event_type="schema_drift", message=text, ok=ok, error=error, table=table)
+    if ok:
         update_throttle(table, event_key)
 
 
@@ -109,5 +145,8 @@ def notify_changepoint(
     text = (
         f"\U0001f4c8 [{table}] Change-point: {metric} {change_str} ({ts[:10]})"
     )
-    if send_message(text):
+    ok, error = send_message(text)
+    _record(event_type="changepoint", message=text, ok=ok, error=error,
+            table=table, metric=metric)
+    if ok:
         update_throttle(table, event_key)

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -105,3 +105,25 @@ CREATE TABLE IF NOT EXISTS telegram_throttle (
     last_sent_at TEXT NOT NULL,
     PRIMARY KEY (table_name, event_key)
 );
+
+-- История отправленных Telegram-уведомлений (#76). Пишется на каждый
+-- вызов notify_*, в т.ч. при ошибке доставки (status='failed' + error).
+-- Bot token и прочие секреты сюда не попадают по дизайну.
+CREATE TABLE IF NOT EXISTS notifications (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts          TEXT NOT NULL,    -- ISO 8601 UTC, момент попытки отправки
+    event_type  TEXT NOT NULL,    -- anomaly | schema_drift | changepoint | forecast | root_cause
+    table_name  TEXT,
+    metric_name TEXT,
+    message     TEXT NOT NULL,
+    status      TEXT NOT NULL,    -- sent | failed
+    error       TEXT,
+    chat_id     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_ts
+    ON notifications (ts DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_event_type_ts
+    ON notifications (event_type, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_table_ts
+    ON notifications (table_name, ts DESC);

--- a/scripts/seed_metrics_db.py
+++ b/scripts/seed_metrics_db.py
@@ -55,6 +55,7 @@ from app import db as target_db
 from app.metrics_storage import (
     get_engine as get_monitor_engine,
     save_metrics,
+    save_notification,
     save_schema_events,
 )
 
@@ -502,8 +503,157 @@ def _generate_distribution_rows(
 
 _PURGE_TABLES = (
     "metrics", "anomaly_scores", "changepoints", "drift_reports",
-    "schema_events", "schema_snapshots",
+    "schema_events", "schema_snapshots", "notifications",
 )
+
+
+# Синтетические Telegram-уведомления для страницы /dashboard/notifications.
+# Профили подобраны так, чтобы лента истории показывала разные типы событий и
+# смесь успешных доставок с одной-двумя ошибками — иначе UI выглядит «слишком
+# идеально». Время каждого уведомления привязано к progress в окне сида.
+@dataclass(frozen=True)
+class NotificationProfile:
+    progress: float
+    event_type: str
+    table_name: str
+    metric_name: str | None
+    message: str
+    status: str = "sent"
+    error: str | None = None
+
+
+NOTIFICATION_PROFILES: tuple[NotificationProfile, ...] = (
+    NotificationProfile(
+        progress=0.20,
+        event_type="anomaly",
+        table_name="events",
+        metric_name="null_rate",
+        message=(
+            "🚨 [events] Аномалия (score: -0.2134)\n"
+            "Объяснение: резкий выброс null_rate — вероятная причина: сбой ETL "
+            "по колонке ip_address."
+        ),
+    ),
+    NotificationProfile(
+        progress=0.40,
+        event_type="schema_drift",
+        table_name="users",
+        metric_name=None,
+        message=(
+            "📋 [users] Дрейф схемы:\n"
+            "  • column_added — phone (varchar)"
+        ),
+    ),
+    NotificationProfile(
+        progress=0.50,
+        event_type="schema_drift",
+        table_name="events",
+        metric_name=None,
+        message=(
+            "📋 [events] Дрейф схемы:\n"
+            "  • nullable_changed — ip_address (inet)"
+        ),
+    ),
+    NotificationProfile(
+        progress=0.55,
+        event_type="anomaly",
+        table_name="orders",
+        metric_name="row_count",
+        message=(
+            "🚨 [orders] Аномалия (score: -0.1842)\n"
+            "Объяснение: row_count подскочил выше прогноза — вероятная "
+            "причина: повторный импорт пакета заказов."
+        ),
+    ),
+    NotificationProfile(
+        progress=0.62,
+        event_type="changepoint",
+        table_name="events",
+        metric_name="null_rate",
+        message="📈 [events] Change-point: null_rate 2.0% → 25.0% (2026-04-30)",
+    ),
+    NotificationProfile(
+        progress=0.70,
+        event_type="anomaly",
+        table_name="products",
+        metric_name="row_count",
+        message=(
+            "🚨 [products] Аномалия (score: -0.1721)\n"
+            "Объяснение: краткосрочный спад каталога — возможен сбой "
+            "пайплайна синхронизации."
+        ),
+        status="failed",
+        error="telegram_error: Bad Request: chat not found",
+    ),
+    NotificationProfile(
+        progress=0.78,
+        event_type="changepoint",
+        table_name="users",
+        metric_name="row_count",
+        message="📈 [users] Change-point: row_count 53,000 → 71,000 (2026-05-04)",
+    ),
+    NotificationProfile(
+        progress=0.85,
+        event_type="root_cause",
+        table_name="events",
+        metric_name="null_rate",
+        message=(
+            "🧠 [events] LLM root-cause: рост NULL в ip_address скоррелирован "
+            "со сменой nullability колонки 50% назад — рекомендуется проверить "
+            "ETL-задачу `etl_events_ingest`."
+        ),
+    ),
+    NotificationProfile(
+        progress=0.90,
+        event_type="forecast",
+        table_name="orders",
+        metric_name="row_count",
+        message=(
+            "📊 [orders] Прогноз: ожидаемый рост ~12% за следующие 7 дней; "
+            "верхняя граница 95% CI = 95,300."
+        ),
+    ),
+    NotificationProfile(
+        progress=0.95,
+        event_type="anomaly",
+        table_name="orders",
+        metric_name="row_count",
+        message=(
+            "🚨 [orders] Аномалия (score: -0.2410)\n"
+            "Объяснение: финальная ступенька роста — соответствует выкатке "
+            "новой версии чекаута."
+        ),
+        status="failed",
+        error="not_configured",
+    ),
+)
+
+
+def _generate_notifications(end: datetime, days: int) -> int:
+    """Запись синтетических Telegram-уведомлений в `notifications`.
+    Возвращает количество созданных строк.
+
+    Идемпотентность не отслеживаем — задача сидера прогоняется поверх
+    очищенной БД (см. _PURGE_TABLES), поэтому повторный запуск без
+    --reset действительно создаст дубликаты, как и для остальных таблиц.
+    """
+    if days <= 0:
+        return 0
+    saved = 0
+    for p in NOTIFICATION_PROFILES:
+        ts = end - timedelta(days=days * (1.0 - p.progress))
+        save_notification(
+            event_type=p.event_type,
+            message=p.message,
+            status=p.status,
+            table_name=p.table_name,
+            metric_name=p.metric_name,
+            error=p.error,
+            chat_id="seed",
+            ts=ts,
+        )
+        saved += 1
+    return saved
 
 
 def _generate_schema_events(
@@ -571,10 +721,12 @@ def main(
 
     saved = save_metrics(all_rows)
     schema_events_saved = save_schema_events(schema_event_rows) if schema_event_rows else 0
+    notifications_saved = _generate_notifications(end, days)
     print(
         f"Засеяно {saved} строк метрик по {len(snapshots)} таблицам "
         f"({len(timestamps)} тиков, {days} дн.), "
-        f"{schema_events_saved} schema-events. "
+        f"{schema_events_saved} schema-events, "
+        f"{notifications_saved} уведомлений. "
         f"Reset удалил {deleted} строк."
     )
     return {
@@ -583,6 +735,7 @@ def main(
         "deleted": deleted,
         "ticks": len(timestamps),
         "schema_events": schema_events_saved,
+        "notifications": notifications_saved,
     }
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,6 +52,7 @@
             ("/dashboard", "Обзор", "M3 12 12 3l9 9M5 10v10h14V10", "exact"),
             ("/dashboard/schema", "Схема", "M4 7h16M4 12h16M4 17h10", "exact"),
             ("/dashboard/history", "История", "M12 8v4l3 3M4 4h16M4 20h16", "exact"),
+            ("/dashboard/notifications", "Уведомления", "M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2c0 .5-.2 1-.6 1.4L4 17h5m6 0a3 3 0 1 1-6 0", "exact"),
           ] %}
           {% for url, label, path, mode in sections %}
             {% set active = (request.path == url) %}

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -1,0 +1,141 @@
+{% extends "base.html" %}
+
+{% block title %}Уведомления — DB Monitor{% endblock %}
+
+{% block breadcrumb %}
+  <a href="/dashboard" class="hover:text-slate-700 dark:hover:text-slate-200">Главная</a>
+  <span>/</span>
+  <span>Уведомления</span>
+{% endblock %}
+
+{% block content %}
+<div class="space-y-6">
+  <div>
+    <h1 class="text-2xl font-semibold tracking-tight">Уведомления</h1>
+    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+      История Telegram-сообщений: что было отправлено, когда и со статусом доставки.
+    </p>
+  </div>
+
+  <section class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <form method="get" class="grid grid-cols-1 gap-3 sm:grid-cols-4">
+      <div>
+        <label class="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400">Тип события</label>
+        <select name="event_type" class="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900">
+          <option value="">Все</option>
+          {% for key, label in event_labels.items() %}
+            <option value="{{ key }}" {% if filters.event_type == key %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label class="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400">Статус</label>
+        <select name="status" class="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900">
+          <option value="">Все</option>
+          <option value="sent" {% if filters.status == 'sent' %}selected{% endif %}>Доставлено</option>
+          <option value="failed" {% if filters.status == 'failed' %}selected{% endif %}>Ошибка</option>
+        </select>
+      </div>
+      <div>
+        <label class="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400">Таблица</label>
+        <input type="text" name="table" value="{{ filters.table }}" placeholder="например, orders"
+               class="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900" />
+      </div>
+      <div class="flex items-end gap-2">
+        <button type="submit" class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover">Применить</button>
+        <a href="/dashboard/notifications" class="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">Сбросить</a>
+      </div>
+    </form>
+  </section>
+
+  <section class="rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+      <div>
+        <h2 class="text-lg font-semibold">Лента отправлений</h2>
+        <p class="text-sm text-slate-500 dark:text-slate-400">Всего записей: {{ total }}</p>
+      </div>
+      <span class="text-sm text-slate-500 dark:text-slate-400">Страница {{ page }} из {{ pages }}</span>
+    </div>
+
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+        <thead class="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-800/80 dark:text-slate-400">
+          <tr>
+            <th class="px-5 py-3 font-medium">Время</th>
+            <th class="px-5 py-3 font-medium">Тип</th>
+            <th class="px-5 py-3 font-medium">Таблица / метрика</th>
+            <th class="px-5 py-3 font-medium">Сообщение</th>
+            <th class="px-5 py-3 font-medium">Статус</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+          {% for n in items %}
+            <tr class="align-top hover:bg-slate-50 dark:hover:bg-slate-800/60">
+              <td class="whitespace-nowrap px-5 py-4 font-mono text-xs text-slate-500 dark:text-slate-400">
+                {{ n.ts.replace("T", " ")[:19] }}
+              </td>
+              <td class="whitespace-nowrap px-5 py-4">
+                <span class="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                  {{ event_labels.get(n.event_type, n.event_type) }}
+                </span>
+              </td>
+              <td class="whitespace-nowrap px-5 py-4">
+                {% if n.table_name %}
+                  <a href="/dashboard/{{ n.table_name }}" class="font-medium text-accent hover:underline">{{ n.table_name }}</a>
+                {% else %}
+                  <span class="text-slate-400">—</span>
+                {% endif %}
+                {% if n.metric_name %}
+                  <span class="ml-1 text-xs text-slate-500 dark:text-slate-400">/ {{ n.metric_name }}</span>
+                {% endif %}
+              </td>
+              <td class="px-5 py-4">
+                <details class="group">
+                  <summary class="cursor-pointer text-slate-700 dark:text-slate-200">
+                    {{ (n.message or "")[:90] }}{% if n.message and n.message|length > 90 %}…{% endif %}
+                  </summary>
+                  <pre class="mt-2 whitespace-pre-wrap rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-700 dark:bg-slate-800/70 dark:text-slate-200">{{ n.message }}</pre>
+                  {% if n.error %}
+                    <div class="mt-2 rounded-md bg-rose-50 px-3 py-2 text-xs text-rose-700 dark:bg-rose-900/30 dark:text-rose-200">
+                      Ошибка: {{ n.error }}
+                    </div>
+                  {% endif %}
+                </details>
+              </td>
+              <td class="whitespace-nowrap px-5 py-4">
+                {% if n.status == 'sent' %}
+                  <span class="rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200">Доставлено</span>
+                {% else %}
+                  <span class="rounded-full bg-rose-100 px-2 py-1 text-xs font-medium text-rose-700 dark:bg-rose-900/40 dark:text-rose-200">Ошибка</span>
+                {% endif %}
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="5" class="px-5 py-8 text-center text-slate-500 dark:text-slate-400">
+                Нет уведомлений по выбранным фильтрам.
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    {% if pages > 1 %}
+      <div class="flex items-center justify-between border-t border-slate-200 px-5 py-3 text-sm dark:border-slate-800">
+        {% set qs = [] %}
+        {% if filters.event_type %}{% set _ = qs.append('event_type=' ~ filters.event_type) %}{% endif %}
+        {% if filters.status %}{% set _ = qs.append('status=' ~ filters.status) %}{% endif %}
+        {% if filters.table %}{% set _ = qs.append('table=' ~ filters.table) %}{% endif %}
+        {% set base_qs = qs | join('&') %}
+
+        <a href="?{{ base_qs }}{% if base_qs %}&{% endif %}page={{ page - 1 }}"
+           class="rounded-md border border-slate-200 px-3 py-1.5 dark:border-slate-700 {% if page <= 1 %}pointer-events-none opacity-50{% endif %}">← Назад</a>
+        <span class="text-slate-500 dark:text-slate-400">{{ page }} / {{ pages }}</span>
+        <a href="?{{ base_qs }}{% if base_qs %}&{% endif %}page={{ page + 1 }}"
+           class="rounded-md border border-slate-200 px-3 py-1.5 dark:border-slate-700 {% if page >= pages %}pointer-events-none opacity-50{% endif %}">Вперёд →</a>
+      </div>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,3 +124,90 @@ def test_schema_table_not_found(client):
 
     assert resp.status_code == 404
     assert "error" in resp.get_json()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/notifications  (#76)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def notifications_storage(tmp_path, monkeypatch):
+    import app.metrics_storage as ms
+    db_path = tmp_path / "metrics.db"
+    monkeypatch.setattr(ms.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    yield ms
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+
+
+def test_notifications_returns_paginated_envelope(client, notifications_storage):
+    from app.metrics_storage import save_notification
+    for i in range(3):
+        save_notification(event_type="anomaly", message=f"m{i}",
+                          status="sent", table_name="orders")
+
+    resp = client.get("/api/notifications")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["total"] == 3
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+    assert len(body["items"]) == 3
+    assert {it["message"] for it in body["items"]} == {"m0", "m1", "m2"}
+
+
+def test_notifications_filters_by_event_type(client, notifications_storage):
+    from app.metrics_storage import save_notification
+    save_notification(event_type="anomaly", message="a", status="sent", table_name="orders")
+    save_notification(event_type="schema_drift", message="s", status="sent", table_name="orders")
+
+    resp = client.get("/api/notifications?event_type=anomaly")
+    body = resp.get_json()
+    assert body["total"] == 1
+    assert body["items"][0]["event_type"] == "anomaly"
+
+
+def test_notifications_filters_by_status_and_table(client, notifications_storage):
+    from app.metrics_storage import save_notification
+    save_notification(event_type="anomaly", message="ok", status="sent", table_name="orders")
+    save_notification(event_type="anomaly", message="bad", status="failed",
+                      table_name="users", error="boom")
+
+    resp = client.get("/api/notifications?status=failed&table=users")
+    body = resp.get_json()
+    assert body["total"] == 1
+    assert body["items"][0]["error"] == "boom"
+
+
+def test_notifications_pagination(client, notifications_storage):
+    from app.metrics_storage import save_notification
+    for i in range(5):
+        save_notification(event_type="anomaly", message=f"m{i}",
+                          status="sent", table_name="orders")
+
+    page1 = client.get("/api/notifications?limit=2&offset=0").get_json()
+    page2 = client.get("/api/notifications?limit=2&offset=2").get_json()
+    assert page1["total"] == 5 and page2["total"] == 5
+    assert len(page1["items"]) == 2 and len(page2["items"]) == 2
+    ids1 = {it["id"] for it in page1["items"]}
+    ids2 = {it["id"] for it in page2["items"]}
+    assert ids1.isdisjoint(ids2)
+
+
+def test_notifications_invalid_event_type(client):
+    resp = client.get("/api/notifications?event_type=garbage")
+    assert resp.status_code == 400
+
+
+def test_notifications_invalid_status(client):
+    resp = client.get("/api/notifications?status=delivered")
+    assert resp.status_code == 400
+
+
+def test_notifications_invalid_limit(client):
+    resp = client.get("/api/notifications?limit=0")
+    assert resp.status_code == 400
+    resp2 = client.get("/api/notifications?limit=9999")
+    assert resp2.status_code == 400

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -127,10 +127,61 @@ def test_table_detail_renders_from_storage_and_schema(client):
     assert "users" in body
     assert "id" in body and "email" in body
     assert "uuid" in body and "text" in body
-    assert "75 NULL" in body  # per-column null count from storage
-    assert "5.0%" in body  # 75/1500 rendered
+    # Detail page uses stored null_count (75) → derives null_rate (75/1500 = 5%)
+    # and renders the rate. Live column_nulls() is intentionally not called.
+    assert "5.0%" in body
     assert "Plotly" in body  # plotly cdn loaded
     mock_col_nulls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# /dashboard/notifications  (#76)
+# ---------------------------------------------------------------------------
+
+def test_notifications_page_empty(client):
+    resp = client.get("/dashboard/notifications")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Уведомления" in body
+    assert "Нет уведомлений" in body
+
+
+def test_notifications_page_lists_records(client):
+    from app.metrics_storage import save_notification
+    save_notification(event_type="anomaly", message="орёл взлетел",
+                      status="sent", table_name="orders", metric_name="row_count")
+    save_notification(event_type="schema_drift", message="колонка добавлена",
+                      status="failed", table_name="users", error="boom")
+
+    resp = client.get("/dashboard/notifications")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "орёл взлетел" in body
+    assert "колонка добавлена" in body
+    assert "Доставлено" in body
+    assert "Ошибка" in body
+
+
+def test_notifications_page_event_type_filter(client):
+    from app.metrics_storage import save_notification
+    save_notification(event_type="anomaly", message="ANOMALY_MARKER_ZZZ",
+                      status="sent", table_name="orders")
+    save_notification(event_type="schema_drift", message="SCHEMA_MARKER_QQQ",
+                      status="sent", table_name="orders")
+
+    resp = client.get("/dashboard/notifications?event_type=anomaly")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "ANOMALY_MARKER_ZZZ" in body
+    assert "SCHEMA_MARKER_QQQ" not in body
+
+
+def test_notifications_page_in_sidebar(client):
+    """Sidebar (rendered from base.html) should expose the new tab on every page."""
+    resp = client.get("/dashboard/notifications")
+    body = resp.get_data(as_text=True)
+    assert "/dashboard/notifications" in body
+    assert "Уведомления" in body
 
 
 def test_table_detail_404_when_not_listed(client):

--- a/tests/test_seed_metrics_db.py
+++ b/tests/test_seed_metrics_db.py
@@ -294,6 +294,8 @@ def test_generate_metric_rows_step_regression_for_high_null_column():
 
 def test_generate_metric_rows_regression_window_matches_days():
     """Начало регрессии — ровно за REGRESSION_DAYS до конца окна."""
+    from scripts.seed_metrics_db import NULL_SPIKE_PROGRESS
+
     end = datetime(2026, 5, 10, tzinfo=timezone.utc)
     days = 14
     ts = _build_timestamps(end, days=days, interval_minutes=60)
@@ -304,6 +306,9 @@ def test_generate_metric_rows_regression_window_matches_days():
     snap = _snapshot("events", row_count=100_000, size_bytes=10_000_000, cols=cols)
     rows = _generate_metric_rows(snap, ts, random.Random(0), days=days)
 
+    n = len(ts)
+    spike_ts = ts[round(NULL_SPIKE_PROGRESS * (n - 1))] if n > 1 else None
+
     rates = sorted(
         ((r["ts"], r["value"], next(
             x["value"] for x in rows if x["metric_name"] == "row_count" and x["ts"] == r["ts"]
@@ -312,7 +317,7 @@ def test_generate_metric_rows_regression_window_matches_days():
     )
     cutoff = end - timedelta(days=REGRESSION_DAYS)
     for ts_pt, null, rc in rates:
-        if ts_pt < cutoff:
+        if ts_pt < cutoff and ts_pt != spike_ts:
             assert null == pytest.approx(rc * BASELINE_NULL_RATE, rel=0.05)
 
 
@@ -501,12 +506,15 @@ def test_main_writes_metrics_and_distributions(monitor_storage, stub_target):
     result = main(days=days, interval_minutes=interval_minutes)
 
     # users есть в SCHEMA_EVENT_PROFILES → 1 schema-event ожидается.
+    # NOTIFICATION_PROFILES — фиксированный набор, не зависит от таблиц в target.
+    from scripts.seed_metrics_db import NOTIFICATION_PROFILES
     assert result == {
         "snapshots": 1,
         "rows": n_ticks * per_tick_rows + distribution_rows,
         "deleted": 0,
         "ticks": n_ticks,
         "schema_events": 1,
+        "notifications": len(NOTIFICATION_PROFILES),
     }
 
     with monitor_storage.get_engine().connect() as conn:
@@ -566,6 +574,10 @@ def test_main_reset_purges_derived_tables(monitor_storage, stub_target):
         "column_name": "y", "details": {"after": {"name": "y", "type": "text"}},
     }])
     monitor_storage.save_schema_snapshot("stale", [{"name": "x", "type": "text", "nullable": True}])
+    monitor_storage.save_notification(
+        event_type="anomaly", message="stale alert", status="sent",
+        table_name="stale", chat_id="old",
+    )
 
     stub_target({
         "users": {"row_count": 100, "size_bytes": 10_000, "columns": []},
@@ -576,7 +588,7 @@ def test_main_reset_purges_derived_tables(monitor_storage, stub_target):
     with monitor_storage.get_engine().connect() as conn:
         for tbl in (
             "anomaly_scores", "changepoints", "drift_reports",
-            "schema_events", "schema_snapshots",
+            "schema_events", "schema_snapshots", "notifications",
         ):
             n = conn.execute(
                 text(f"SELECT COUNT(*) FROM {tbl} WHERE table_name = 'stale'")
@@ -590,12 +602,40 @@ def test_main_no_tables_returns_zero(monitor_storage, monkeypatch):
         lambda schema=None: [],
     )
 
+    # No snapshots → early return without notifications either (мониторим
+    # только то, что реально есть в target DB).
     assert main(days=1, interval_minutes=60) == {
         "snapshots": 0, "rows": 0, "deleted": 0, "ticks": 0,
     }
 
 
 # --- per-table profiles ---
+
+
+def test_main_seeds_notifications_with_mixed_statuses(monitor_storage, stub_target):
+    """Сид-ноды для /dashboard/notifications: должно быть несколько типов
+    событий и хотя бы одна запись со статусом 'failed' (иначе UI выглядит
+    нереалистично)."""
+    from scripts.seed_metrics_db import NOTIFICATION_PROFILES
+    from app.metrics_storage import count_notifications, get_notifications
+
+    stub_target({
+        "users": {"row_count": 100, "size_bytes": 10_000, "columns": []},
+    })
+
+    result = main(days=14, interval_minutes=60, reset=True)
+    assert result["notifications"] == len(NOTIFICATION_PROFILES)
+    assert count_notifications() == len(NOTIFICATION_PROFILES)
+
+    items = get_notifications(limit=200)
+    event_types = {n["event_type"] for n in items}
+    statuses = {n["status"] for n in items}
+    # Лента должна показывать разнообразие типов событий и не быть «слишком идеальной».
+    assert len(event_types) >= 3
+    assert {"sent", "failed"}.issubset(statuses)
+    # Bot token не сохраняется ни в одном поле (acceptance #76).
+    blob = " ".join(str(v) for n in items for v in n.values() if v is not None)
+    assert "TELEGRAM_BOT_TOKEN" not in blob
 
 
 def test_profile_for_known_tables_returns_specific():

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -40,13 +40,17 @@ def _ts(hours_ago: int = 0) -> str:
 def test_send_message_no_token_returns_false(monkeypatch):
     monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "")
     monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "123")
-    assert send_message("hello") is False
+    ok, error = send_message("hello")
+    assert ok is False
+    assert error == "not_configured"
 
 
 def test_send_message_no_chat_id_returns_false(monkeypatch):
     monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "tok")
     monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "")
-    assert send_message("hello") is False
+    ok, error = send_message("hello")
+    assert ok is False
+    assert error == "not_configured"
 
 
 def test_send_message_success(monkeypatch):
@@ -54,8 +58,9 @@ def test_send_message_success(monkeypatch):
     monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "123")
     with patch("app.notifications.telegram.asyncio.run",
                side_effect=lambda coro: coro.close()) as mock_run:
-        result = send_message("test")
-    assert result is True
+        ok, error = send_message("test")
+    assert ok is True
+    assert error is None
     mock_run.assert_called_once()
 
 
@@ -69,8 +74,9 @@ def test_send_message_telegram_error_returns_false(monkeypatch):
         raise TelegramError("bad")
 
     with patch("app.notifications.telegram.asyncio.run", side_effect=_raise):
-        result = send_message("test")
-    assert result is False
+        ok, error = send_message("test")
+    assert ok is False
+    assert error and "telegram_error" in error
 
 
 def test_send_message_network_error_returns_false(monkeypatch):
@@ -82,8 +88,9 @@ def test_send_message_network_error_returns_false(monkeypatch):
         raise OSError("conn")
 
     with patch("app.notifications.telegram.asyncio.run", side_effect=_raise):
-        result = send_message("test")
-    assert result is False
+        ok, error = send_message("test")
+    assert ok is False
+    assert error and "error" in error
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +138,7 @@ def test_notify_anomaly_sends_message(storage, monkeypatch):
         "app.notifications.telegram.explain_anomaly",
         lambda t, m, ts: {"explanation": "ETL сбой", "suggested_fix": "", "confidence": 0.3},
     )
-    with patch("app.notifications.telegram.send_message", return_value=True) as mock_send:
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
         notify_anomaly("orders", _ts(), -0.14)
     mock_send.assert_called_once()
     text = mock_send.call_args[0][0]
@@ -144,7 +151,7 @@ def test_notify_anomaly_message_contains_score(storage, monkeypatch):
         "app.notifications.telegram.explain_anomaly",
         lambda t, m, ts: {"explanation": "причина", "suggested_fix": "", "confidence": 0.3},
     )
-    with patch("app.notifications.telegram.send_message", return_value=True) as mock_send:
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
         notify_anomaly("orders", _ts(), -0.25)
     text = mock_send.call_args[0][0]
     assert "-0.2500" in text
@@ -170,7 +177,7 @@ def test_notify_schema_drift_sends_message(storage, monkeypatch):
         {"change_type": "column_added", "column_name": "email",
          "details": {"after": {"type": "text"}}},
     ]
-    with patch("app.notifications.telegram.send_message", return_value=True) as mock_send:
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
         notify_schema_drift("orders", events)
     mock_send.assert_called_once()
     text = mock_send.call_args[0][0]
@@ -186,7 +193,7 @@ def test_notify_schema_drift_multiple_events_single_message(storage, monkeypatch
         {"change_type": "column_removed", "column_name": "age",
          "details": {"before": {"type": "integer"}}},
     ]
-    with patch("app.notifications.telegram.send_message", return_value=True) as mock_send:
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
         notify_schema_drift("orders", events)
     assert mock_send.call_count == 1
     text = mock_send.call_args[0][0]
@@ -205,7 +212,7 @@ def test_notify_schema_drift_empty_events_skips(storage, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_notify_changepoint_sends_message(storage, monkeypatch):
-    with patch("app.notifications.telegram.send_message", return_value=True) as mock_send:
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
         notify_changepoint("orders", "row_count", 1000.0, 2500.0, _ts())
     mock_send.assert_called_once()
     text = mock_send.call_args[0][0]
@@ -216,7 +223,7 @@ def test_notify_changepoint_sends_message(storage, monkeypatch):
 def test_notify_changepoint_null_rate_format(storage, monkeypatch):
     captured = []
     with patch("app.notifications.telegram.send_message",
-               side_effect=lambda t: captured.append(t) or True):
+               side_effect=lambda t: (captured.append(t) or True, None)):
         notify_changepoint("orders", "null_rate", 0.02, 0.18, _ts())
 
     assert captured, "expected a message"
@@ -228,12 +235,160 @@ def test_notify_changepoint_null_rate_format(storage, monkeypatch):
 # Flood test: 10 anomaly calls → only 1 send
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Notification persistence (#76)
+# ---------------------------------------------------------------------------
+
+def test_notify_anomaly_persists_sent_record(storage, monkeypatch):
+    from app.metrics_storage import get_notifications
+    monkeypatch.setattr(
+        "app.notifications.telegram.explain_anomaly",
+        lambda t, m, ts: {"explanation": "ETL сбой", "suggested_fix": "", "confidence": 0.3},
+    )
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)):
+        notify_anomaly("orders", _ts(), -0.14)
+
+    rows = get_notifications()
+    assert len(rows) == 1
+    rec = rows[0]
+    assert rec["event_type"] == "anomaly"
+    assert rec["table_name"] == "orders"
+    assert rec["metric_name"] == "row_count"
+    assert rec["status"] == "sent"
+    assert rec["error"] is None
+    assert "orders" in rec["message"]
+
+
+def test_notify_anomaly_persists_failed_record_on_send_error(storage, monkeypatch):
+    """Acceptance: failed sends still create a record with status='failed' + error."""
+    from app.metrics_storage import get_notifications
+    monkeypatch.setattr(
+        "app.notifications.telegram.explain_anomaly",
+        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
+    )
+    with patch("app.notifications.telegram.send_message",
+               return_value=(False, "telegram_error: bad")):
+        notify_anomaly("orders", _ts(), -0.2)
+
+    rows = get_notifications()
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+    assert "telegram_error" in (rows[0]["error"] or "")
+
+
+def test_notify_anomaly_failed_send_does_not_throttle(storage, monkeypatch):
+    """If send failed, throttle is NOT updated — next attempt should go through."""
+    from app.metrics_storage import is_throttled
+    monkeypatch.setattr(
+        "app.notifications.telegram.explain_anomaly",
+        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
+    )
+    with patch("app.notifications.telegram.send_message", return_value=(False, "oops")):
+        notify_anomaly("orders", _ts(), -0.2)
+    assert is_throttled("orders", "anomaly") is False
+
+
+def test_notify_schema_drift_persists_record(storage, monkeypatch):
+    from app.metrics_storage import get_notifications
+    events = [{"change_type": "column_added", "column_name": "email",
+               "details": {"after": {"type": "text"}}}]
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)):
+        notify_schema_drift("orders", events)
+    rows = get_notifications()
+    assert len(rows) == 1
+    assert rows[0]["event_type"] == "schema_drift"
+    assert rows[0]["table_name"] == "orders"
+    assert rows[0]["status"] == "sent"
+
+
+def test_notify_changepoint_persists_record(storage, monkeypatch):
+    from app.metrics_storage import get_notifications
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)):
+        notify_changepoint("orders", "row_count", 1000.0, 2500.0, _ts())
+    rows = get_notifications()
+    assert len(rows) == 1
+    assert rows[0]["event_type"] == "changepoint"
+    assert rows[0]["metric_name"] == "row_count"
+
+
+def test_get_notifications_filters_by_event_type(storage, monkeypatch):
+    from app.metrics_storage import get_notifications, save_notification
+    save_notification(event_type="anomaly", message="m1", status="sent", table_name="orders")
+    save_notification(event_type="schema_drift", message="m2", status="sent", table_name="orders")
+    save_notification(event_type="anomaly", message="m3", status="failed", table_name="users", error="e")
+
+    only_anomaly = get_notifications(event_type="anomaly")
+    assert len(only_anomaly) == 2
+    assert {r["table_name"] for r in only_anomaly} == {"orders", "users"}
+
+    only_failed = get_notifications(status="failed")
+    assert len(only_failed) == 1
+    assert only_failed[0]["table_name"] == "users"
+
+    by_table = get_notifications(table_name="orders")
+    assert len(by_table) == 2
+
+
+def test_get_notifications_pagination(storage):
+    from app.metrics_storage import count_notifications, get_notifications, save_notification
+    for i in range(7):
+        save_notification(event_type="anomaly", message=f"m{i}", status="sent", table_name="t")
+    assert count_notifications() == 7
+    page1 = get_notifications(limit=3, offset=0)
+    page2 = get_notifications(limit=3, offset=3)
+    assert len(page1) == 3
+    assert len(page2) == 3
+    # Newest-first ordering — offset slice should not overlap.
+    ids1 = {r["id"] for r in page1}
+    ids2 = {r["id"] for r in page2}
+    assert ids1.isdisjoint(ids2)
+
+
+def test_save_notification_omits_secrets(storage, monkeypatch):
+    """chat_id is recorded but bot token is never persisted (acceptance)."""
+    from app.metrics_storage import get_notifications
+    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "super-secret-token")
+    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "42")
+    monkeypatch.setattr(
+        "app.notifications.telegram.explain_anomaly",
+        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
+    )
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)):
+        notify_anomaly("orders", _ts(), -0.2)
+
+    rows = get_notifications()
+    assert rows[0]["chat_id"] == "42"
+    blob = " ".join(str(v) for v in rows[0].values() if v is not None)
+    assert "super-secret-token" not in blob
+
+
 def test_flood_throttle_10_anomalies(storage, monkeypatch):
     monkeypatch.setattr(
         "app.notifications.telegram.explain_anomaly",
         lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
     )
-    with patch("app.notifications.telegram.send_message", return_value=True) as mock_send:
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
         for _ in range(10):
             notify_anomaly("orders", _ts(), -0.2)
     assert mock_send.call_count == 1, f"expected 1 send, got {mock_send.call_count}"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: send_message stub failure path is recorded
+# ---------------------------------------------------------------------------
+
+def test_notify_persists_failure_when_telegram_not_configured(storage, monkeypatch):
+    """No token → send_message returns ('not_configured'); record still saved."""
+    from app.metrics_storage import get_notifications
+    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "")
+    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "")
+    monkeypatch.setattr(
+        "app.notifications.telegram.explain_anomaly",
+        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
+    )
+    notify_anomaly("orders", _ts(), -0.2)
+
+    rows = get_notifications()
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+    assert rows[0]["error"] == "not_configured"


### PR DESCRIPTION
## Summary
- Adds a `notifications` table + storage helpers; every `notify_*` call now persists a record (sent/failed + error), so the audit trail survives Telegram outages and "not_configured" runs.
- New `/api/notifications` endpoint with `event_type`, `table`, `status`, `range` filters and pagination.
- New `/dashboard/notifications` page with filter form, expandable message bodies, error surfaces, pagination — plus a sidebar tab «Уведомления».
- Seed script writes 10 mixed-status notifications across 5 event types so the page is populated out-of-the-box; `notifications` joined the `--reset` purge list.
- Bot token is never persisted — only `chat_id` per the issue's acceptance.

## Implementation notes
- `send_message()` now returns `(ok, error)`; throttle is updated only on success.
- Saving the audit record is best-effort and never propagates exceptions to the alert path.
- Storage layer (`save_notification` / `get_notifications` / `count_notifications`) lives next to existing time-series helpers in `metrics_storage.py`.
- Two pre-existing test failures fixed: `test_table_detail_renders_from_storage_and_schema` (template no longer prints absolute null counts after #1e7578b — assertion now matches the rendered rate) and `test_generate_metric_rows_regression_window_matches_days` (didn't account for `NULL_SPIKE_PROGRESS` tick).

## Test plan
- [x] `pytest -q` — 300 passed
- [ ] `python -m scripts.seed_metrics_db --reset` and open `/dashboard/notifications` — 10 records, mixed sent/failed, filter form works
- [ ] `curl /api/notifications?event_type=anomaly&status=failed` returns paginated envelope
- [ ] Trigger a real `notify_anomaly` with no `TELEGRAM_BOT_TOKEN` set → record appears with `status=failed`, `error=not_configured`

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)