### PR TITLE
feat(#45): E2E тесты дашборда (Playwright)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,3 +76,43 @@ jobs:
           SECRET_KEY: test-secret
           DATABASE_URL: postgresql://test:test@localhost/test
         run: pytest -m integration -v --tb=short
+
+  # E2E dashboard tests (#45) — Playwright + headless Chromium drives the
+  # live Flask app. Master-only (skipped on PRs) for the same reason as the
+  # integration job: download + browser-driven flow is slow on every PR.
+  e2e:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Install Playwright browsers
+        run: playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        env:
+          SECRET_KEY: test-secret
+          DATABASE_URL: postgresql://test:test@localhost/test
+        run: pytest -m e2e -v --tb=short
+
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-screenshots
+          path: tests/e2e/_artifacts/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ models/*
 .coverage
 coverage.xml
 htmlcov/
+tests/e2e/_artifacts/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE ?= db-monitoring
 PORT  ?= 5001
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration lint lint-fix timescale-up timescale-down timescale-migrate live-demo
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo
 
 build:
 	docker build -t $(IMAGE) .
@@ -59,6 +59,11 @@ test-integration:
 # (`make server`).
 live-demo:
 	python -m scripts.live_demo $(ARGS)
+
+# E2E dashboard tests (#45) — Playwright + headless Chromium against the live
+# Flask app. One-time setup: `playwright install chromium`.
+test-e2e:
+	pytest -m e2e -v $(ARGS)
 
 # ── TimescaleDB metrics store (#40) ──────────────────────────────────
 timescale-up:

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ Setup (один раз — выкачивает Chromium ~80 МБ):
 ```bash
 pip install -r requirements-dev.txt
 playwright install chromium
+# В CI на Ubuntu используем `playwright install --with-deps chromium` —
+# подтягивает системные libnss3/libasound2/etc. На macOS dev-машине
+# эти библиотеки уже есть.
 ```
 
 Запуск:

--- a/README.md
+++ b/README.md
@@ -269,6 +269,32 @@ make test-integration              # = pytest -m integration -v
 
 В CI отдельный job `integration` запускается **только** на push в `master` (на PR не запускается — медленно, ~3–5 мин).
 
+### E2E дашборда (Playwright)
+
+`tests/e2e/test_dashboard_ui.py` (#45) — headless Chromium ходит по реальному Flask-приложению (запущенному в отдельном потоке через `werkzeug.make_server`). Покрывает:
+
+- Рендер обзора (KPI-карточки, список таблиц).
+- Клик по строке таблицы → `/dashboard/schema/<name>` и подгрузку Plotly-графика.
+- Переключение `Строки` ↔ `NULL rate` в табах графика.
+- `/dashboard/schema` со списком колонок и типов.
+- Тогл темы (light/dark): сохранение в `localStorage` без flash на reload.
+- Empty-state: «Нет таблиц для мониторинга» / «Нет исторических метрик».
+
+Setup (один раз — выкачивает Chromium ~80 МБ):
+
+```bash
+pip install -r requirements-dev.txt
+playwright install chromium
+```
+
+Запуск:
+
+```bash
+make test-e2e                      # = pytest -m e2e -v
+```
+
+В CI отдельный job `e2e` запускается **только** на push в `master`. Скриншоты упавших тестов прикладываются как артефакт `e2e-screenshots`.
+
 ---
 
 ## Поддерживаемые СУБД

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-# Default run skips integration tests (slow — they spin up real DBs via
-# testcontainers). Opt in with `pytest -m integration` (or `make test-integration`).
-addopts = "-m 'not integration'"
+# Default run skips slow tests:
+#   integration — testcontainers DBs (#44)
+#   e2e        — Playwright + headless Chromium (#45)
+# Opt in via `pytest -m integration` / `pytest -m e2e` (or the matching Make targets).
+addopts = "-m 'not integration and not e2e'"
 markers = [
     "integration: end-to-end tests that need a real DB container (slow)",
+    "e2e: browser-driven dashboard tests via Playwright (slow)",
 ]
 
 [tool.ruff]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,8 @@ ruff==0.9.4
 # Integration tests (#44) — spin up real Postgres/MySQL/ClickHouse via Docker.
 # `pytest -m integration` opts in; default test runs skip these.
 testcontainers[postgres,mysql,clickhouse]==4.10.0
+
+# E2E dashboard tests (#45) — headless Chromium drives the live Flask app.
+# `pytest -m e2e` opts in. After install: `playwright install chromium`.
+playwright==1.50.0
+pytest-playwright==0.7.0

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,186 @@
+"""Shared fixtures for Playwright dashboard E2E tests (#45).
+
+Runs the real Flask app in a background thread (Werkzeug's
+``make_server`` — no test client mock) so Playwright can drive the
+dashboard exactly as a user would. Database introspection is stubbed at
+the ``app.db`` module level: tests don't need a live Postgres / MySQL /
+ClickHouse, just the metrics SQLite that the app already speaks.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+
+def _free_port() -> int:
+    """Bind to port 0 and read the OS-assigned port back."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# --- Seed data for the fake monitored database -----------------------------
+
+# Two tables: `users` has full metric history (chart + KPI cards), `events`
+# is registered as monitored but has no stored metrics — used to verify the
+# "Нет исторических метрик" empty-state on the chart.
+SEEDED_TABLES = [
+    {"table_name": "users", "schema": "public"},
+    {"table_name": "events", "schema": "public"},
+]
+
+SEEDED_SCHEMAS = {
+    "users": [
+        {"name": "id", "type": "integer", "nullable": False},
+        {"name": "email", "type": "text", "nullable": True},
+        {"name": "country", "type": "text", "nullable": False},
+    ],
+    "events": [
+        {"name": "id", "type": "integer", "nullable": False},
+        {"name": "event_type", "type": "text", "nullable": False},
+    ],
+}
+
+
+def _seed_metrics(metrics_url: str) -> None:
+    from app.config import settings
+
+    settings.MONITOR_DB_URL = metrics_url
+
+    from app import metrics_storage
+
+    metrics_storage._engine = None
+    metrics_storage._initialized = False
+    metrics_storage.get_engine()  # apply schema
+
+    now = datetime.now(UTC)
+    # 14 days of hourly row_count and null_rate for `users` so the chart
+    # renders a real series. `events` is left empty.
+    rows: list[dict] = []
+    for hours_ago in range(14 * 24, 0, -1):
+        ts = now - timedelta(hours=hours_ago)
+        rows.append({
+            "ts": ts, "table_name": "users",
+            "metric_name": "row_count", "value": 1000 + hours_ago,
+        })
+        rows.append({
+            "ts": ts, "table_name": "users",
+            "metric_name": "null_rate", "value": 0.05,
+            "tags": {"column": "email"},
+        })
+    rows.append({
+        "ts": now, "table_name": "users",
+        "metric_name": "size_bytes", "value": 65536,
+    })
+    metrics_storage.save_metrics(rows)
+
+
+def _patch_db_module() -> dict:
+    """Replace app.db introspection with fixture data.
+
+    Returns the originals so the teardown can restore them. The patch lives
+    at the module-attribute level (not via pytest's monkeypatch) so the
+    Flask thread, which imports app.db lazily on every request, sees the
+    stub regardless of when the request fires.
+    """
+    from app import db
+
+    originals = {
+        "list_tables": db.list_tables,
+        "table_schema": db.table_schema,
+        "table_stats": db.table_stats,
+        "column_nulls": db.column_nulls,
+        "column_distribution": db.column_distribution,
+    }
+
+    db.list_tables = lambda schema=None: list(SEEDED_TABLES)
+    db.table_schema = lambda t, schema=None: list(SEEDED_SCHEMAS.get(t, []))
+    db.table_stats = lambda t, schema=None: (
+        {"table_name": t, "schema": "public", "row_count": 1000,
+         "size_bytes": 65536, "last_analyze": None}
+        if t in SEEDED_SCHEMAS else None
+    )
+    db.column_nulls = lambda t, schema=None: []
+    db.column_distribution = lambda t, schema=None, top_n=20: []
+    return originals
+
+
+def _restore_db_module(originals: dict) -> None:
+    from app import db
+
+    for name, fn in originals.items():
+        setattr(db, name, fn)
+
+
+# --- Server fixture --------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def live_dashboard(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Start the Flask app in a background thread; yield base URL.
+
+    Scope is session so 6+ Playwright tests share one app — startup adds
+    ~200ms which we don't want to pay per test.
+    """
+    metrics_db = tmp_path_factory.mktemp("e2e") / "metrics.db"
+    _seed_metrics(f"sqlite:///{metrics_db}")
+    originals = _patch_db_module()
+
+    # Import create_app *after* the patch so the blueprints that read
+    # settings at import time see the override.
+    from app.app import create_app
+
+    app = create_app({"TESTING": True})
+    port = _free_port()
+
+    from werkzeug.serving import make_server
+
+    server = make_server("127.0.0.1", port, app, threaded=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        _restore_db_module(originals)
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args: dict) -> dict:
+    """Extend pytest-playwright's default context with a stable viewport."""
+    return {
+        **browser_context_args,
+        "viewport": {"width": 1280, "height": 800},
+    }
+
+
+# --- Artifact path helper --------------------------------------------------
+
+
+SCREENSHOT_DIR = Path(__file__).resolve().parent / "_artifacts"
+
+
+@pytest.fixture
+def screenshot_on_failure(request, page):
+    """Drop a screenshot under tests/e2e/_artifacts/ if the test fails.
+
+    Uploaded by CI as a job artifact for post-mortem debugging.
+    """
+    yield
+    rep = getattr(request.node, "rep_call", None)
+    if rep and rep.failed:
+        SCREENSHOT_DIR.mkdir(exist_ok=True)
+        page.screenshot(path=str(SCREENSHOT_DIR / f"{request.node.name}.png"))
+
+
+def pytest_runtest_makereport(item, call):  # noqa: D401 — pytest hook signature
+    """Stash the call-phase result so screenshot_on_failure can read it."""
+    if call.when == "call":
+        item.rep_call = call

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -161,26 +161,30 @@ def browser_context_args(browser_context_args: dict) -> dict:
     }
 
 
-# --- Artifact path helper --------------------------------------------------
+# --- Screenshot artifact on failure ----------------------------------------
 
 
 SCREENSHOT_DIR = Path(__file__).resolve().parent / "_artifacts"
 
 
-@pytest.fixture
-def screenshot_on_failure(request, page):
-    """Drop a screenshot under tests/e2e/_artifacts/ if the test fails.
-
-    Uploaded by CI as a job artifact for post-mortem debugging.
-    """
-    yield
-    rep = getattr(request.node, "rep_call", None)
-    if rep and rep.failed:
-        SCREENSHOT_DIR.mkdir(exist_ok=True)
-        page.screenshot(path=str(SCREENSHOT_DIR / f"{request.node.name}.png"))
-
-
 def pytest_runtest_makereport(item, call):  # noqa: D401 — pytest hook signature
-    """Stash the call-phase result so screenshot_on_failure can read it."""
-    if call.when == "call":
-        item.rep_call = call
+    """Drop a screenshot for any failing test that has a ``page`` fixture.
+
+    Implemented inline in the hook (instead of a fixture that tests have to
+    opt into) so coverage is automatic — adding a new e2e test never
+    requires remembering a fixture argument. The CI workflow uploads the
+    `_artifacts/` directory as `e2e-screenshots` when this job fails.
+    """
+    if call.when != "call" or call.excinfo is None:
+        return
+    page = item.funcargs.get("page")
+    if page is None:
+        return
+    SCREENSHOT_DIR.mkdir(exist_ok=True)
+    try:
+        page.screenshot(path=str(SCREENSHOT_DIR / f"{item.name}.png"))
+    except Exception:  # pragma: no cover - best-effort artifact
+        # If the page itself is what failed (closed context, navigation crash)
+        # we still want the original test failure to surface, not the
+        # screenshot error.
+        pass

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -167,7 +167,7 @@ def browser_context_args(browser_context_args: dict) -> dict:
 SCREENSHOT_DIR = Path(__file__).resolve().parent / "_artifacts"
 
 
-def pytest_runtest_makereport(item, call):  # noqa: D401 — pytest hook signature
+def pytest_runtest_makereport(item, call):
     """Drop a screenshot for any failing test that has a ``page`` fixture.
 
     Implemented inline in the hook (instead of a fixture that tests have to

--- a/tests/e2e/test_dashboard_ui.py
+++ b/tests/e2e/test_dashboard_ui.py
@@ -1,0 +1,134 @@
+"""Playwright dashboard E2E tests (#45).
+
+Drives the real Flask app in a headless Chromium. Tests are intentionally
+shallow — they confirm the page wires up, navigation works, the chart
+script runs, and the theme toggle persists — not exhaustive UI assertions.
+The browser process is the slow part, so we keep the suite tight.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+_ACTIVE_TAB_RE = re.compile(r"bg-accent")
+
+
+def test_overview_renders_kpi_cards_and_table_list(live_dashboard: str, page: Page):
+    page.goto(f"{live_dashboard}/dashboard")
+    # exact=True — without it, "Обзор" also matches the "Обзор таблиц" h2.
+    expect(page.get_by_role("heading", name="Обзор", exact=True)).to_be_visible()
+
+    # The three KPI labels — order is stable in the template.
+    for label in ("Мониторируется таблиц", "Всего строк", "Средний NULL %"):
+        expect(page.get_by_text(label, exact=True)).to_be_visible()
+
+    # Both seeded tables appear in the table list.
+    expect(page.get_by_role("link", name="users").first).to_be_visible()
+    expect(page.get_by_role("link", name="events").first).to_be_visible()
+
+
+def _wait_for_chart(page: Page) -> None:
+    """Block until Plotly has injected something into #chart.
+
+    Asserting visibility of .plot-container is flaky in headless Chromium —
+    Plotly initialises the container with zero dimensions before the first
+    trace draws. Checking children count is the reliable proxy: the chart
+    JS only appends when /api/metrics returns a non-empty series.
+    """
+    page.wait_for_function(
+        "() => document.querySelector('#chart')?.children.length > 0",
+        timeout=10_000,
+    )
+
+
+def test_click_table_navigates_to_detail_with_chart(live_dashboard: str, page: Page):
+    page.goto(f"{live_dashboard}/dashboard")
+    page.get_by_role("link", name="users").first.click()
+
+    expect(page).to_have_url(f"{live_dashboard}/dashboard/schema/users")
+    expect(page.get_by_role("heading", name="Таблица: users")).to_be_visible()
+
+    _wait_for_chart(page)
+    expect(page.locator("#chart-empty")).to_be_hidden()
+
+
+def test_chart_metric_toggle_redraws_plot(live_dashboard: str, page: Page):
+    page.goto(f"{live_dashboard}/dashboard/schema/users")
+    _wait_for_chart(page)
+
+    row_count_tab = page.locator("#chart-tabs button[data-metric='row_count']")
+    null_rate_tab = page.locator("#chart-tabs button[data-metric='null_rate']")
+
+    # Initial state: row_count active (bg-accent), null_rate inactive.
+    expect(row_count_tab).to_have_class(_ACTIVE_TAB_RE)
+
+    # Click the NULL rate tab — Plotly re-renders, active style swaps.
+    null_rate_tab.click()
+    expect(null_rate_tab).to_have_class(_ACTIVE_TAB_RE)
+    expect(row_count_tab).not_to_have_class(_ACTIVE_TAB_RE)
+
+    # And back — confirms the toggle is reversible.
+    row_count_tab.click()
+    expect(row_count_tab).to_have_class(_ACTIVE_TAB_RE)
+
+
+def test_schema_page_lists_table_with_columns(live_dashboard: str, page: Page):
+    page.goto(f"{live_dashboard}/dashboard/schema")
+    expect(page.get_by_role("heading", name="Схема")).to_be_visible()
+    # Seeded tables appear with their column counts.
+    expect(page.get_by_role("link", name="users").first).to_be_visible()
+    # Column names from SEEDED_SCHEMAS["users"].
+    expect(page.get_by_text("email", exact=True).first).to_be_visible()
+    expect(page.get_by_text("country", exact=True).first).to_be_visible()
+
+
+def test_theme_toggle_persists_in_localstorage(live_dashboard: str, page: Page):
+    page.goto(f"{live_dashboard}/dashboard")
+    # Default theme depends on prefers-color-scheme; force a known starting
+    # point by clearing localStorage and reloading.
+    page.evaluate("() => localStorage.removeItem('theme')")
+    page.reload()
+
+    # First click — switch to whichever isn't current, read localStorage.
+    page.locator("#theme-toggle").click()
+    stored = page.evaluate("() => localStorage.getItem('theme')")
+    assert stored in ("dark", "light")
+
+    # Reload and verify the stored theme wins (no flash → the inline head
+    # script applies the class synchronously before paint).
+    page.reload()
+    has_dark = page.evaluate(
+        "() => document.documentElement.classList.contains('dark')"
+    )
+    assert has_dark == (stored == "dark"), \
+        f"theme={stored} but dark class={'present' if has_dark else 'absent'} after reload"
+
+
+def test_empty_chart_state_on_table_without_history(live_dashboard: str, page: Page):
+    """Acceptance: «Нет исторических метрик» when a table has no row_count."""
+    page.goto(f"{live_dashboard}/dashboard/schema/events")
+
+    # The chart fetches /api/metrics/events?metric=row_count, gets an empty
+    # series, and reveals #chart-empty while keeping #chart hidden.
+    expect(page.locator("#chart-empty")).to_be_visible(timeout=10_000)
+    expect(page.locator("#chart-empty")).to_have_text(
+        "Нет исторических метрик. Запустите коллектор или сидер."
+    )
+
+
+def test_empty_overview_when_no_tables_monitored(live_dashboard: str, page: Page):
+    """Acceptance: «Нет таблиц для мониторинга» empty-state on overview."""
+    from app import db
+
+    original = db.list_tables
+    db.list_tables = lambda schema=None: []
+    try:
+        page.goto(f"{live_dashboard}/dashboard")
+        expect(page.get_by_text("Нет таблиц для мониторинга", exact=True)).to_be_visible()
+    finally:
+        db.list_tables = original

--- a/tests/e2e/test_dashboard_ui.py
+++ b/tests/e2e/test_dashboard_ui.py
@@ -35,13 +35,14 @@ def test_overview_renders_kpi_cards_and_table_list(live_dashboard: str, page: Pa
 def _wait_for_chart(page: Page) -> None:
     """Block until Plotly has injected something into #chart.
 
-    Asserting visibility of .plot-container is flaky in headless Chromium —
-    Plotly initialises the container with zero dimensions before the first
-    trace draws. Checking children count is the reliable proxy: the chart
-    JS only appends when /api/metrics returns a non-empty series.
+    Checking ``children.length > 0`` is too weak — Plotly injects its
+    container skeleton synchronously, before any trace renders. Waiting
+    for ``svg.main-svg .scatterlayer .trace`` is the closest reliable
+    proxy for "the data line is on screen": the trace group only appears
+    after the first data point has been drawn.
     """
     page.wait_for_function(
-        "() => document.querySelector('#chart')?.children.length > 0",
+        "() => document.querySelector('#chart svg.main-svg .scatterlayer .trace') !== null",
         timeout=10_000,
     )
 


### PR DESCRIPTION
## Summary

Closes #45. Headless Chromium ходит по реальному Flask-приложению, запущенному в background-потоке через `werkzeug.make_server` — никаких mock'ов test_client, никаких `requests` для проверки HTML. UI впервые покрыт автотестами.

- `requirements-dev.txt` — `playwright==1.50.0`, `pytest-playwright==0.7.0`.
- `pyproject.toml` — маркер `e2e`, дефолтный `pytest` отфильтровывает и `integration`, и `e2e` (`-m 'not integration and not e2e'`).
- `tests/e2e/conftest.py` — `live_dashboard` session-scoped fixture: SQLite metrics seed + monkeypatch `app.db.list_tables` / `table_schema` / ... → Flask на свободном порту → `base_url`. Плюс screenshot-on-failure hook.
- `tests/e2e/test_dashboard_ui.py` — 7 сценариев из acceptance:
  - Overview рендерит KPI + список таблиц
  - Click → `/dashboard/schema/<name>` + Plotly подгружается
  - Переключение метрик `row_count` ↔ `null_rate`
  - `/dashboard/schema` со списком колонок и типов
  - Theme toggle: localStorage сохраняется, без flash на reload
  - Empty-state «Нет исторических метрик» (таблица без `row_count`)
  - Empty-state «Нет таблиц для мониторинга» (пустой `list_tables`)
- `.github/workflows/tests.yml` — новый job `e2e`, **только на push в master**. Устанавливает Chromium через `playwright install --with-deps`. Скриншоты падений → артефакт `e2e-screenshots` (retention 14 дней).
- `Makefile` — `make test-e2e`.
- `README.md` — раздел "E2E дашборда (Playwright)" с setup'ом.
- `.gitignore` — `tests/e2e/_artifacts/`.

## Verification

- `pytest` (default): **315 passed, 31 deselected** (24 integration + 7 e2e). Маркер работает.
- `pytest -m e2e -v`: **7 passed in 7.98s** локально на Chromium 133 headless.

## Test plan

- [x] Юнит-сьют не задет (315 всё ещё green).
- [x] Все 7 e2e-сценариев зелёные локально.
- [ ] CI: первый push в master запустит новый `e2e` job — проверить, что `playwright install --with-deps chromium` работает на ubuntu-latest.

## Не входит в этот PR

- Visual regression testing (отдельная задача).
- Покрытие `/dashboard/history` и `/dashboard/notifications` — добавим, если станут проблемными зонами.