### PR TITLE
fix(#89): исправить формат временных меток в обзоре таблиц и уведомлениях

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from flask import Flask, jsonify, redirect
 
@@ -8,12 +9,24 @@ from .config import settings
 from .dashboard import bp as dashboard_bp
 from .dashboard import status_class
 
+_ISO_TS_RE = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})"
+)
+
+
+def _fmt_iso_in_text(text: str) -> str:
+    """Replace ISO 8601 timestamps inside a string with 'YYYY-MM-DD HH:MM UTC'."""
+    if not text:
+        return text
+    return _ISO_TS_RE.sub(lambda m: m.group()[:16].replace("T", " ") + " UTC", text)
+
 
 def create_app(config: dict | None = None):
     app = Flask(__name__)
     app.config["SECRET_KEY"] = settings.SECRET_KEY
     app.config["COLLECT_INTERVAL_MINUTES"] = settings.COLLECT_INTERVAL_MINUTES
     app.jinja_env.filters["status_class"] = status_class
+    app.jinja_env.filters["fmt_iso_in_text"] = _fmt_iso_in_text
 
     if config:
         app.config.update(config)

--- a/app/llm.py
+++ b/app/llm.py
@@ -51,14 +51,17 @@ def _build_prompt(table: str, metric: str, ts: str) -> str:
     recent_rc = [r for r in recent_rc if r["ts"] <= ts]
     recent_nr = [r for r in recent_nr if r["ts"] <= ts]
 
+    def _fmt(raw_ts: str) -> str:
+        return raw_ts[:16].replace("T", " ") + " UTC"
+
     rc_sample = [
-        f"{r['ts']}: {int(r['value'])}" for r in recent_rc[-10:]
+        f"{_fmt(r['ts'])}: {int(r['value'])}" for r in recent_rc[-10:]
     ]
     nr_sample = [
-        f"{r['ts']}: {r['value']:.3f}" for r in recent_nr[-10:]
+        f"{_fmt(r['ts'])}: {r['value']:.3f}" for r in recent_nr[-10:]
     ]
     cp_text = "\n".join(
-        f"  {c['ts']} {c['metric_name']}: {c['value_before']:.2f} → {c['value_after']:.2f}"
+        f"  {_fmt(c['ts'])} {c['metric_name']}: {c['value_before']:.2f} → {c['value_after']:.2f}"
         for c in changepoints
     ) or "  none"
     anomaly_at_ts = next(
@@ -67,14 +70,15 @@ def _build_prompt(table: str, metric: str, ts: str) -> str:
     anomaly_score_text = (
         f"{anomaly_at_ts['score']:.4f}" if anomaly_at_ts else "not available"
     )
+    ts_fmt = _fmt(ts)
 
     return f"""You are a database reliability expert. Analyze the anomaly below and explain its root cause.
 
 Table: {table}
 Schema: {schema_text}
-Anomaly detected at: {ts}
+Anomaly detected at: {ts_fmt}
 Trigger metric: {metric}
-Isolation Forest score at {ts}: {anomaly_score_text}
+Isolation Forest score at {ts_fmt}: {anomaly_score_text}
 
 Recent row_count (last 48 h):
 {chr(10).join(rc_sample) or "  no data"}

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -92,9 +92,9 @@
               <td class="px-5 py-4">
                 <details class="group">
                   <summary class="cursor-pointer text-slate-700 dark:text-slate-200">
-                    {{ (n.message or "")[:90] }}{% if n.message and n.message|length > 90 %}…{% endif %}
+                    {{ ((n.message or "")|fmt_iso_in_text)[:90] }}{% if n.message and n.message|length > 90 %}…{% endif %}
                   </summary>
-                  <pre class="mt-2 whitespace-pre-wrap rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-700 dark:bg-slate-800/70 dark:text-slate-200">{{ n.message }}</pre>
+                  <pre class="mt-2 whitespace-pre-wrap rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-700 dark:bg-slate-800/70 dark:text-slate-200">{{ (n.message or "")|fmt_iso_in_text }}</pre>
                   {% if n.error %}
                     <div class="mt-2 rounded-md bg-rose-50 px-3 py-2 text-xs text-rose-700 dark:bg-rose-900/30 dark:text-rose-200">
                       Ошибка: {{ n.error }}

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -83,7 +83,7 @@
               <td class="px-5 py-3 text-right tabular-nums">
                 {% if t.size_bytes is not none %}{{ "{:,} KB".format((t.size_bytes / 1024)|round|int).replace(",", " ") }}{% else %}—{% endif %}
               </td>
-              <td class="px-5 py-3 text-slate-600 dark:text-slate-300">{{ t.last_check or "—" }}</td>
+              <td class="px-5 py-3 text-slate-600 dark:text-slate-300">{{ (t.last_check[:16].replace("T", " ") + " UTC") if t.last_check else "—" }}</td>
               <td class="px-5 py-3 text-right">
                 <a href="/dashboard/schema/{{ t.table_name }}" class="text-xs text-slate-500 hover:text-accent dark:text-slate-400">Подробнее →</a>
               </td>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.app import create_app
+from app.app import _fmt_iso_in_text, create_app
 from app.dashboard import status_class
 
 
@@ -222,3 +222,83 @@ def test_healthz_still_works(client):
     resp = client.get("/healthz")
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# _fmt_iso_in_text Jinja2 filter (#89)
+# ---------------------------------------------------------------------------
+
+def test_fmt_iso_in_text_single_timestamp():
+    result = _fmt_iso_in_text("аномалия в 2026-05-12T09:21:00+00:00 обнаружена")
+    assert "2026-05-12 09:21 UTC" in result
+    assert "T09:21:00+00:00" not in result
+
+
+def test_fmt_iso_in_text_multiple_timestamps():
+    text = "с 2026-05-12T09:21:00+00:00 до 2026-05-12T10:21:00+00:00"
+    result = _fmt_iso_in_text(text)
+    assert "2026-05-12 09:21 UTC" in result
+    assert "2026-05-12 10:21 UTC" in result
+    assert "+00:00" not in result
+
+
+def test_fmt_iso_in_text_z_suffix():
+    result = _fmt_iso_in_text("время: 2026-05-12T09:21:00Z")
+    assert "2026-05-12 09:21 UTC" in result
+    assert "T09:21:00Z" not in result
+
+
+def test_fmt_iso_in_text_with_milliseconds():
+    result = _fmt_iso_in_text("ts: 2026-05-12T20:26:40.856465+00:00")
+    assert "2026-05-12 20:26 UTC" in result
+    assert ".856465" not in result
+
+
+def test_fmt_iso_in_text_no_timestamps_passthrough():
+    text = "обычный текст без временных меток"
+    assert _fmt_iso_in_text(text) == text
+
+
+def test_fmt_iso_in_text_empty_string():
+    assert _fmt_iso_in_text("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Overview: last_check rendered as 'YYYY-MM-DD HH:MM UTC' (#89)
+# ---------------------------------------------------------------------------
+
+def test_overview_last_check_formatted(client):
+    fake_tables = [{"table_name": "users", "schema": "public"}]
+    metrics = {
+        ("users", "row_count"): 1000,
+        ("users", "null_rate"): 0.01,
+        ("users", "size_bytes"): 32768,
+    }
+    with patch("app.dashboard.db.list_tables", return_value=fake_tables), \
+         patch("app.dashboard.get_latest_metric", side_effect=_latest_factory(metrics)):
+        resp = client.get("/dashboard")
+
+    body = resp.get_data(as_text=True)
+    assert "2026-04-29 10:00 UTC" in body
+    assert "2026-04-29T10:00:00+00:00" not in body
+
+
+# ---------------------------------------------------------------------------
+# Notifications: ISO timestamps in message body replaced on render (#89)
+# ---------------------------------------------------------------------------
+
+def test_notifications_iso_timestamps_in_body_are_formatted(client):
+    from app.metrics_storage import save_notification
+    raw_msg = (
+        "Изменение row_count с 3145 до 4995 "
+        "(с 2026-05-12T09:21:00+00:00 до 2026-05-12T10:21:00+00:00)"
+    )
+    save_notification(event_type="anomaly", message=raw_msg,
+                      status="sent", table_name="users")
+
+    resp = client.get("/dashboard/notifications")
+    body = resp.get_data(as_text=True)
+    assert "2026-05-12 09:21 UTC" in body
+    assert "2026-05-12 10:21 UTC" in body
+    assert "T09:21:00+00:00" not in body
+    assert "T10:21:00+00:00" not in body

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -29,7 +29,7 @@ def test_build_prompt_contains_table_and_ts(tmp_path, monkeypatch):
     ts = _ts()
     prompt = llm_mod._build_prompt("orders", "row_count", ts)
     assert "orders" in prompt
-    assert ts in prompt
+    assert "2026-04-20 12:00 UTC" in prompt
     assert "row_count" in prompt
     assert "id int" in prompt
     assert "Respond in Russian" in prompt
@@ -49,6 +49,8 @@ def test_build_prompt_includes_both_metrics(tmp_path, monkeypatch):
     prompt = llm_mod._build_prompt("orders", "null_rate", _ts())
     assert "500" in prompt
     assert "0.150" in prompt
+    assert "2026-04-20 12:00 UTC" in prompt
+    assert "T12:00:00+00:00" not in prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Описание

Закрывает #89.

В двух местах UI отображался сырой ISO-формат временных меток вместо читаемого `YYYY-MM-DD HH:MM UTC`.

**Обзор таблиц → «Последняя проверка»:**
- было: `2026-05-13T00:54:12+00:00`
- стало: `2026-05-13 00:54 UTC`

**Уведомления → тело сообщений:**
- было: `с 2026-05-12T09:21:00+00:00 до 2026-05-12T10:21:00+00:00`
- стало: `с 2026-05-12 09:21 UTC до 2026-05-12 10:21 UTC`

### Что изменено

**`templates/overview.html`** — форматирование `t.last_check` через срез + replace вместо вывода raw-строки.

**`app/app.py`** — добавлен Jinja2-фильтр `fmt_iso_in_text` с regex-заменой ISO-паттернов. Фильтр исправляет отображение уже хранящихся записей в БД без миграции данных.

**`templates/notifications.html`** — фильтр применён в обоих местах рендеринга сообщения (превью и полный текст в `<pre>`), оба защищены от `None` через `n.message or ""`.

**`app/llm.py`** — временные метки в промпте LLM форматируются перед подстановкой, чтобы будущие LLM-объяснения не содержали сырой ISO в Telegram и UI. Оригинальный `ts` сохранён для сравнений `r["ts"] <= ts` — логика фильтрации данных не затронута.

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы

### Новые тесты (8 новых + 2 расширенных, итого 315 проходят)

**`tests/test_dashboard.py`**
- `test_fmt_iso_in_text_single_timestamp` — замена одиночной метки `+00:00`
- `test_fmt_iso_in_text_multiple_timestamps` — несколько меток в одной строке
- `test_fmt_iso_in_text_z_suffix` — поддержка Z-суффикса
- `test_fmt_iso_in_text_with_milliseconds` — метки с долями секунды
- `test_fmt_iso_in_text_no_timestamps_passthrough` — строки без меток не изменяются
- `test_fmt_iso_in_text_empty_string` — пустая строка возвращается как есть
- `test_overview_last_check_formatted` — интеграционный: столбец рендерится как `YYYY-MM-DD HH:MM UTC`
- `test_notifications_iso_timestamps_in_body_are_formatted` — интеграционный: ISO-метки в теле уведомления заменяются при рендере

**`tests/test_llm.py`**
- `test_build_prompt_contains_table_and_ts` — обновлён под новый формат меток
- `test_build_prompt_includes_both_metrics` — расширен проверкой формата в `rc_sample`