### PR TITLE
feat(#44): Интеграционные тесты с реальными СУБД (testcontainers)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,3 +48,31 @@ jobs:
           name: coverage-report
           path: coverage.xml
           retention-days: 14
+
+  # Integration tests (#44) — spin up real Postgres / MySQL / ClickHouse via
+  # testcontainers. Slow (~3–5 min total) so we only run them on push to
+  # master, not on every PR.
+  integration:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run integration tests
+        env:
+          SECRET_KEY: test-secret
+          DATABASE_URL: postgresql://test:test@localhost/test
+        run: pytest -m integration -v --tb=short

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE ?= db-monitoring
 PORT  ?= 5001
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test lint lint-fix timescale-up timescale-down timescale-migrate
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration lint lint-fix timescale-up timescale-down timescale-migrate
 
 build:
 	docker build -t $(IMAGE) .
@@ -46,6 +46,12 @@ test:
 	docker compose run --rm --no-deps --build \
 		-v $(CURDIR)/tests:/app/tests \
 		app pytest $(ARGS)
+
+# Integration tests (#44) — real Postgres / MySQL / ClickHouse / TimescaleDB
+# via testcontainers. Requires a running Docker daemon on the host. Run
+# locally; CI invokes the same command on push to master only.
+test-integration:
+	pytest -m integration -v $(ARGS)
 
 # ── TimescaleDB metrics store (#40) ──────────────────────────────────
 timescale-up:

--- a/README.md
+++ b/README.md
@@ -229,6 +229,31 @@ python -m scripts.seed_target_db --users 50000 --products 1000 \
 
 ---
 
+## Тесты
+
+Юнит-тесты (быстрые, моки/SQLite) — каждый PR:
+
+```bash
+pytest                 # все, кроме integration (~5 c)
+```
+
+Интеграционные тесты (#44) поднимают реальные Postgres / MySQL / ClickHouse / TimescaleDB через [testcontainers-python](https://testcontainers-python.readthedocs.io/) — нужен запущенный Docker-демон. Покрывают:
+
+- `tests/integration/test_db_postgres.py` / `test_db_mysql.py` / `test_db_clickhouse.py` — диалект-специфичный SQL адаптеров на живых СУБД (3 диалекта по #42).
+- `tests/integration/test_metrics_storage_timescale.py` — `app.metrics_storage` на TimescaleDB (acceptance для #40: hypertable, `drop_chunks`, ON CONFLICT, RETURNING id).
+- `tests/integration/test_full_cycle.py` — `Postgres → MetricsCollector → SQLite storage → /api/metrics` end-to-end.
+
+Запуск локально:
+
+```bash
+make test-integration              # = pytest -m integration -v
+# или: pytest -m integration tests/integration/test_db_postgres.py -v
+```
+
+В CI отдельный job `integration` запускается **только** на push в `master` (на PR не запускается — медленно, ~3–5 мин).
+
+---
+
 ## Поддерживаемые СУБД
 
 Мониторируемая БД выбирается через scheme в `DATABASE_URL` — фабрика в `app/db.py` диспатчит вызовы в адаптер для соответствующего диалекта.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Default run skips integration tests (slow — they spin up real DBs via
+# testcontainers). Opt in with `pytest -m integration` (or `make test-integration`).
+addopts = "-m 'not integration'"
+markers = [
+    "integration: end-to-end tests that need a real DB container (slow)",
+]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,7 @@
 pytest==8.3.4
 coverage==7.13.5
 ruff==0.9.4
+
+# Integration tests (#44) — spin up real Postgres/MySQL/ClickHouse via Docker.
+# `pytest -m integration` opts in; default test runs skip these.
+testcontainers[postgres,mysql,clickhouse]==4.10.0

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,70 @@
+"""Shared helpers for integration tests (#44).
+
+Each test in this directory spins up a real database via testcontainers and
+exercises the production code path end-to-end (no SQL is mocked). Default
+``pytest`` runs skip everything in this directory — opt in with
+``pytest -m integration``.
+
+Helpers here centralise the bookkeeping that's identical across the
+adapter tests: pointing ``settings.DATABASE_URL`` at the live container and
+clearing the cached engine/adapter in ``app.db`` so the next call rebuilds
+them against the new DSN.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+@contextmanager
+def use_target_db(url: str) -> Iterator[None]:
+    """Point app.db at *url* and reset its cached engine/adapter.
+
+    Restores the previous DSN on exit. Use as a fixture or in tests that
+    only need one container DSN.
+    """
+    from app import db
+    from app.config import settings
+
+    original_url = settings.DATABASE_URL
+    original_engine = db._engine
+    original_adapter = db._adapter
+
+    settings.DATABASE_URL = url
+    db._engine = None
+    db._adapter = None
+    try:
+        yield
+    finally:
+        if db._engine is not None:
+            db._engine.dispose()
+        settings.DATABASE_URL = original_url
+        db._engine = original_engine
+        db._adapter = original_adapter
+
+
+@contextmanager
+def use_metrics_db(url: str) -> Iterator[None]:
+    """Point app.metrics_storage at *url* and reset its cached state.
+
+    Mirrors ``use_target_db`` for the monitoring-side storage.
+    """
+    from app import metrics_storage
+    from app.config import settings
+
+    original_url = settings.MONITOR_DB_URL
+    original_engine = metrics_storage._engine
+    original_initialized = metrics_storage._initialized
+
+    settings.MONITOR_DB_URL = url
+    metrics_storage._engine = None
+    metrics_storage._initialized = False
+    try:
+        yield
+    finally:
+        if metrics_storage._engine is not None:
+            metrics_storage._engine.dispose()
+        settings.MONITOR_DB_URL = original_url
+        metrics_storage._engine = original_engine
+        metrics_storage._initialized = original_initialized

--- a/tests/integration/test_db_clickhouse.py
+++ b/tests/integration/test_db_clickhouse.py
@@ -1,0 +1,123 @@
+"""End-to-end ClickHouse adapter tests against a real container (#44).
+
+Exercises ClickHouseAdapter — `system.tables`/`system.columns` introspection,
+backtick quoting, and the Nullable(...) detection in `table_schema`.
+
+NULL semantics on ClickHouse differ from Postgres/MySQL: only
+``Nullable(T)`` columns can contain NULL, so the seeded table mixes one
+nullable and one plain column to verify both branches of the generic
+``COUNT(*) - COUNT(col)`` NULL counter.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from tests.integration.conftest import use_target_db
+
+pytestmark = pytest.mark.integration
+
+testcontainers_clickhouse = pytest.importorskip("testcontainers.clickhouse")
+ClickHouseContainer = testcontainers_clickhouse.ClickHouseContainer
+
+
+def _to_sqlalchemy_url(url: str) -> str:
+    """Normalise the testcontainers URL to the clickhouse-sqlalchemy form.
+
+    ``ClickHouseContainer.get_connection_url()`` returns ``clickhouse://...``
+    which clickhouse-sqlalchemy maps to its native driver by default — but
+    being explicit (``clickhouse+native://...``) is more robust across
+    driver versions.
+    """
+    if url.startswith("clickhouse+"):
+        return url
+    return url.replace("clickhouse://", "clickhouse+native://", 1)
+
+
+@pytest.fixture(scope="module")
+def ch_container():
+    with ClickHouseContainer("clickhouse/clickhouse-server:24.8") as ch:
+        yield ch
+
+
+@pytest.fixture(scope="module")
+def ch_url(ch_container):
+    return _to_sqlalchemy_url(ch_container.get_connection_url())
+
+
+@pytest.fixture(scope="module")
+def ch_database(ch_container) -> str:
+    """ClickHouse "database" — analogous to a Postgres schema."""
+    return ch_container.get_connection_url().rsplit("/", 1)[-1]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _seed(ch_container):
+    raw_url = _to_sqlalchemy_url(ch_container.get_connection_url())
+    engine = create_engine(raw_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE users (
+                id      UInt64,
+                email   Nullable(String),
+                country String
+            ) ENGINE = MergeTree() ORDER BY id
+        """))
+        conn.execute(text(
+            "INSERT INTO users (id, email, country) VALUES "
+            "(1, 'a@x.io', 'RU'), "
+            "(2, NULL,     'US'), "
+            "(3, 'c@x.io', 'RU'), "
+            "(4, NULL,     'DE')"
+        ))
+    engine.dispose()
+
+
+def test_list_tables_returns_seeded_table(ch_url, ch_database):
+    with use_target_db(ch_url):
+        from app.db import list_tables
+        tables = list_tables(schema=ch_database)
+    names = [t["table_name"] for t in tables]
+    assert "users" in names
+
+
+def test_table_stats_reports_row_count_and_size(ch_url, ch_database):
+    with use_target_db(ch_url):
+        from app.db import table_stats
+        stats = table_stats("users", schema=ch_database)
+    assert stats is not None
+    assert stats["table_name"] == "users"
+    assert stats["row_count"] == 4
+    assert stats["size_bytes"] > 0
+
+
+def test_table_stats_returns_none_for_missing_table(ch_url, ch_database):
+    with use_target_db(ch_url):
+        from app.db import table_stats
+        assert table_stats("does_not_exist", schema=ch_database) is None
+
+
+def test_table_schema_detects_nullable(ch_url, ch_database):
+    with use_target_db(ch_url):
+        from app.db import table_schema
+        cols = table_schema("users", schema=ch_database)
+    by_name = {c["name"]: c for c in cols}
+    assert by_name["email"]["nullable"] is True
+    # Non-Nullable columns must report nullable=False even though the dialect
+    # has no SQL-standard NOT NULL keyword.
+    assert by_name["id"]["nullable"] is False
+    assert by_name["country"]["nullable"] is False
+
+
+def test_column_nulls_counts_only_nullable_columns(ch_url, ch_database):
+    with use_target_db(ch_url):
+        from app.db import column_nulls
+        cols = column_nulls("users", schema=ch_database)
+    by_name = {c["column"]: c for c in cols}
+    # 2 of 4 emails are NULL (the column is Nullable(String)).
+    assert by_name["email"]["null_count"] == 2
+    assert by_name["email"]["null_rate"] == 0.5
+    # Non-Nullable columns can't contain NULL — must report zero.
+    assert by_name["id"]["null_count"] == 0
+    assert by_name["country"]["null_count"] == 0

--- a/tests/integration/test_db_mysql.py
+++ b/tests/integration/test_db_mysql.py
@@ -1,0 +1,120 @@
+"""End-to-end MySQL adapter tests against a real container (#44).
+
+Mirrors test_db_postgres but exercises MySQLAdapter — backtick identifier
+quoting, `information_schema.tables` for stats, and the generic
+``COUNT(*) - COUNT(col)`` NULL-count path.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from tests.integration.conftest import use_target_db
+
+pytestmark = pytest.mark.integration
+
+testcontainers_mysql = pytest.importorskip("testcontainers.mysql")
+MySqlContainer = testcontainers_mysql.MySqlContainer
+
+
+@pytest.fixture(scope="module")
+def mysql_container():
+    with MySqlContainer("mysql:8.4") as my:
+        yield my
+
+
+def _to_pymysql(url: str) -> str:
+    """Force the PyMySQL driver — MySqlContainer's default is `mysql+mysqldb`,
+    but the project pins PyMySQL (and MySQLdb isn't installed).
+    """
+    for prefix in ("mysql+mysqldb://", "mysql+mysqlconnector://", "mysql://"):
+        if url.startswith(prefix):
+            return "mysql+pymysql://" + url[len(prefix):]
+    return url
+
+
+@pytest.fixture(scope="module")
+def mysql_url(mysql_container):
+    # Keep the `+pymysql` driver suffix — without it SQLAlchemy falls back to
+    # the MySQLdb (mysqlclient) driver, which isn't installed. Backend
+    # detection still routes to MySQLAdapter: `make_url(url).get_backend_name()`
+    # returns "mysql" for any `mysql[+driver]://...` form.
+    return _to_pymysql(mysql_container.get_connection_url())
+
+
+@pytest.fixture(scope="module")
+def mysql_schema(mysql_container) -> str:
+    """The MySqlContainer creates a default DB; return its name."""
+    # SQLAlchemy URL path includes the DB name (after the slash, before query).
+    return mysql_container.get_connection_url().rsplit("/", 1)[-1].split("?", 1)[0]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _seed(mysql_container):
+    engine = create_engine(_to_pymysql(mysql_container.get_connection_url()), future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE users (
+                id      INT AUTO_INCREMENT PRIMARY KEY,
+                email   VARCHAR(255),
+                country VARCHAR(8) NOT NULL
+            )
+        """))
+        conn.execute(text("""
+            INSERT INTO users (email, country) VALUES
+                ('a@x.io', 'RU'),
+                (NULL,     'US'),
+                ('c@x.io', 'RU'),
+                (NULL,     'DE')
+        """))
+        # information_schema.tables.table_rows is filled by ANALYZE on InnoDB.
+        conn.execute(text("ANALYZE TABLE users"))
+    engine.dispose()
+
+
+def test_list_tables_returns_seeded_table(mysql_url, mysql_schema):
+    with use_target_db(mysql_url):
+        from app.db import list_tables
+        tables = list_tables(schema=mysql_schema)
+    names = [t["table_name"] for t in tables]
+    assert "users" in names
+
+
+def test_table_stats_reports_row_count_and_size(mysql_url, mysql_schema):
+    with use_target_db(mysql_url):
+        from app.db import table_stats
+        stats = table_stats("users", schema=mysql_schema)
+    assert stats is not None
+    assert stats["table_name"] == "users"
+    # InnoDB row count is an estimate — for 4 rows it may report any small
+    # number, but should not be 0 after ANALYZE.
+    assert stats["row_count"] >= 1
+    assert stats["size_bytes"] > 0
+
+
+def test_table_stats_returns_none_for_missing_table(mysql_url, mysql_schema):
+    with use_target_db(mysql_url):
+        from app.db import table_stats
+        assert table_stats("does_not_exist", schema=mysql_schema) is None
+
+
+def test_table_schema_returns_columns_with_nullability(mysql_url, mysql_schema):
+    with use_target_db(mysql_url):
+        from app.db import table_schema
+        cols = table_schema("users", schema=mysql_schema)
+    by_name = {c["name"]: c for c in cols}
+    assert by_name["id"]["nullable"] is False
+    assert by_name["email"]["nullable"] is True
+    assert by_name["country"]["nullable"] is False
+
+
+def test_column_nulls_counts_email_nulls(mysql_url, mysql_schema):
+    with use_target_db(mysql_url):
+        from app.db import column_nulls
+        cols = column_nulls("users", schema=mysql_schema)
+    by_name = {c["column"]: c for c in cols}
+    assert by_name["email"]["null_count"] == 2
+    assert by_name["email"]["null_rate"] == 0.5
+    assert by_name["country"]["null_count"] == 0
+    assert by_name["id"]["null_count"] == 0

--- a/tests/integration/test_db_postgres.py
+++ b/tests/integration/test_db_postgres.py
@@ -1,0 +1,110 @@
+"""End-to-end Postgres adapter tests against a real container (#44).
+
+Runs the production adapter against a real Postgres so dialect-specific
+SQL (information_schema, pg_stat_user_tables, FILTER, quote_ident) is
+verified — not just shapes-of-mocks. The container is session-scoped to
+amortise the ~3-5s startup over all Postgres-adapter tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from tests.integration.conftest import use_target_db
+
+pytestmark = pytest.mark.integration
+
+testcontainers_postgres = pytest.importorskip("testcontainers.postgres")
+PostgresContainer = testcontainers_postgres.PostgresContainer
+
+
+@pytest.fixture(scope="module")
+def pg_container():
+    with PostgresContainer("postgres:16") as pg:
+        yield pg
+
+
+@pytest.fixture(scope="module")
+def pg_url(pg_container):
+    # Normalise to plain `postgresql://` so app.db's backend detection
+    # routes to PostgresAdapter (rather than `postgresql+psycopg2://`,
+    # which works but adds noise to URL assertions).
+    url = pg_container.get_connection_url()
+    return url.replace("postgresql+psycopg2", "postgresql")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _seed(pg_container):
+    """Create one table with a NULL and one fully-populated column."""
+    raw_url = pg_container.get_connection_url()
+    engine = create_engine(raw_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE users (
+                id      SERIAL PRIMARY KEY,
+                email   TEXT,
+                country TEXT NOT NULL
+            )
+        """))
+        conn.execute(text("""
+            INSERT INTO users (email, country) VALUES
+                ('a@x.io', 'RU'),
+                (NULL,     'US'),
+                ('c@x.io', 'RU'),
+                (NULL,     'DE')
+        """))
+        # pg_stat_user_tables.n_live_tup is populated by autovacuum; for a
+        # fresh table we need an explicit ANALYZE so table_stats returns a
+        # non-zero row_count.
+        conn.execute(text("ANALYZE users"))
+    engine.dispose()
+
+
+def test_list_tables_returns_seeded_table(pg_url):
+    with use_target_db(pg_url):
+        from app.db import list_tables
+        tables = list_tables(schema="public")
+    names = [t["table_name"] for t in tables]
+    assert "users" in names
+    assert all(t["schema"] == "public" for t in tables)
+
+
+def test_table_stats_reports_row_count_and_size(pg_url):
+    with use_target_db(pg_url):
+        from app.db import table_stats
+        stats = table_stats("users", schema="public")
+    assert stats is not None
+    assert stats["table_name"] == "users"
+    assert stats["row_count"] == 4
+    assert stats["size_bytes"] > 0
+
+
+def test_table_stats_returns_none_for_missing_table(pg_url):
+    with use_target_db(pg_url):
+        from app.db import table_stats
+        assert table_stats("does_not_exist", schema="public") is None
+
+
+def test_table_schema_returns_columns_with_nullability(pg_url):
+    with use_target_db(pg_url):
+        from app.db import table_schema
+        cols = table_schema("users", schema="public")
+    by_name = {c["name"]: c for c in cols}
+    assert by_name["id"]["nullable"] is False
+    assert by_name["email"]["nullable"] is True
+    assert by_name["country"]["nullable"] is False
+    assert "integer" in by_name["id"]["type"]
+
+
+def test_column_nulls_counts_email_nulls(pg_url):
+    with use_target_db(pg_url):
+        from app.db import column_nulls
+        cols = column_nulls("users", schema="public")
+    by_name = {c["column"]: c for c in cols}
+    # 2 of 4 emails are NULL → null_rate 0.5
+    assert by_name["email"]["null_count"] == 2
+    assert by_name["email"]["null_rate"] == 0.5
+    # NOT NULL columns must report zero
+    assert by_name["country"]["null_count"] == 0
+    assert by_name["id"]["null_count"] == 0

--- a/tests/integration/test_full_cycle.py
+++ b/tests/integration/test_full_cycle.py
@@ -1,0 +1,95 @@
+"""Full pipeline smoke (#44): real Postgres → collector → SQLite metrics → API.
+
+Spins up a real Postgres, seeds one table, runs ``MetricsCollector.collect``,
+persists via ``save_metrics`` to a temp SQLite file, then queries
+``/api/metrics/<table>`` through the Flask test client. Verifies the whole
+chain wires together — not just any single layer.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from tests.integration.conftest import use_metrics_db, use_target_db
+
+pytestmark = pytest.mark.integration
+
+testcontainers_postgres = pytest.importorskip("testcontainers.postgres")
+PostgresContainer = testcontainers_postgres.PostgresContainer
+
+
+@pytest.fixture(scope="module")
+def pg_container():
+    with PostgresContainer("postgres:16") as pg:
+        yield pg
+
+
+@pytest.fixture(scope="module")
+def pg_url(pg_container) -> str:
+    return pg_container.get_connection_url().replace(
+        "postgresql+psycopg2", "postgresql"
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _seed_monitored_db(pg_container):
+    engine = create_engine(pg_container.get_connection_url(), future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE orders (
+                id    SERIAL PRIMARY KEY,
+                total NUMERIC(10, 2) NOT NULL,
+                email TEXT
+            )
+        """))
+        conn.execute(text("""
+            INSERT INTO orders (total, email) VALUES
+                (10.00, 'a@x.io'),
+                (20.00, NULL),
+                (30.00, 'c@x.io')
+        """))
+        # Populate pg_stat_user_tables so table_stats returns row_count=3.
+        conn.execute(text("ANALYZE orders"))
+    engine.dispose()
+
+
+def test_collector_to_api_full_cycle(pg_url, tmp_path):
+    """Real Postgres → collector → SQLite metrics_storage → /api/metrics."""
+    metrics_url = f"sqlite:///{tmp_path / 'metrics.db'}"
+
+    with use_target_db(pg_url), use_metrics_db(metrics_url):
+        # 1. Collect metrics for the seeded `orders` table.
+        from collectors.metrics_collector import MetricsCollector
+
+        rows = MetricsCollector().collect("orders")
+        assert rows, "collector returned no rows for seeded table"
+
+        metric_names = {r["metric_name"] for r in rows}
+        assert {"row_count", "null_rate"}.issubset(metric_names)
+
+        # 2. Persist into the SQLite metrics store.
+        from app.metrics_storage import save_metrics
+
+        saved = save_metrics(rows)
+        assert saved == len(rows)
+
+        # 3. Read back via the public REST API using the Flask test client.
+        from app.app import create_app
+
+        app = create_app({"TESTING": True})
+        client = app.test_client()
+
+        resp = client.get("/api/metrics/orders?metric=row_count&range=24h")
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert isinstance(payload, list) and len(payload) == 1
+        assert payload[0]["value"] == 3.0
+
+        # 4. /api/tables should also list the table with its freshest metrics.
+        tables_resp = client.get("/api/tables")
+        assert tables_resp.status_code == 200
+        tables = tables_resp.get_json()
+        orders = next((t for t in tables if t["table_name"] == "orders"), None)
+        assert orders is not None
+        assert orders["row_count"] == 3.0

--- a/tests/integration/test_metrics_storage_timescale.py
+++ b/tests/integration/test_metrics_storage_timescale.py
@@ -1,0 +1,201 @@
+"""Run the metrics_storage SQLite-aimed test cases against TimescaleDB (#40).
+
+Validates the second half of #40's acceptance criteria — "full test suite
+green on TimescaleDB" — by replaying the same set of round-trip,
+upsert, and cluster-replace scenarios from ``tests/test_metrics_storage.py``
+on a real Timescale container. The container also exercises the
+``create_hypertable``/``drop_chunks`` paths that the SQLite suite cannot.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from tests.integration.conftest import use_metrics_db
+
+pytestmark = pytest.mark.integration
+
+testcontainers_postgres = pytest.importorskip("testcontainers.postgres")
+PostgresContainer = testcontainers_postgres.PostgresContainer
+
+
+# The community Timescale image bundles Postgres 16 + TimescaleDB.
+_TIMESCALE_IMAGE = "timescale/timescaledb:latest-pg16"
+
+
+@pytest.fixture(scope="module")
+def timescale_container():
+    with PostgresContainer(_TIMESCALE_IMAGE) as ts:
+        yield ts
+
+
+@pytest.fixture(scope="module")
+def timescale_url(timescale_container) -> str:
+    return timescale_container.get_connection_url().replace(
+        "postgresql+psycopg2", "postgresql"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_schema(timescale_url):
+    """Drop tables between tests so each one starts on a fresh schema.
+
+    metrics_storage.get_engine() reapplies the schema on first access via
+    ``_initialized`` — clearing it lets the next test trigger a clean
+    bootstrap (including ``create_hypertable``).
+    """
+    engine = create_engine(timescale_url, future=True)
+    with engine.begin() as conn:
+        for t in (
+            "metrics", "changepoints", "schema_snapshots", "schema_events",
+            "anomaly_scores", "drift_reports", "llm_explanations",
+            "telegram_throttle", "notifications",
+        ):
+            conn.execute(text(f"DROP TABLE IF EXISTS {t} CASCADE"))
+    engine.dispose()
+    yield
+
+
+def test_schema_creates_hypertable(timescale_url):
+    with use_metrics_db(timescale_url):
+        from app.metrics_storage import get_engine
+
+        get_engine()  # triggers _apply_schema
+        engine = create_engine(timescale_url, future=True)
+        with engine.connect() as conn:
+            count = conn.execute(text(
+                "SELECT count(*) FROM timescaledb_information.hypertables "
+                "WHERE hypertable_name = 'metrics'"
+            )).scalar()
+        engine.dispose()
+    assert count == 1, "metrics must be registered as a Timescale hypertable"
+
+
+def test_save_and_get_metrics_roundtrip(timescale_url):
+    with use_metrics_db(timescale_url):
+        from app.metrics_storage import get_metrics, save_metrics
+
+        now = datetime.now(UTC)
+        rows = [
+            {"ts": now - timedelta(hours=2), "table_name": "users",
+             "metric_name": "row_count", "value": 100},
+            {"ts": now - timedelta(hours=1), "table_name": "users",
+             "metric_name": "row_count", "value": 110},
+            {"ts": now, "table_name": "users",
+             "metric_name": "row_count", "value": 120,
+             "tags": {"column": "email"}},
+        ]
+        assert save_metrics(rows) == 3
+        result = get_metrics("users", "row_count", window=timedelta(days=1))
+
+    assert [r["value"] for r in result] == [100.0, 110.0, 120.0]
+    # ts must be coerced to an ISO string on read, even though Timescale
+    # stores a TIMESTAMPTZ — callers downstream rely on the string form.
+    assert all(isinstance(r["ts"], str) for r in result)
+    assert result[-1]["tags"] == {"column": "email"}
+
+
+def test_get_metrics_respects_window(timescale_url):
+    with use_metrics_db(timescale_url):
+        from app.metrics_storage import get_metrics, save_metrics
+
+        now = datetime.now(UTC)
+        save_metrics([
+            {"ts": now - timedelta(days=10), "table_name": "orders",
+             "metric_name": "null_rate", "value": 0.05},
+            {"ts": now - timedelta(days=2), "table_name": "orders",
+             "metric_name": "null_rate", "value": 0.06},
+            {"ts": now, "table_name": "orders",
+             "metric_name": "null_rate", "value": 0.07},
+        ])
+        result = get_metrics("orders", "null_rate", window=timedelta(days=7))
+
+    assert [r["value"] for r in result] == [0.06, 0.07]
+
+
+def test_anomaly_scores_upsert(timescale_url):
+    """ON CONFLICT (ts, table_name) DO UPDATE — replaces score on re-run."""
+    with use_metrics_db(timescale_url):
+        from app.metrics_storage import get_anomaly_scores, save_anomaly_scores
+
+        ts = datetime.now(UTC)
+        save_anomaly_scores([
+            {"ts": ts, "table_name": "users", "score": -0.3, "is_anomaly": 1}
+        ])
+        save_anomaly_scores([
+            {"ts": ts, "table_name": "users", "score": -0.9, "is_anomaly": 1}
+        ])
+        scores = get_anomaly_scores("users", window=timedelta(hours=1))
+
+    assert len(scores) == 1
+    assert scores[0]["score"] == -0.9
+
+
+def test_changepoints_cluster_replaces_lower_score(timescale_url):
+    """Within the 72h cluster window the higher-score detection wins."""
+    with use_metrics_db(timescale_url):
+        from app.metrics_storage import get_changepoints, save_changepoints
+
+        now = datetime.now(UTC)
+        save_changepoints([{
+            "ts": now - timedelta(hours=24), "table_name": "users",
+            "metric_name": "row_count", "score": 5.0,
+            "value_before": 100, "value_after": 200,
+        }])
+        save_changepoints([{
+            "ts": now - timedelta(hours=12), "table_name": "users",
+            "metric_name": "row_count", "score": 7.5,
+            "value_before": 100, "value_after": 200,
+        }])
+        cps = get_changepoints("users", window=timedelta(days=7))
+
+    assert len(cps) == 1
+    assert cps[0]["score"] == 7.5
+
+
+def test_save_notification_returns_id(timescale_url):
+    """BIGSERIAL + RETURNING id (Postgres branch of save_notification)."""
+    with use_metrics_db(timescale_url):
+        from app.metrics_storage import get_notifications, save_notification
+
+        nid = save_notification(
+            event_type="anomaly", message="boom", status="sent",
+            table_name="users", metric_name="row_count",
+        )
+        rows = get_notifications(table_name="users")
+
+    assert nid > 0
+    assert len(rows) == 1
+    assert rows[0]["id"] == nid
+    assert rows[0]["message"] == "boom"
+
+
+def test_purge_old_drops_timescale_chunks(timescale_url):
+    """drop_chunks deletes the old chunk; recent rows survive."""
+    with use_metrics_db(timescale_url):
+        from app.metrics_storage import get_metrics, purge_old, save_metrics
+
+        now = datetime.now(UTC)
+        save_metrics([
+            {"ts": now - timedelta(days=200), "table_name": "users",
+             "metric_name": "row_count", "value": 1},
+            {"ts": now, "table_name": "users",
+             "metric_name": "row_count", "value": 2},
+        ])
+        purge_old(retention_days=90)
+        remaining = get_metrics("users", "row_count", window=timedelta(days=365))
+
+    assert [r["value"] for r in remaining] == [2.0]
+
+
+def test_throttle_roundtrip(timescale_url):
+    """is_throttled returns False then True after update_throttle."""
+    with use_metrics_db(timescale_url):
+        from app.metrics_storage import is_throttled, update_throttle
+
+        assert not is_throttled("users", "anomaly_row_count")
+        update_throttle("users", "anomaly_row_count")
+        assert is_throttled("users", "anomaly_row_count")


### PR DESCRIPTION
## Summary

Закрывает #44 — поднимает реальные Postgres / MySQL / ClickHouse / TimescaleDB через `testcontainers-python` и прогоняет адаптеры из #42 + хранилище из #40 end-to-end (никаких моков SQL).

**Ветка ветвится от `feature/40-timescale-storage` (PR #91)** — нужна, чтобы test_metrics_storage_timescale.py видел Timescale-путь хранилища. Когда #91 смержится в master, эта ветка перерастёт в линейный rebase.

## Что внутри

- `requirements-dev.txt` — `testcontainers[postgres,mysql,clickhouse]==4.10.0`.
- `pyproject.toml` — маркер `integration` зарегистрирован, по умолчанию `pytest` отфильтровывает его (`addopts = -m 'not integration'`). Опт-ин через `pytest -m integration` или `make test-integration`.
- `tests/integration/conftest.py` — context managers `use_target_db` / `use_metrics_db` (сбрасывают кеш `_engine` / `_adapter` в `app.db` и `app.metrics_storage`).
- `tests/integration/test_db_postgres.py` (5 тестов) — `list_tables` / `table_stats` (после `ANALYZE`) / `table_schema` / `column_nulls` на `postgres:16`.
- `tests/integration/test_db_mysql.py` (5 тестов) — то же на `mysql:8.4` через PyMySQL.
- `tests/integration/test_db_clickhouse.py` (5 тестов) — упор на `Nullable(T)` семантику и backtick-quoting.
- `tests/integration/test_metrics_storage_timescale.py` (8 тестов) — acceptance #40: hypertable, save/get, ON CONFLICT upserts, changepoints cluster-replace через `EXTRACT(EPOCH)`, `RETURNING id`, `drop_chunks`.
- `tests/integration/test_full_cycle.py` (1 тест) — `Postgres → MetricsCollector → SQLite storage → /api/metrics` через Flask test client.
- `.github/workflows/tests.yml` — отдельный job `integration`, **только на push в master**.
- `Makefile` — `make test-integration`.
- `README.md` — раздел «Тесты».

## Verification

- `pytest` (default): **315 passed, 24 deselected** — маркер фильтрует корректно.
- `pytest -m integration -v`: **24 passed in 20.34s**
  - Postgres adapter 5/5
  - MySQL adapter 5/5
  - ClickHouse adapter 5/5
  - Timescale metrics_storage 8/8
  - Full-cycle smoke 1/1

## Test plan

- [x] Юнит-сьют не задет, маркер deselect'ит integration по умолчанию.
- [x] Все 24 интеграционных теста зелёные локально на Docker Desktop (macOS).
- [ ] CI: первый push в master с этой веткой запустит новый job `integration` — проверить, что Docker-сервис в раннере работает (использует `runs-on: ubuntu-latest`, у которого Docker предустановлен).
- [ ] После мержа #91 (Timescale storage) сделать rebase этой ветки на master.

## Closes

- Closes #44.
- Завершает acceptance "full test suite green on TimescaleDB" из #40 (PR #91).