### PR TITLE
fix(#83): always include table/metric/timestamp header in anomaly Telegram alerts

### DIFF
--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -87,12 +87,14 @@ def notify_anomaly(table: str, ts: str, score: float) -> None:
     if is_throttled(table, event_key):
         return
 
-    result = explain_anomaly(table, "row_count", _fmt_ts(ts))
-    explanation = result.get("explanation", "")
+    result = explain_anomaly(table, "row_count", ts)
+    is_llm = result.get("confidence", 0) > 0.3
+    body = result["explanation"] if is_llm else "Требуется ручная проверка данных."
 
     text = (
         f"\U0001f6a8 [{table}] Аномалия (score: {score:.4f})\n"
-        f"Объяснение: {explanation}"
+        f"Обнаружена аномалия в таблице {table} по метрике row_count"
+        f" в момент {_fmt_ts(ts)}. {body}"
     )
     ok, error = send_message(text)
     _record(event_type="anomaly", message=text, ok=ok, error=error,

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -1,7 +1,7 @@
 """Telegram Bot notifications for anomalies, schema drift, and change-points (#38).
 
 Public entry points called from collectors/scheduler.py:
-  notify_anomaly(table, ts)
+  notify_anomaly(table, ts, score, metric="row_count")
   notify_schema_drift(table, events)
   notify_changepoint(table, metric, value_before, value_after, ts)
 
@@ -76,29 +76,32 @@ def _record(
         logger.warning("Failed to persist notification audit: %s", exc)
 
 
+_RULE_BASED_CONFIDENCE: float = 0.3
+
+
 def _fmt_ts(ts: str) -> str:
     """Format ISO timestamp to '2026-05-11 19:13 UTC'."""
     return ts.replace("T", " ")[:16] + " UTC"
 
 
-def notify_anomaly(table: str, ts: str, score: float) -> None:
+def notify_anomaly(table: str, ts: str, score: float, metric: str = "row_count") -> None:
     """Send anomaly alert. Throttled per (table, event_key)."""
     event_key = "anomaly"
     if is_throttled(table, event_key):
         return
 
-    result = explain_anomaly(table, "row_count", ts)
-    is_llm = result.get("confidence", 0) > 0.3
-    body = result["explanation"] if is_llm else "Требуется ручная проверка данных."
+    result = explain_anomaly(table, metric, ts)
+    is_llm = result.get("confidence", 0) > _RULE_BASED_CONFIDENCE
+    body = result.get("explanation", "Требуется ручная проверка данных.") if is_llm else "Требуется ручная проверка данных."
 
     text = (
         f"\U0001f6a8 [{table}] Аномалия (score: {score:.4f})\n"
-        f"Обнаружена аномалия в таблице {table} по метрике row_count"
+        f"Обнаружена аномалия в таблице {table} по метрике {metric}"
         f" в момент {_fmt_ts(ts)}. {body}"
     )
     ok, error = send_message(text)
     _record(event_type="anomaly", message=text, ok=ok, error=error,
-            table=table, metric="row_count")
+            table=table, metric=metric)
     if ok:
         update_throttle(table, event_key)
 

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -136,14 +136,40 @@ def test_throttle_is_per_table_and_key(storage):
 def test_notify_anomaly_sends_message(storage, monkeypatch):
     monkeypatch.setattr(
         "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "ETL сбой", "suggested_fix": "", "confidence": 0.3},
+        lambda t, m, ts: {"explanation": "ETL сбой", "suggested_fix": "", "confidence": 0.85},
     )
     with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
         notify_anomaly("orders", _ts(), -0.14)
     mock_send.assert_called_once()
     text = mock_send.call_args[0][0]
     assert "orders" in text
+    assert "row_count" in text
+    assert "UTC" in text
     assert "ETL сбой" in text
+
+
+def test_notify_anomaly_fallback_message(storage, monkeypatch):
+    monkeypatch.setattr(
+        "app.notifications.telegram.explain_anomaly",
+        lambda t, m, ts: {"explanation": "Требуется ручная проверка.", "suggested_fix": "", "confidence": 0.3},
+    )
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
+        notify_anomaly("orders", _ts(), -0.14)
+    text = mock_send.call_args[0][0]
+    assert "orders" in text
+    assert "Требуется ручная проверка данных." in text
+
+
+def test_notify_anomaly_passes_raw_ts_to_explain(storage, monkeypatch):
+    received = {}
+    def capture(t, m, ts):
+        received["ts"] = ts
+        return {"explanation": "ok", "suggested_fix": "", "confidence": 0.85}
+    monkeypatch.setattr("app.notifications.telegram.explain_anomaly", capture)
+    raw_ts = "2026-05-12T02:36:00+00:00"
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)):
+        notify_anomaly("orders", raw_ts, -0.14)
+    assert received["ts"] == raw_ts, "explain_anomaly must receive the original ISO ts, not a formatted string"
 
 
 def test_notify_anomaly_message_contains_score(storage, monkeypatch):

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -160,16 +160,30 @@ def test_notify_anomaly_fallback_message(storage, monkeypatch):
     assert "Требуется ручная проверка данных." in text
 
 
-def test_notify_anomaly_passes_raw_ts_to_explain(storage, monkeypatch):
+def test_notify_anomaly_passes_raw_ts_and_metric_to_explain(storage, monkeypatch):
     received = {}
     def capture(t, m, ts):
         received["ts"] = ts
+        received["metric"] = m
         return {"explanation": "ok", "suggested_fix": "", "confidence": 0.85}
     monkeypatch.setattr("app.notifications.telegram.explain_anomaly", capture)
     raw_ts = "2026-05-12T02:36:00+00:00"
     with patch("app.notifications.telegram.send_message", return_value=(True, None)):
-        notify_anomaly("orders", raw_ts, -0.14)
+        notify_anomaly("orders", raw_ts, -0.14, metric="null_rate")
     assert received["ts"] == raw_ts, "explain_anomaly must receive the original ISO ts, not a formatted string"
+    assert received["metric"] == "null_rate"
+
+
+def test_notify_anomaly_metric_appears_in_message(storage, monkeypatch):
+    monkeypatch.setattr(
+        "app.notifications.telegram.explain_anomaly",
+        lambda t, m, ts: {"explanation": "высокий null", "suggested_fix": "", "confidence": 0.85},
+    )
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
+        notify_anomaly("orders", _ts(), -0.14, metric="null_rate")
+    text = mock_send.call_args[0][0]
+    assert "null_rate" in text
+    assert "высокий null" in text
 
 
 def test_notify_anomaly_message_contains_score(storage, monkeypatch):


### PR DESCRIPTION
Closes #83

## Описание

После подключения NIM LLM (#36) Telegram-сообщения об аномалиях потеряли структурированный заголовок — LLM генерировал вольный текст без упоминания таблицы, метрики и времени. Дополнительно обнаружен баг: в `explain_anomaly` передавался отформатированный timestamp вместо оригинального ISO, что ломало фильтрацию данных внутри LLM-модуля.

**Теперь:**
```
🚨 [orders] Аномалия (score: -0.1465)
Обнаружена аномалия в таблице orders по метрике row_count в момент 2026-05-12 02:36 UTC. Аномалия вызвана внезапным увеличением...
```

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены (добавлено 2 новых теста + 1 обновлён)
- [x] `pytest` проходит локально — 302 passed
- [x] Если изменена схема БД — не применимо