### PR TITLE
docs: README — TOC + раздел «Хранилище метрик» (Timescale, #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 - [ML-фичи](#ml-фичи)
 - [Schema drift detection](#schema-drift-detection)
 - [REST API](#rest-api)
+- [Тесты](#тесты)
+- [Хранилище метрик](#хранилище-метрик)
 - [Поддерживаемые СУБД](#поддерживаемые-субд)
 - [Запуск в Docker](#запуск-в-docker)
 - [Переменные окружения](#переменные-окружения)
@@ -300,6 +302,31 @@ make test-e2e                      # = pytest -m e2e -v
 
 ---
 
+## Хранилище метрик
+
+Метрики коллектора (`row_count`, `null_rate`, schema-snapshots, anomaly scores, change-points, …) хранятся в отдельной БД, выбираемой через `MONITOR_DB_URL`:
+
+- **SQLite** (по умолчанию, `sqlite:///monitor.db`) — нулевая настройка для разработки и MVP. Хватает на 14-дневную историю при 4–10 таблицах.
+- **PostgreSQL + TimescaleDB** (опционально, #40) — для длинных историй и масштаба. `metrics` становится hypertable, retention идёт через `drop_chunks` вместо row-by-row DELETE.
+
+```bash
+# Поднять Timescale-контейнер (порт 5433, профиль `timescale`)
+make timescale-up
+
+# Указать новый DSN в .env:
+#   MONITOR_DB_URL=postgresql://postgres:dev@localhost:5433/metrics
+
+# Перенести историю SQLite → Timescale
+make timescale-migrate                              # = scripts.migrate_metrics_to_timescale
+make timescale-migrate ARGS="--reset"               # truncate append-таблиц перед загрузкой
+
+make timescale-down                                 # остановить
+```
+
+Тот же `app.metrics_storage` работает на обоих бэкендах через единый интерфейс — переключение управляется только DSN. На plain Postgres (без расширения) тоже работает: `CREATE EXTENSION timescaledb` и `create_hypertable` пропускаются, остаётся обычная таблица с DELETE-retention.
+
+---
+
 ## Поддерживаемые СУБД
 
 Мониторируемая БД выбирается через scheme в `DATABASE_URL` — фабрика в `app/db.py` диспатчит вызовы в адаптер для соответствующего диалекта.
@@ -377,7 +404,7 @@ DATABASE_URL=postgresql://postgres.<project>:<PASSWORD>@aws-0-<region>.pooler.su
 | Переменная           | Обязательная | По умолчанию              | Описание                                      |
 |----------------------|:------------:|---------------------------|-----------------------------------------------|
 | `DATABASE_URL`       | ✅           | —                         | DSN мониторируемой БД (Postgres/MySQL/CH)     |
-| `MONITOR_DB_URL`     | —            | `sqlite:///monitor.db`    | DSN хранилища метрик                          |
+| `MONITOR_DB_URL`     | —            | `sqlite:///monitor.db`    | DSN хранилища метрик (SQLite или Postgres/Timescale — см. [Хранилище метрик](#хранилище-метрик)) |
 | `MONITORED_SCHEMA`   | —            | `public`                  | Схема Postgres / БД для MySQL/CH              |
 | `SECRET_KEY`         | ✅           | —                         | Секрет для Flask-сессий/CSRF                  |
 | `COLLECT_INTERVAL_MINUTES` | —      | `15`                      | Интервал коллектора метрик                    |


### PR DESCRIPTION
## Summary

README не упоминал TimescaleDB-бэкенд (#40) и не имел в TOC появившегося с #44/#45 раздела «Тесты». Этот PR закрывает оба пробела — никаких изменений в коде.

### Что поменялось

- **TOC** — добавлены «Тесты» и «Хранилище метрик».
- **Новый раздел «Хранилище метрик»** перед «Поддерживаемые СУБД»: документирует выбор бэкенда через `MONITOR_DB_URL`, опциональный Postgres+TimescaleDB, make-таргеты `timescale-up/down/migrate`, миграцию SQLite → Timescale (`scripts/migrate_metrics_to_timescale.py`), graceful-fallback на plain Postgres без расширения.
- **Env-vars table** — описание `MONITOR_DB_URL` теперь ссылается на новый раздел.

### Какие фичи теперь видны в README

| Issue | Тип | Где упомянуто (после PR) |
|---|---|---|
| #40 — Timescale storage | Code+ops | **NEW:** «Хранилище метрик», обновлённый env-var, ранее не упоминалось |
| #44 — testcontainers | Tests | «Тесты» → подраздел про integration (уже было) |
| #45 — Playwright | Tests | «Тесты» → подраздел E2E (уже было) |
| #75 — Live demo | Demo | «Демо-данные» → «Live demo» (уже было) |

## Test plan

- [x] `grep -n "## " README.md` — TOC соответствует структуре.
- [x] Все ссылки в TOC ведут на существующие anchors.
- [ ] Визуальный осмотр после мерджа.