### PR TITLE
fix(#87): единый run_ts на весь запуск collect_all_tables

### DIFF
--- a/collectors/metrics_collector.py
+++ b/collectors/metrics_collector.py
@@ -10,8 +10,8 @@ class MetricsCollector:
     def __init__(self, schema: str | None = None):
         self.schema = schema
 
-    def collect(self, table_name: str) -> list[dict]:
-        ts = datetime.now(UTC)
+    def collect(self, table_name: str, ts: datetime | None = None) -> list[dict]:
+        ts = ts or datetime.now(UTC)
         rows = []
 
         try:

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -65,15 +65,18 @@ def get_scheduler() -> BackgroundScheduler | None:
 
 
 def collect_all_tables() -> None:
+    from datetime import UTC, datetime
+
     from app.db import list_tables
     from app.metrics_storage import save_metrics
     from collectors.metrics_collector import MetricsCollector
 
     logger.info("Job %s started", JOB_ID)
     collector = MetricsCollector()
+    run_ts = datetime.now(UTC)
     total_saved = 0
     for table in list_tables():
-        rows = collector.collect(table["table_name"])
+        rows = collector.collect(table["table_name"], ts=run_ts)
         if rows:
             saved = save_metrics(rows)
             total_saved += saved

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -172,7 +172,7 @@ def test_collect_uses_provided_ts(collector):
 def test_collect_all_tables_uses_single_run_ts(storage):
     # All tables collected in one scheduler run must share the same ts so
     # _history_aggregate groups them into a single run (100% coverage).
-    from unittest.mock import MagicMock, call, patch
+    from unittest.mock import MagicMock, patch
 
     import collectors.scheduler as sched_mod
 

--- a/tests/test_metrics_collector.py
+++ b/tests/test_metrics_collector.py
@@ -159,6 +159,50 @@ def test_collect_all_rows_share_same_timestamp(collector):
     assert len(timestamps) == 1
 
 
+def test_collect_uses_provided_ts(collector):
+    from datetime import UTC, datetime
+    fixed_ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    with patch("collectors.metrics_collector.db.table_stats", return_value=FAKE_STATS), \
+         patch("collectors.metrics_collector.db.column_nulls", return_value=FAKE_COLS):
+        rows = collector.collect("users", ts=fixed_ts)
+
+    assert all(r["ts"] == fixed_ts for r in rows)
+
+
+def test_collect_all_tables_uses_single_run_ts(storage):
+    # All tables collected in one scheduler run must share the same ts so
+    # _history_aggregate groups them into a single run (100% coverage).
+    from unittest.mock import MagicMock, call, patch
+
+    import collectors.scheduler as sched_mod
+
+    collected_timestamps: list = []
+
+    def fake_collect(table_name, ts=None):
+        collected_timestamps.append(ts)
+        return [{"ts": ts, "table_name": table_name,
+                 "metric_name": "row_count", "value": 1}]
+
+    fake_collector = MagicMock()
+    fake_collector.collect.side_effect = fake_collect
+
+    tables = [{"table_name": "orders"}, {"table_name": "users"}, {"table_name": "events"}]
+
+    with patch("app.db.list_tables", return_value=tables), \
+         patch("collectors.metrics_collector.MetricsCollector", return_value=fake_collector), \
+         patch("app.metrics_storage.save_metrics", return_value=1), \
+         patch("collectors.schema_collector.collect_all_schemas", return_value={"events": 0}), \
+         patch("ml.drift.compute_and_store_drift_all", return_value={}), \
+         patch("collectors.scheduler._score_recent_anomalies"):
+        sched_mod.collect_all_tables()
+
+    assert len(collected_timestamps) == 3
+    assert len(set(collected_timestamps)) == 1, (
+        "all tables must share the same run_ts — got multiple timestamps: "
+        f"{collected_timestamps}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Unit tests — _to_epoch()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Описание

Фикс бага #87: страница «История проверок» показывала один collector run как несколько строк с покрытием 75%/25% вместо одной строки 100%.

Корень — `MetricsCollector.collect()` генерировал `ts = datetime.now(UTC)` внутри себя при каждом вызове. Таблицы сохранялись с разницей в 1–2 секунды, `_history_aggregate` группировал их по точному `ts` — один запуск распадался на несколько.

**Решение:** `collect_all_tables()` генерирует `run_ts` один раз перед циклом и передаёт его в каждый вызов `collect()`. Параметр `ts` добавлен как опциональный — обратная совместимость сохранена.

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально (307/307)
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы