### PR TITLE
fix: replace EOL NIM model with meta/llama-3.3-70b-instruct

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     # NVIDIA NIM LLM
     NIM_API_KEY: str = ""
     NIM_BASE_URL: str = "https://integrate.api.nvidia.com/v1"
-    NIM_MODEL: str = "nvidia/llama-3.3-nemotron-super-49b-instruct"
+    NIM_MODEL: str = "meta/llama-3.3-70b-instruct"
 
     # Telegram Bot alerts
     TELEGRAM_BOT_TOKEN: str = ""


### PR DESCRIPTION
Closes #82

## Описание

Модель `nvidia/llama-3.3-nemotron-super-49b-instruct` никогда не существовала на NIM (возвращала 404), а `deepseek-ai/deepseek-r1` достигла EOL 26 января 2026. Заменяем дефолт на `meta/llama-3.3-70b-instruct` — проверена и работает на `integrate.api.nvidia.com`.

## Тип изменения

- [x] Bug fix

## Чеклист

- [ ] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [x] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы (не применимо)