### PR TITLE
fix(#85): deduplicate changepoint cross-run cluster detections

### DIFF
--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -153,13 +153,19 @@ def get_latest_null_counts(table_name: str) -> dict[str, int]:
     return result
 
 
-def save_changepoints(rows: Iterable[dict]) -> int:
-    """Upsert detected change-points. Each row: {ts, table_name, metric_name,
-    score, value_before, value_after}.
+# Mirrors DEDUPE_WINDOW_HOURS in ml/changepoint — both layers use the same
+# window so within-run and cross-run deduplication behave consistently.
+_CLUSTER_WINDOW_HOURS = 72
 
-    The PRIMARY KEY (ts, table, metric) collapses repeats from successive
-    detection runs, so the table grows linearly with distinct events rather
-    than with hourly polls.
+
+def save_changepoints(rows: Iterable[dict]) -> int:
+    """Persist detected change-points with cross-run cluster deduplication.
+
+    Within a ±72 h window, at most one record is kept per
+    (table, metric, direction).  A new detection replaces the stored one only
+    when its score is strictly higher, so the best signal for each real shift
+    survives successive hourly runs.  This complements the within-run
+    deduplication already done by ml/changepoint._dedupe.
     """
     payload = []
     detected_at = _iso(datetime.now(UTC))
@@ -175,16 +181,45 @@ def save_changepoints(rows: Iterable[dict]) -> int:
         })
     if not payload:
         return 0
-    # `INSERT OR REPLACE` is the SQLite spelling; Postgres has the same
-    # behaviour via `ON CONFLICT DO UPDATE`. We only run on SQLite today.
-    stmt = text("""
+
+    insert_stmt = text("""
         INSERT OR REPLACE INTO changepoints
             (ts, table_name, metric_name, score, value_before, value_after, detected_at)
         VALUES (:ts, :table_name, :metric_name, :score, :value_before, :value_after, :detected_at)
     """)
+    cluster_query = text("""
+        SELECT rowid, score FROM changepoints
+        WHERE table_name = :t
+          AND metric_name = :m
+          AND ABS(julianday(ts) - julianday(:ts)) * 24 <= :w
+          AND (CASE WHEN value_after > value_before THEN 1 ELSE 0 END) = :dir
+    """)
+
+    saved = 0
     with get_engine().begin() as conn:
-        conn.execute(stmt, payload)
-    return len(payload)
+        for row in payload:
+            direction = 1 if row["value_after"] > row["value_before"] else 0
+            existing = conn.execute(cluster_query, {
+                "t": row["table_name"],
+                "m": row["metric_name"],
+                "ts": row["ts"],
+                "w": _CLUSTER_WINDOW_HOURS,
+                "dir": direction,
+            }).fetchall()
+
+            if not existing:
+                conn.execute(insert_stmt, row)
+                saved += 1
+            elif row["score"] > max(r.score for r in existing):
+                for old in existing:
+                    conn.execute(
+                        text("DELETE FROM changepoints WHERE rowid = :id"),
+                        {"id": old.rowid},
+                    )
+                conn.execute(insert_stmt, row)
+                saved += 1
+
+    return saved
 
 
 def get_changepoints(

--- a/tests/test_changepoint.py
+++ b/tests/test_changepoint.py
@@ -100,6 +100,50 @@ def test_save_changepoints_upserts_on_repeat(clean_metrics):
     assert rows[0]["score"] == 6.5
 
 
+def test_save_changepoints_deduplicates_cross_run_cluster(clean_metrics):
+    # Simulates the hourly-scheduler bug: the same real shift is detected
+    # across multiple runs with slightly different timestamps (±hours apart).
+    # Only the highest-score record should survive.
+    base = datetime.now(UTC) - timedelta(hours=10)
+    def _e(offset_hours: float, score: float) -> dict:
+        return {
+            "ts": (base + timedelta(hours=offset_hours)).isoformat(timespec="seconds"),
+            "table_name": "orders",
+            "metric_name": "row_count",
+            "score": score,
+            "value_before": 1000.0,
+            "value_after": 5000.0,  # all rising — same direction
+        }
+
+    save_changepoints([_e(0, 49.7)])   # run 1
+    save_changepoints([_e(1, 50.7)])   # run 2 — better, replaces
+    save_changepoints([_e(2, 51.7)])   # run 3 — better, replaces
+    save_changepoints([_e(3, 7.0)])    # run 4 — worse, ignored
+
+    rows = get_changepoints("orders")
+    assert len(rows) == 1, f"expected 1 record, got {len(rows)}"
+    assert rows[0]["score"] == 51.7
+
+
+def test_save_changepoints_preserves_opposite_directions(clean_metrics):
+    # A spike has two legitimate events: rise then fall. Both must be kept
+    # even though they fall within the 72 h dedup window.
+    base = datetime.now(UTC) - timedelta(hours=5)
+    save_changepoints([{
+        "ts": base.isoformat(timespec="seconds"),
+        "table_name": "orders", "metric_name": "row_count",
+        "score": 50.0, "value_before": 1000.0, "value_after": 5000.0,  # rise
+    }])
+    save_changepoints([{
+        "ts": (base + timedelta(hours=2)).isoformat(timespec="seconds"),
+        "table_name": "orders", "metric_name": "row_count",
+        "score": 50.0, "value_before": 5000.0, "value_after": 1000.0,  # fall
+    }])
+
+    rows = get_changepoints("orders")
+    assert len(rows) == 2, "rise and fall are separate events and must both be kept"
+
+
 # ---------------------------------------------------------------------------
 # /api/changepoints/<table>
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Описание

Фикс бага #85: детектор change-point запускался каждый час и накапливал 5–14 дублирующих записей для одного реального скачка, что выражалось в 5–14 вертикальных линиях на графике вместо одной.

**Причина:** `_dedupe` в `ml/changepoint.py` дедуплицирует точки только внутри одного запуска. Между запусками PELT находит тот же скачок с немного другим `ts` (окно сдвинулось на один новый datapoint) — каждый `ts` уникален, `INSERT OR REPLACE` честно вставляет новую строку.

**Решение:** `save_changepoints` теперь перед каждым INSERT проверяет базу на наличие записи в радиусе ±72 ч для той же `(table, metric, direction)`:
- нет конфликта → INSERT как раньше
- есть конфликт и новый score выше → удаляем старую запись, вставляем новую
- есть конфликт и новый score ≤ → пропускаем

72 ч = то же окно, что `DEDUPE_WINDOW_HOURS` в `ml/changepoint.py`, чтобы оба слоя дедупликации были согласованы.

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы