### PR TITLE
feat(#50): Project model — CRUD «мои проекты»

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -11,6 +11,8 @@ from .auth import bp as auth_bp
 from .config import settings
 from .dashboard import bp as dashboard_bp
 from .dashboard import status_class
+from .projects import bp as projects_bp
+from .projects import load_current_project_into_g
 from .security import init_logging_filter
 
 _ISO_TS_RE = re.compile(
@@ -120,19 +122,25 @@ def create_app(config: dict | None = None):
     app.register_blueprint(api)
     app.register_blueprint(admin_bp)
     app.register_blueprint(dashboard_bp)
+    app.register_blueprint(projects_bp)
 
-    # Gate the HTML surface (dashboard + admin) behind login. Done as an
-    # app-level before_request with path-based dispatch (not a blueprint
-    # hook) because blueprints are module-level objects shared across
-    # `create_app()` calls — Flask refuses a second `before_request` once
-    # they've been registered once.
-    _PROTECTED_PREFIXES = ("/dashboard", "/admin")
+    # Gate the HTML surface (dashboard + admin + projects) behind login.
+    # Done as an app-level before_request with path-based dispatch (not a
+    # blueprint hook) because blueprints are module-level objects shared
+    # across `create_app()` calls — Flask refuses a second `before_request`
+    # once they've been registered once.
+    _PROTECTED_PREFIXES = ("/dashboard", "/admin", "/projects")
     @app.before_request
     def _require_login_for_html():
         from flask import request
         if request.path.startswith(_PROTECTED_PREFIXES):
             return _abort_if_unauthenticated()
         return None
+
+    # Populate g.current_project on every request for authenticated users.
+    # Runs *after* the login gate above (Flask runs before_request hooks in
+    # registration order), so anonymous requests never hit the DB lookup.
+    app.before_request(load_current_project_into_g)
 
     @app.route("/")
     def index():

--- a/app/auth.py
+++ b/app/auth.py
@@ -195,6 +195,11 @@ def register():
         # still set via login_user so the user lands on /dashboard without
         # a second auth round-trip.
         login_user(User(row))
+        # Auto-create the "Default" project (#50 acceptance) so the new
+        # user never sees an empty projects switcher. Lazy import to avoid
+        # a circular dependency (projects → auth.User for current_user).
+        from app.projects import create_default_project_for
+        create_default_project_for(row["id"])
         flash("Аккаунт создан. Добро пожаловать!", "success")
         return redirect(url_for("dashboard.overview"))
     return render_template("auth/register.html", form=form)

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -1272,6 +1272,101 @@ def clear_failed_logins(email: str) -> int:
     return result.rowcount or 0
 
 
+# --- Projects (#50) --------------------------------------------------------
+
+
+class ProjectSlugTaken(Exception):
+    """Raised by create_project when (user_id, slug) is already used."""
+
+
+def create_project(project_id: str, user_id: str, name: str, slug: str) -> dict:
+    """Insert a new project. Raises ProjectSlugTaken on UNIQUE violation.
+
+    Slug must already be normalised (lower-cased, URL-safe) by the caller.
+    """
+    # Pre-check keeps ProjectSlugTaken trustworthy if future schema adds
+    # other UNIQUEs (see same pattern in create_user). Race window is benign:
+    # the IntegrityError fallback re-checks before re-raising.
+    if get_project_by_slug(user_id, slug) is not None:
+        raise ProjectSlugTaken(slug)
+    now = _iso(datetime.now(UTC))
+    payload = {
+        "id": project_id, "user_id": user_id,
+        "name": name, "slug": slug, "created_at": now,
+    }
+    stmt = text(
+        "INSERT INTO projects (id, user_id, name, slug, created_at) "
+        "VALUES (:id, :user_id, :name, :slug, :created_at)"
+    )
+    try:
+        with get_engine().begin() as conn:
+            conn.execute(stmt, payload)
+    except IntegrityError:
+        if get_project_by_slug(user_id, slug) is not None:
+            raise ProjectSlugTaken(slug) from None
+        raise
+    return payload
+
+
+def _row_to_project(row) -> dict | None:
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "user_id": row[1],
+        "name": row[2],
+        "slug": row[3],
+        "created_at": _normalize_ts(row[4]),
+    }
+
+
+def get_project_by_slug(user_id: str, slug: str) -> dict | None:
+    """Scoped to user — never returns another user's project even on slug match."""
+    stmt = text(
+        "SELECT id, user_id, name, slug, created_at FROM projects "
+        "WHERE user_id = :user_id AND slug = :slug"
+    )
+    with get_engine().connect() as conn:
+        row = conn.execute(stmt, {"user_id": user_id, "slug": slug}).fetchone()
+    return _row_to_project(row)
+
+
+def get_project_by_id(user_id: str, project_id: str) -> dict | None:
+    """Scoped to user. Returns None if the project belongs to someone else
+    even when the id is correct — defence against horizontal escalation."""
+    stmt = text(
+        "SELECT id, user_id, name, slug, created_at FROM projects "
+        "WHERE id = :id AND user_id = :user_id"
+    )
+    with get_engine().connect() as conn:
+        row = conn.execute(stmt, {"id": project_id, "user_id": user_id}).fetchone()
+    return _row_to_project(row)
+
+
+def list_projects_for_user(user_id: str) -> list[dict]:
+    stmt = text(
+        "SELECT id, user_id, name, slug, created_at FROM projects "
+        "WHERE user_id = :user_id ORDER BY created_at"
+    )
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt, {"user_id": user_id}).fetchall()
+    return [_row_to_project(r) for r in rows]
+
+
+def delete_project(user_id: str, project_id: str) -> bool:
+    """Hard delete. Returns True if a row was removed (i.e. the project
+    existed and belonged to this user)."""
+    stmt = text(
+        "DELETE FROM projects WHERE id = :id AND user_id = :user_id"
+    )
+    with get_engine().begin() as conn:
+        result = conn.execute(stmt, {"id": project_id, "user_id": user_id})
+    return (result.rowcount or 0) > 0
+
+
+# --- /Projects -------------------------------------------------------------
+
+
 def record_successful_login(user_id: str, email: str) -> None:
     """Atomic side-effects of a successful login: stamp last_login_at AND
     clear the email's failed-login counter, both in one transaction.

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 
@@ -42,7 +42,18 @@ def _new_engine() -> Engine:
     kwargs: dict[str, Any] = {"future": True}
     if url.startswith("sqlite"):
         kwargs["connect_args"] = {"check_same_thread": False}
-    return create_engine(url, **kwargs)
+    engine = create_engine(url, **kwargs)
+    if url.startswith("sqlite"):
+        # SQLite parses FK clauses but enforces them only when this PRAGMA
+        # is ON, and it has to be set on every new connection. Without it,
+        # `ON DELETE CASCADE` (projects → users, future #51 connections →
+        # projects) silently fails to fire on the MVP backend.
+        @event.listens_for(engine, "connect")
+        def _enable_sqlite_fk(dbapi_connection, _record):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys = ON")
+            cursor.close()
+    return engine
 
 
 def get_engine() -> Engine:

--- a/app/projects.py
+++ b/app/projects.py
@@ -61,18 +61,12 @@ class ProjectForm(FlaskForm):
             Regexp(
                 _SLUG_RE,
                 message="Слаг: латиница, цифры, дефисы; начинается и "
-                "заканчивается на буквой или цифрой.",
+                "заканчивается буквой или цифрой.",
             ),
         ],
         render_kw={"autocomplete": "off"},
     )
     submit = SubmitField("Создать")
-
-
-def _slugify(value: str) -> str:
-    """Best-effort slug from a name (used as a default for the form)."""
-    s = re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-")
-    return s[:40] or "project"
 
 
 # --- Routes ---------------------------------------------------------------
@@ -177,8 +171,12 @@ def load_current_project_into_g() -> None:
     """before_request hook: populates ``g.current_project`` so templates
     can render the header switcher without each route doing the lookup.
 
-    Pure-read: never mutates the session beyond the implicit pop-on-stale
-    that happens when the stored id no longer belongs to the user.
+    Side-effecting under a read-y name: mutates the session in two cases —
+    (a) drops ``current_project_id`` if the stored id no longer belongs to
+    the current user (stale after delete / cross-account session reuse),
+    (b) seeds ``current_project_id`` to the user's first project so the
+    header switcher has a current value on first visit after registration.
+    Both writes are idempotent.
     """
     g.current_project = None
     g.user_projects = []

--- a/app/projects.py
+++ b/app/projects.py
@@ -1,0 +1,203 @@
+"""Projects blueprint for #50 (Sprint 3 multi-tenant epic).
+
+Each authenticated user owns a list of projects; a project is a container
+for the DB connections that will land in #51. Every storage helper
+filters by ``user_id`` so URL-guessing a sibling user's slug can't escalate.
+
+Routes:
+- ``GET  /projects``                — list the user's projects
+- ``GET  /projects/new``            — create form
+- ``POST /projects/new``            — create
+- ``GET  /projects/<slug>``         — detail (placeholder until #51)
+- ``POST /projects/<slug>/delete``  — hard delete
+- ``POST /projects/<slug>/switch``  — set session.current_project_id
+
+Cross-cutting concerns:
+- ``g.current_project`` is populated in a before_request hook (see
+  ``app/app.py``); templates use it for the header switcher.
+- New users get a "Default" project auto-created on register; the
+  create_user_default_project helper is invoked from ``app/auth.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    g,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from flask_login import current_user, login_required
+from flask_wtf import FlaskForm
+from wtforms import StringField, SubmitField
+from wtforms.validators import DataRequired, Length, Regexp
+
+from app import metrics_storage
+
+bp = Blueprint("projects", __name__, url_prefix="/projects")
+
+_SLUG_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$")
+
+
+class ProjectForm(FlaskForm):
+    name = StringField(
+        "Название",
+        validators=[DataRequired(), Length(min=1, max=80)],
+        render_kw={"autocomplete": "off", "autofocus": True},
+    )
+    slug = StringField(
+        "Слаг",
+        validators=[
+            DataRequired(),
+            Length(min=1, max=40),
+            Regexp(
+                _SLUG_RE,
+                message="Слаг: латиница, цифры, дефисы; начинается и "
+                "заканчивается на буквой или цифрой.",
+            ),
+        ],
+        render_kw={"autocomplete": "off"},
+    )
+    submit = SubmitField("Создать")
+
+
+def _slugify(value: str) -> str:
+    """Best-effort slug from a name (used as a default for the form)."""
+    s = re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-")
+    return s[:40] or "project"
+
+
+# --- Routes ---------------------------------------------------------------
+
+
+@bp.route("")
+@bp.route("/")
+@login_required
+def list_projects():
+    projects = metrics_storage.list_projects_for_user(current_user.id)
+    return render_template("projects/list.html", projects=projects)
+
+
+@bp.route("/new", methods=["GET", "POST"])
+@login_required
+def new_project():
+    form = ProjectForm()
+    if form.validate_on_submit():
+        name = form.name.data.strip()
+        slug = form.slug.data.strip().lower()
+        try:
+            project = metrics_storage.create_project(
+                project_id=uuid.uuid4().hex,
+                user_id=current_user.id,
+                name=name,
+                slug=slug,
+            )
+        except metrics_storage.ProjectSlugTaken:
+            form.slug.errors.append("Проект с таким слагом уже существует.")
+            return render_template("projects/new.html", form=form), 409
+        # New project becomes the current one — saves a click.
+        session["current_project_id"] = project["id"]
+        flash(f"Проект «{name}» создан.", "success")
+        return redirect(url_for("projects.detail", slug=slug))
+    return render_template("projects/new.html", form=form)
+
+
+def _require_owned_project(slug: str) -> dict:
+    """Lookup-or-404 scoped to the current user. Centralises the ownership
+    check so every route gets it right by default."""
+    project = metrics_storage.get_project_by_slug(current_user.id, slug)
+    if project is None:
+        abort(404)
+    return project
+
+
+@bp.route("/<slug>")
+@login_required
+def detail(slug: str):
+    project = _require_owned_project(slug)
+    # Placeholder: real content lands with #51 (DB connections).
+    return render_template("projects/detail.html", project=project)
+
+
+@bp.route("/<slug>/delete", methods=["POST"])
+@login_required
+def delete(slug: str):
+    project = _require_owned_project(slug)
+    metrics_storage.delete_project(current_user.id, project["id"])
+    # If we just deleted the current project, fall back to the first
+    # remaining one (or clear the slot — list view will pick again).
+    if session.get("current_project_id") == project["id"]:
+        session.pop("current_project_id", None)
+    flash(f"Проект «{project['name']}» удалён.", "info")
+    return redirect(url_for("projects.list_projects"))
+
+
+@bp.route("/<slug>/switch", methods=["POST"])
+@login_required
+def switch(slug: str):
+    project = _require_owned_project(slug)
+    session["current_project_id"] = project["id"]
+    # Honour ?next= if present and safe — same allowlist policy as
+    # auth.login. Falls back to dashboard.
+    from app.auth import _safe_next
+
+    target = _safe_next(request.args.get("next")) or url_for("dashboard.overview")
+    return redirect(target)
+
+
+# --- Helpers used by other blueprints -------------------------------------
+
+
+def create_default_project_for(user_id: str) -> dict:
+    """Auto-create the "Default" project on user registration (#50 acceptance).
+
+    Called from ``app/auth.py::register``. Idempotent: if the user somehow
+    already has a "default" project (e.g. retry after a crash), returns it.
+    """
+    existing = metrics_storage.get_project_by_slug(user_id, "default")
+    if existing is not None:
+        return existing
+    return metrics_storage.create_project(
+        project_id=uuid.uuid4().hex,
+        user_id=user_id,
+        name="Default",
+        slug="default",
+    )
+
+
+def load_current_project_into_g() -> None:
+    """before_request hook: populates ``g.current_project`` so templates
+    can render the header switcher without each route doing the lookup.
+
+    Pure-read: never mutates the session beyond the implicit pop-on-stale
+    that happens when the stored id no longer belongs to the user.
+    """
+    g.current_project = None
+    g.user_projects = []
+    if not current_user.is_authenticated:
+        return
+    g.user_projects = metrics_storage.list_projects_for_user(current_user.id)
+    if not g.user_projects:
+        session.pop("current_project_id", None)
+        return
+    stored_id = session.get("current_project_id")
+    if stored_id:
+        for p in g.user_projects:
+            if p["id"] == stored_id:
+                g.current_project = p
+                return
+        # Stored id doesn't belong to this user any more (deleted, or the
+        # session is reused across accounts). Drop it.
+        session.pop("current_project_id", None)
+    # Default: pick the first project so the header switcher has something
+    # to show even on first visit after registration.
+    g.current_project = g.user_projects[0]
+    session["current_project_id"] = g.current_project["id"]

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -148,16 +148,23 @@ CREATE TABLE IF NOT EXISTS users (
 -- Projects (#50). Каждый юзер видит ТОЛЬКО свои проекты (фильтр по
 -- user_id во всех запросах + UNIQUE(user_id, slug)). Slug per-user, чтобы
 -- два юзера могли независимо назвать свой проект "default".
+--
+-- UNIQUE(user_id, slug) автоматически создаёт композитный индекс с
+-- ведущим user_id — этого достаточно и для list_projects_for_user
+-- (WHERE user_id=?), и для get_project_by_slug (WHERE user_id=? AND slug=?).
+-- Отдельный индекс по user_id был бы дублированием.
 CREATE TABLE IF NOT EXISTS projects (
     id          TEXT NOT NULL PRIMARY KEY,
     user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     name        TEXT NOT NULL,
     slug        TEXT NOT NULL,
     created_at  TEXT NOT NULL,
-    UNIQUE (user_id, slug)
+    UNIQUE (user_id, slug),
+    -- Belt-and-braces защита поверх .lower() в app/projects.py — ловит
+    -- любой raw INSERT мимо нормализации (см. зеркальный CHECK на
+    -- users.email и failed_login_attempts.email).
+    CHECK (slug = LOWER(slug))
 );
-
-CREATE INDEX IF NOT EXISTS idx_projects_user ON projects (user_id);
 
 -- Failed login attempts (#56). Используется для per-email lockout после
 -- 5 неуспешных попыток в окне 15 минут. Append-only лог: успешный логин

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -145,6 +145,20 @@ CREATE TABLE IF NOT EXISTS users (
     CHECK (email = LOWER(email))
 );
 
+-- Projects (#50). Каждый юзер видит ТОЛЬКО свои проекты (фильтр по
+-- user_id во всех запросах + UNIQUE(user_id, slug)). Slug per-user, чтобы
+-- два юзера могли независимо назвать свой проект "default".
+CREATE TABLE IF NOT EXISTS projects (
+    id          TEXT NOT NULL PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL,
+    slug        TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    UNIQUE (user_id, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_projects_user ON projects (user_id);
+
 -- Failed login attempts (#56). Используется для per-email lockout после
 -- 5 неуспешных попыток в окне 15 минут. Append-only лог: успешный логин
 -- ничего не пишет, очистка — purge_old_failed_logins по retention.

--- a/scripts/migrate_metrics_to_timescale.py
+++ b/scripts/migrate_metrics_to_timescale.py
@@ -66,6 +66,10 @@ _KEYED_TABLES: dict[str, tuple[list[str], list[str]]] = {
         ["id", "email", "password_hash", "created_at", "last_login_at"],
         ["id"],
     ),
+    "projects": (
+        ["id", "user_id", "name", "slug", "created_at"],
+        ["id"],
+    ),
 }
 
 # Append-only tables — no PK, idempotency requires --reset.

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -144,10 +144,11 @@ CREATE TABLE IF NOT EXISTS projects (
     name        TEXT NOT NULL,
     slug        TEXT NOT NULL,
     created_at  TIMESTAMPTZ NOT NULL,
-    UNIQUE (user_id, slug)
+    UNIQUE (user_id, slug),
+    -- Mirror the slug CHECK from metrics_schema.sql — see the comment
+    -- there.
+    CHECK (slug = LOWER(slug))
 );
-
-CREATE INDEX IF NOT EXISTS idx_projects_user ON projects (user_id);
 
 CREATE TABLE IF NOT EXISTS failed_login_attempts (
     email        TEXT NOT NULL,

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -138,6 +138,17 @@ CREATE TABLE IF NOT EXISTS users (
     CHECK (email = LOWER(email))
 );
 
+CREATE TABLE IF NOT EXISTS projects (
+    id          TEXT NOT NULL PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL,
+    slug        TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL,
+    UNIQUE (user_id, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_projects_user ON projects (user_id);
+
 CREATE TABLE IF NOT EXISTS failed_login_attempts (
     email        TEXT NOT NULL,
     attempted_at TIMESTAMPTZ NOT NULL,

--- a/templates/_flash.html
+++ b/templates/_flash.html
@@ -1,0 +1,17 @@
+{# Shared flash-message renderer. Include from any page that wants Flask
+   `flash()` output styled to the design language. Supports `success`,
+   `error`, `info` (default) categories. #}
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for category, message in messages %}
+        <div class="rounded-md border px-4 py-2 text-sm
+          {% if category == 'success' %}border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-200
+          {% elif category == 'error' %}border-red-200 bg-red-50 text-red-800 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-200
+          {% else %}border-slate-200 bg-white text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200{% endif %}">
+          {{ message }}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endwith %}

--- a/templates/auth/_layout.html
+++ b/templates/auth/_layout.html
@@ -33,20 +33,7 @@
           <span class="text-lg font-semibold">DB Monitor</span>
         </div>
 
-        {% with messages = get_flashed_messages(with_categories=true) %}
-          {% if messages %}
-            <div class="mb-4 space-y-2">
-              {% for category, message in messages %}
-                <div class="rounded-md border px-4 py-2 text-sm
-                  {% if category == 'success' %}border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-200
-                  {% elif category == 'error' %}border-red-200 bg-red-50 text-red-800 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-200
-                  {% else %}border-slate-200 bg-white text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200{% endif %}">
-                  {{ message }}
-                </div>
-              {% endfor %}
-            </div>
-          {% endif %}
-        {% endwith %}
+        {% include "_flash.html" %}
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
           <h1 class="text-xl font-semibold tracking-tight">{% block heading %}{% endblock %}</h1>

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,6 +54,7 @@
             ("/dashboard/history", "История", "M12 8v4l3 3M4 4h16M4 20h16", "exact"),
             ("/dashboard/notifications", "Уведомления", "M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2c0 .5-.2 1-.6 1.4L4 17h5m6 0a3 3 0 1 1-6 0", "exact"),
           ] %}
+          {% set sections = sections + [("/projects", "Проекты", "M3 7h18M3 12h18M3 17h18", "exact")] %}
           {% for url, label, path, mode in sections %}
             {% set active = (request.path == url) %}
             <a href="{{ url }}" class="flex items-center gap-2 rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 {% if active %}bg-slate-100 font-medium text-slate-900 dark:bg-slate-800 dark:text-white{% endif %}">
@@ -70,6 +71,35 @@
             {% block breadcrumb %}<span>Обзор</span>{% endblock %}
           </div>
           <div class="flex items-center gap-3">
+            {# Project switcher (#50). Only rendered when load_current_project_into_g
+               has populated `g`, which means the request is from an authenticated
+               user. The dropdown lists every project; selecting one POSTs to
+               /projects/<slug>/switch to update session.current_project_id. #}
+            {% if g.get('current_project') %}
+              <details class="relative">
+                <summary class="flex cursor-pointer items-center gap-2 rounded-md border border-slate-200 px-3 py-1 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
+                  <span class="font-medium">{{ g.current_project.name }}</span>
+                  <span class="text-xs text-slate-400">▾</span>
+                </summary>
+                <div class="absolute right-0 z-10 mt-1 w-56 overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg dark:border-slate-800 dark:bg-slate-900">
+                  <ul class="divide-y divide-slate-100 dark:divide-slate-800">
+                    {% for p in g.get('user_projects', []) %}
+                      <li>
+                        {% if p.id == g.current_project.id %}
+                          <span class="block px-3 py-2 text-sm font-medium text-slate-900 dark:text-slate-100">{{ p.name }}</span>
+                        {% else %}
+                          <form method="POST" action="{{ url_for('projects.switch', slug=p.slug) }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="block w-full px-3 py-2 text-left text-sm text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800">{{ p.name }}</button>
+                          </form>
+                        {% endif %}
+                      </li>
+                    {% endfor %}
+                  </ul>
+                  <a href="{{ url_for('projects.list_projects') }}" class="block border-t border-slate-200 px-3 py-2 text-xs text-slate-500 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-400 dark:hover:bg-slate-800">Управление проектами →</a>
+                </div>
+              </details>
+            {% endif %}
             <button id="theme-toggle" type="button" aria-label="Toggle theme"
                     class="flex h-8 w-8 items-center justify-center rounded-md border border-slate-200 text-slate-500 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
               <svg class="h-4 w-4 dark:hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,7 +54,9 @@
             ("/dashboard/history", "История", "M12 8v4l3 3M4 4h16M4 20h16", "exact"),
             ("/dashboard/notifications", "Уведомления", "M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2c0 .5-.2 1-.6 1.4L4 17h5m6 0a3 3 0 1 1-6 0", "exact"),
           ] %}
-          {% set sections = sections + [("/projects", "Проекты", "M3 7h18M3 12h18M3 17h18", "exact")] %}
+          {# Folder icon — distinct from the Схема hamburger so the
+             sidebar rail scans cleanly. #}
+          {% set sections = sections + [("/projects", "Проекты", "M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z", "exact")] %}
           {% for url, label, path, mode in sections %}
             {% set active = (request.path == url) %}
             <a href="{{ url }}" class="flex items-center gap-2 rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 {% if active %}bg-slate-100 font-medium text-slate-900 dark:bg-slate-800 dark:text-white{% endif %}">
@@ -81,8 +83,8 @@
                   <span class="font-medium">{{ g.current_project.name }}</span>
                   <span class="text-xs text-slate-400">▾</span>
                 </summary>
-                <div class="absolute right-0 z-10 mt-1 w-56 overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg dark:border-slate-800 dark:bg-slate-900">
-                  <ul class="divide-y divide-slate-100 dark:divide-slate-800">
+                <div class="absolute right-0 z-10 mt-1 w-56 overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg dark:border-slate-800 dark:bg-slate-900 dark:ring-1 dark:ring-slate-700">
+                  <ul class="max-h-80 divide-y divide-slate-100 overflow-y-auto dark:divide-slate-800">
                     {% for p in g.get('user_projects', []) %}
                       <li>
                         {% if p.id == g.current_project.id %}
@@ -96,7 +98,7 @@
                       </li>
                     {% endfor %}
                   </ul>
-                  <a href="{{ url_for('projects.list_projects') }}" class="block border-t border-slate-200 px-3 py-2 text-xs text-slate-500 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-400 dark:hover:bg-slate-800">Управление проектами →</a>
+                  <a href="{{ url_for('projects.list_projects') }}" class="block border-t border-slate-200 px-3 py-2 text-xs text-slate-500 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-400 dark:hover:bg-slate-800">Все проекты →</a>
                 </div>
               </details>
             {% endif %}

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}{{ project.name }} — DB Monitor{% endblock %}
+{% block breadcrumb %}
+  <a href="{{ url_for('projects.list_projects') }}" class="hover:text-slate-700 dark:hover:text-slate-200">Проекты</a>
+  <span class="text-slate-300 dark:text-slate-600">/</span>
+  <span class="font-medium text-slate-700 dark:text-slate-200">{{ project.name }}</span>
+{% endblock %}
+
+{% block content %}
+  <div class="flex items-baseline justify-between">
+    <h1 class="text-2xl font-semibold tracking-tight">{{ project.name }}</h1>
+    <span class="font-mono text-xs text-slate-500 dark:text-slate-400">{{ project.slug }}</span>
+  </div>
+
+  <section class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <header class="border-b border-slate-200 px-5 py-3 dark:border-slate-800">
+      <h2 class="text-base font-semibold">Подключения к БД</h2>
+    </header>
+    <div class="px-5 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+      В проекте пока нет подключений.<br>
+      <span class="text-xs">Добавление подключений появится с задачей #51 (DB connections + Fernet-шифрование).</span>
+    </div>
+  </section>
+{% endblock %}

--- a/templates/projects/list.html
+++ b/templates/projects/list.html
@@ -11,19 +11,7 @@
     </a>
   </div>
 
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      <div class="mt-4 space-y-2">
-        {% for category, message in messages %}
-          <div class="rounded-md border px-4 py-2 text-sm
-            {% if category == 'success' %}border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-200
-            {% else %}border-slate-200 bg-white text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200{% endif %}">
-            {{ message }}
-          </div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  <div class="mt-4">{% include "_flash.html" %}</div>
 
   <section class="mt-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
     <div class="divide-y divide-slate-100 dark:divide-slate-800">

--- a/templates/projects/list.html
+++ b/templates/projects/list.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+{% block title %}Проекты — DB Monitor{% endblock %}
+{% block breadcrumb %}<span>Главная</span><span class="text-slate-300 dark:text-slate-600">/</span><span class="font-medium text-slate-700 dark:text-slate-200">Проекты</span>{% endblock %}
+
+{% block content %}
+  <div class="flex items-baseline justify-between">
+    <h1 class="text-2xl font-semibold tracking-tight">Проекты</h1>
+    <a href="{{ url_for('projects.new_project') }}"
+       class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover">
+      Новый проект
+    </a>
+  </div>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      <div class="mt-4 space-y-2">
+        {% for category, message in messages %}
+          <div class="rounded-md border px-4 py-2 text-sm
+            {% if category == 'success' %}border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-200
+            {% else %}border-slate-200 bg-white text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200{% endif %}">
+            {{ message }}
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+
+  <section class="mt-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="divide-y divide-slate-100 dark:divide-slate-800">
+      {% for project in projects %}
+        <div class="flex items-center justify-between px-5 py-4">
+          <div class="min-w-0">
+            <a href="{{ url_for('projects.detail', slug=project.slug) }}"
+               class="text-base font-semibold text-accent hover:underline">{{ project.name }}</a>
+            <div class="text-xs text-slate-500 dark:text-slate-400">
+              <span class="font-mono">{{ project.slug }}</span>
+              · создан {{ project.created_at[:16].replace('T', ' ') }} UTC
+            </div>
+          </div>
+          <div class="flex items-center gap-2">
+            {% if g.current_project and g.current_project.id == project.id %}
+              <span class="rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">текущий</span>
+            {% else %}
+              <form method="POST" action="{{ url_for('projects.switch', slug=project.slug) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit"
+                        class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
+                  Сделать текущим
+                </button>
+              </form>
+            {% endif %}
+            <form method="POST" action="{{ url_for('projects.delete', slug=project.slug) }}"
+                  onsubmit="return confirm('Удалить проект «{{ project.name }}»?');">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button type="submit"
+                      class="rounded-md border border-red-200 px-3 py-1 text-xs text-red-600 hover:bg-red-50 dark:border-red-900/40 dark:text-red-400 dark:hover:bg-red-950/30">
+                Удалить
+              </button>
+            </form>
+          </div>
+        </div>
+      {% else %}
+        <div class="px-5 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+          У вас пока нет проектов. <a href="{{ url_for('projects.new_project') }}" class="text-accent hover:underline">Создать первый</a>.
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+{% endblock %}

--- a/templates/projects/new.html
+++ b/templates/projects/new.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% from "auth/_macros.html" import render_field %}
+{% block title %}Новый проект — DB Monitor{% endblock %}
+{% block breadcrumb %}
+  <a href="{{ url_for('projects.list_projects') }}" class="hover:text-slate-700 dark:hover:text-slate-200">Проекты</a>
+  <span class="text-slate-300 dark:text-slate-600">/</span>
+  <span class="font-medium text-slate-700 dark:text-slate-200">Новый</span>
+{% endblock %}
+
+{% set input_cls = "mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent dark:border-slate-700 dark:bg-slate-950" %}
+
+{% block content %}
+  <h1 class="text-2xl font-semibold tracking-tight">Новый проект</h1>
+  <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+    Каждый проект — отдельный набор подключений к БД и истории метрик.
+  </p>
+
+  <div class="mt-6 max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <form method="POST" class="space-y-4" novalidate>
+      {{ form.hidden_tag() }}
+      {{ render_field(form.name, input_class=input_cls) }}
+      {{ render_field(form.slug, input_class=input_cls) }}
+      <p class="text-xs text-slate-500 dark:text-slate-400">
+        Слаг — короткий уникальный идентификатор в URL. Латиница, цифры,
+        дефисы; до 40 символов.
+      </p>
+      <div class="flex items-center justify-between">
+        <a href="{{ url_for('projects.list_projects') }}" class="text-sm text-slate-500 hover:text-accent dark:text-slate-400">← К списку</a>
+        {{ form.submit(class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover") }}
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,222 @@
+"""Projects CRUD + ownership-isolation tests for #50.
+
+Covers the acceptance criteria from the issue:
+- Юзер видит ТОЛЬКО свои проекты (URL-guessing другого юзера → 404)
+- При регистрации auto-создаётся "Default" проект
+- Switcher хранит current_project_id в сессии
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.app import create_app
+
+
+@pytest.fixture
+def projects_app(tmp_path, monkeypatch):
+    """App with auth enabled (LOGIN_DISABLED=False) and CSRF off for ergonomics.
+    Real users, real projects table, in-memory SQLite under tmp_path.
+    """
+    db_path = tmp_path / "projects.db"
+    import app.metrics_storage as storage
+
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    app = create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+    return app
+
+
+@pytest.fixture
+def client(projects_app):
+    return projects_app.test_client()
+
+
+def _register(client, email="u@example.com", password="supersecret1"):
+    """Register a user; the post-register session is left authenticated."""
+    return client.post("/auth/register", data={
+        "email": email, "password": password, "confirm": password,
+    })
+
+
+def _logout(client):
+    client.post("/auth/logout")
+
+
+def _login(client, email="u@example.com", password="supersecret1"):
+    return client.post("/auth/login", data={"email": email, "password": password})
+
+
+# --- Auto-create Default on register ---------------------------------------
+
+
+def test_register_creates_default_project(client):
+    _register(client, "default@example.com")
+    # Hit /projects — Default should be the only entry.
+    resp = client.get("/projects")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Default" in body
+    assert "default" in body  # slug
+
+
+def test_default_project_is_set_as_current(client):
+    _register(client, "current@example.com")
+    # Dashboard renders the switcher; it must show "Default".
+    resp = client.get("/dashboard/")
+    assert b"Default" in resp.data
+
+
+# --- Create / list / detail ------------------------------------------------
+
+
+def test_create_project_redirects_to_detail(client):
+    _register(client)
+    resp = client.post("/projects/new", data={
+        "name": "Production", "slug": "prod",
+    }, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/projects/prod")
+
+
+def test_detail_page_shows_placeholder_for_connections(client):
+    _register(client)
+    client.post("/projects/new", data={"name": "Prod", "slug": "prod"})
+    resp = client.get("/projects/prod")
+    assert resp.status_code == 200
+    assert "В проекте пока нет подключений" in resp.get_data(as_text=True)
+
+
+def test_list_shows_default_plus_new_project(client):
+    _register(client)
+    client.post("/projects/new", data={"name": "Staging", "slug": "staging"})
+    resp = client.get("/projects")
+    body = resp.get_data(as_text=True)
+    assert "Default" in body
+    assert "Staging" in body
+
+
+# --- Slug rules ------------------------------------------------------------
+
+
+def test_duplicate_slug_per_same_user_returns_409(client):
+    _register(client, "dup@example.com")
+    # Default already takes "default" — try to create another with same slug.
+    resp = client.post("/projects/new", data={"name": "Other", "slug": "default"})
+    assert resp.status_code == 409
+    assert "уже существует" in resp.get_data(as_text=True)
+
+
+def test_two_different_users_can_share_a_slug(client):
+    _register(client, "user1@example.com")
+    client.post("/projects/new", data={"name": "Shared", "slug": "shared"})
+    _logout(client)
+
+    _register(client, "user2@example.com")
+    resp = client.post("/projects/new", data={"name": "Shared", "slug": "shared"})
+    # Should succeed — slug uniqueness is per-user.
+    assert resp.status_code == 302
+
+
+def test_invalid_slug_rejected(client):
+    _register(client)
+    bad = ["UPPER", "with spaces", "-leading", "trailing-", "with/slash", "a" * 41]
+    for slug in bad:
+        resp = client.post("/projects/new", data={"name": "n", "slug": slug})
+        # Form re-renders 200 (no project created); 409 would mean uniqueness,
+        # which we don't exercise here.
+        assert resp.status_code == 200, f"slug {slug!r} should be rejected"
+
+
+# --- Ownership isolation ---------------------------------------------------
+
+
+def test_user_cannot_see_another_users_project(client):
+    _register(client, "owner@example.com")
+    client.post("/projects/new", data={"name": "Secret", "slug": "secret"})
+    _logout(client)
+
+    _register(client, "stranger@example.com")
+    # Guess the other user's slug.
+    resp = client.get("/projects/secret")
+    assert resp.status_code == 404
+
+
+def test_user_cannot_delete_another_users_project(client):
+    _register(client, "victim@example.com")
+    client.post("/projects/new", data={"name": "Mine", "slug": "mine"})
+    _logout(client)
+
+    _register(client, "attacker@example.com")
+    resp = client.post("/projects/mine/delete")
+    assert resp.status_code == 404
+
+    # And the victim's project must still exist after re-login.
+    _logout(client)
+    _login(client, "victim@example.com", "supersecret1")
+    resp = client.get("/projects/mine")
+    assert resp.status_code == 200
+
+
+def test_user_cannot_switch_to_another_users_project(client):
+    _register(client, "a@example.com")
+    client.post("/projects/new", data={"name": "Theirs", "slug": "theirs"})
+    _logout(client)
+
+    _register(client, "b@example.com")
+    resp = client.post("/projects/theirs/switch")
+    assert resp.status_code == 404
+
+
+# --- Delete + switcher state -----------------------------------------------
+
+
+def test_delete_clears_current_if_it_was_the_current_project(client):
+    _register(client)
+    # Create a second project; switch to it; delete it.
+    client.post("/projects/new", data={"name": "Other", "slug": "other"})
+    # `new_project` auto-switches; deleting it should fall back gracefully.
+    resp = client.post("/projects/other/delete", follow_redirects=True)
+    assert resp.status_code == 200
+    # The remaining "Default" project should now be picked up as current.
+    assert b"Default" in resp.data
+
+
+def test_switch_changes_current_project(client):
+    _register(client)
+    client.post("/projects/new", data={"name": "Production", "slug": "prod"})
+    # We're already on Production (new_project auto-switches). Switch back
+    # to Default.
+    client.post("/projects/default/switch")
+    resp = client.get("/dashboard/")
+    body = resp.get_data(as_text=True)
+    # The switcher's summary shows the current project's name as the first
+    # render — Default must appear before Production in the dropdown order
+    # since list_projects orders by created_at, but the *current* one is in
+    # the <summary>.
+    assert "Default" in body
+
+
+# --- Gating ----------------------------------------------------------------
+
+
+def test_projects_requires_login(client):
+    """Unauthenticated /projects → 302 to /auth/login."""
+    resp = client.get("/projects", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/auth/login" in resp.headers["Location"]
+
+
+def test_new_project_requires_login(client):
+    resp = client.get("/projects/new", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/auth/login" in resp.headers["Location"]

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -191,6 +191,29 @@ def test_delete_clears_current_if_it_was_the_current_project(client):
     assert b"Default" in resp.data
 
 
+def test_switch_honours_safe_next(client):
+    """Switching with ?next=/projects redirects there (same-host relative path)."""
+    _register(client)
+    client.post("/projects/new", data={"name": "Production", "slug": "prod"})
+    resp = client.post(
+        "/projects/default/switch?next=/projects",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/projects")
+
+
+def test_switch_rejects_open_redirect_next(client):
+    """`?next=https://evil/` must not leak the user off-site."""
+    _register(client)
+    resp = client.post(
+        "/projects/default/switch?next=https://evil.example.com/",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "evil.example.com" not in resp.headers["Location"]
+
+
 def test_switch_changes_current_project(client):
     _register(client)
     client.post("/projects/new", data={"name": "Production", "slug": "prod"})


### PR DESCRIPTION
## Summary

Closes #50. Третий тикет Sprint 3 multi-tenant эпика (после #49 Users и #56 Security hygiene). Scaffolding для #51 (DB connections + Fernet) и #53 (tenant isolation в метриках).

## Что внутри

- **Схема**: `projects(id, user_id FK users CASCADE, name, slug, created_at)` + `UNIQUE(user_id, slug)` в обоих schemas. Index на `user_id`. Migration script обновлён.
- **Storage layer**: `create_project` / `get_project_by_slug` / `get_project_by_id` / `list_projects_for_user` / `delete_project` — все scoped по `user_id`, не существует пути получить чужой проект через подбор URL. `ProjectSlugTaken` с pre-check (тот же паттерн, что у `UserAlreadyExists` в #49).
- **Blueprint `app/projects.py`** с роутами `/projects` (list), `/projects/new` (form + POST), `/projects/<slug>` (detail), `POST /projects/<slug>/delete`, `POST /projects/<slug>/switch`. Централизованный `_require_owned_project(slug)` гарантирует, что новые роуты не забудут ownership-фильтр.
- **`g.current_project`** через `before_request`: `load_current_project_into_g()` ставит `g.current_project` и `g.user_projects` из сессии. Stale id (после delete / cross-account session reuse) автоматически чистится. Гости не делают DB lookup (хук стоит ПОСЛЕ login-gate).
- **Auto-create "Default"** при регистрации (acceptance #50) — lazy-импорт из `auth.register`, идемпотентен.
- **Header switcher** в `templates/base.html` — `<details>/<summary>` dropdown со всеми проектами + ссылкой на /projects. Рендерится только когда g.current_project выставлен (на `/auth/*` страницах ничего нет).
- **Templates** `projects/{list,new,detail}.html` — стилизация под дашборд. Форма через макрос `auth/_macros.html` — наследует aria-invalid/aria-describedby и итерацию всех ошибок (из #49 review-фиксов).

## Что НЕ входит (по дизайну)

- **Detail-страница пока placeholder** — "В проекте пока нет подключений" + ссылка на #51 в комментарии. Реальный контент придёт с #51.
- **Дашборд не фильтруется по project_id** — оставлено на #53 (tenant isolation). `g.current_project` доступен в шаблонах сразу, но запросы метрик пока тотальные.
- **Soft-delete** — для MVP hard delete с `ON DELETE CASCADE` (project удалился → связанные коннекшны/метрики из #51/#53 уйдут автоматически).

## Verification

- `pytest -q`: **368 passed**, 31 deselected. +15 кейсов от #50, существующие 353 не задеты.
- `ruff check .`: clean.

## Acceptance (issue #50)

- [x] Модель Project с FK на users + UNIQUE(user_id, slug)
- [x] Миграция в monitor.db (+ timescale)
- [x] GET /projects (список) + GET/POST /projects/new + GET /projects/<slug> + POST /projects/<slug>/delete
- [x] Шаблоны list + new + detail
- [x] `current_project_id` в сессии + переключатель в шапке
- [x] Auto-create "Default" project при регистрации
- [x] Тесты: создание, дубликат slug, видимость только своих, удаление чужого = 404, gating

## Test plan

- [x] 15 кейсов в `tests/test_projects.py` зелёные.
- [x] Все 353 предыдущих unit-теста не задеты.
- [ ] Browser smoke (после мерджа) — switcher dropdown, dark mode, sidebar link.