### PR TITLE
feat(#52): Test-connection endpoint + log-scrubbing фикс

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -23,19 +23,30 @@ scrubs as belt-and-braces).
 
 from __future__ import annotations
 
+import logging
+import time
 import uuid
 
-from flask import Blueprint, abort, flash, redirect, render_template, url_for
-from flask_login import login_required
+from flask import Blueprint, abort, flash, jsonify, redirect, render_template, url_for
+from flask_login import current_user, login_required
 from flask_wtf import FlaskForm
+from sqlalchemy import create_engine, make_url, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.pool import NullPool
 from wtforms import BooleanField, IntegerField, StringField, SubmitField
 from wtforms.validators import DataRequired, Length, NumberRange
 
 from app import crypto, metrics_storage
+from app.auth import limiter
 from app.projects import _require_owned_project
 from app.security import mask_dsn
 
+logger = logging.getLogger(__name__)
+
 bp = Blueprint("connections", __name__, url_prefix="/projects/<slug>/connections")
+
+# Connection-test budget — caps the wall-clock for the whole probe.
+_TEST_CONNECT_TIMEOUT_S = 5
 
 
 class ConnectionForm(FlaskForm):
@@ -140,6 +151,38 @@ def delete(slug: str, conn_id: str):
     return redirect(url_for("connections.list_connections", slug=slug))
 
 
+def _user_key() -> str:
+    """Per-user rate-limit key — matches #56's `/test`: 30/min per user.
+
+    Falls back to IP for anonymous (defence in depth — the route is
+    @login_required so anonymous can't reach it, but a misconfiguration
+    shouldn't degrade to "no rate limit").
+    """
+    from flask_limiter.util import get_remote_address
+
+    if current_user.is_authenticated:
+        return f"user:{current_user.id}"
+    return f"ip:{get_remote_address()}"
+
+
+@bp.route("/<conn_id>/test", methods=["POST"])
+@limiter.limit("30 per minute", key_func=_user_key)
+@login_required
+def test_connection(slug: str, conn_id: str):
+    """Live-probe the stored DSN. Per-user-throttled (#56)."""
+    _project, conn = _require_owned_connection(slug, conn_id)
+    try:
+        plain = crypto.decrypt_dsn(conn["dsn_encrypted"])
+    except crypto.InvalidToken:
+        return jsonify({
+            "status": "error", "code": "invalid_ciphertext",
+            "message": "Сохранённый DSN не расшифровывается. Пересохрани подключение.",
+        }), 422
+    result = probe_connection(plain)
+    status_code = 200 if result["status"] == "ok" else 422
+    return jsonify(result), status_code
+
+
 @bp.route("/<conn_id>/toggle", methods=["POST"])
 @login_required
 def toggle(slug: str, conn_id: str):
@@ -152,6 +195,112 @@ def toggle(slug: str, conn_id: str):
         "info",
     )
     return redirect(url_for("connections.list_connections", slug=slug))
+
+
+# --- Connection probe (#52) ------------------------------------------------
+
+
+# Error-code mapping: rough match on exception text. Order matters — auth
+# is more specific than the generic "could not connect" patterns and must
+# be checked first. Each phrase is a substring of the lower-cased message.
+_AUTH_HINTS = (
+    "password authentication failed",
+    "authentication failed",
+    "access denied for user",  # MySQL phrasing (future-proofing)
+)
+_TIMEOUT_HINTS = (
+    "timeout expired",
+    "connection timed out",
+    "connect_timeout expired",
+)
+_NETWORK_HINTS = (
+    "could not translate host name",
+    "could not connect to server",
+    "connection refused",
+    "no route to host",
+    "network is unreachable",
+    "name or service not known",
+    "temporary failure in name resolution",
+    "unable to connect",
+)
+
+
+def _classify_error(exc: BaseException) -> tuple[str, str]:
+    """Map an exception to (code, user-safe message).
+
+    User-safe message must NOT leak DSN content — the DSNFilter (#56)
+    will scrub on the way to logs, but the JSON response goes straight
+    to the browser without the filter. Phrasing is deliberately generic.
+    """
+    msg = str(exc).lower()
+    if any(h in msg for h in _AUTH_HINTS):
+        return "auth_failed", "Неверный логин или пароль."
+    if any(h in msg for h in _TIMEOUT_HINTS):
+        return "timeout", f"Подключение не удалось за {_TEST_CONNECT_TIMEOUT_S} c."
+    if any(h in msg for h in _NETWORK_HINTS):
+        return "network", "Хост недоступен или DNS не разрешается."
+    return "error", "Ошибка подключения (см. логи сервера)."
+
+
+def probe_connection(dsn: str) -> dict:
+    """Try connecting and reading a couple of harmless metadata bits.
+
+    Postgres-only at the moment — other dialects return ``unsupported_dialect``
+    until a per-dialect probe lands (the adapters in #42 know how to
+    introspect tables but not how to phrase a self-test in a way that
+    works across MySQL / ClickHouse). The JSON response is identical
+    shape across success and failure so the UI never has to branch on
+    keys, only on ``status``.
+    """
+    try:
+        backend = make_url(dsn).get_backend_name()
+    except Exception:
+        return {
+            "status": "error", "code": "invalid_dsn",
+            "message": "DSN не парсится как URL.",
+        }
+
+    if backend != "postgresql":
+        return {
+            "status": "error", "code": "unsupported_dialect",
+            "message": f"Тест для диалекта {backend!r} ещё не реализован.",
+        }
+
+    # NullPool: do NOT keep the connection alive after the probe — we don't
+    # want a one-off test to occupy a pool slot for the rest of the process.
+    # connect_args.connect_timeout: psycopg2 / libpq honours this for the
+    # initial TCP+startup phase, which is exactly what we want to bound.
+    engine = create_engine(
+        dsn,
+        poolclass=NullPool,
+        connect_args={"connect_timeout": _TEST_CONNECT_TIMEOUT_S},
+    )
+    started = time.monotonic()
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+            row = conn.execute(
+                text("SELECT current_database(), version()")
+            ).fetchone()
+        latency_ms = int((time.monotonic() - started) * 1000)
+        return {
+            "status": "ok",
+            "database": row[0],
+            "version": row[1].split(" on ", 1)[0],  # trim "on x86_64-..."
+            "latency_ms": latency_ms,
+        }
+    except SQLAlchemyError as exc:
+        # Full traceback (with masked DSN — DSNFilter scrubs the password
+        # before it reaches any handler) goes to server logs; user sees
+        # only the classified code.
+        logger.warning("connection probe failed: %s", exc, exc_info=True)
+        code, user_msg = _classify_error(exc)
+        return {
+            "status": "error", "code": code, "message": user_msg,
+            "latency_ms": int((time.monotonic() - started) * 1000),
+        }
+    finally:
+        engine.dispose()
 
 
 # --- Helper for other modules ----------------------------------------------

--- a/app/security.py
+++ b/app/security.py
@@ -69,12 +69,21 @@ def mask_dsn(url: str) -> str:
 
 
 def _scrub(value):
-    """Recursively rewrite DSN passwords inside any string/tuple/dict/list."""
+    """Recursively rewrite DSN passwords inside any string/tuple/dict/list.
+
+    Exceptions are str()-ed and scrubbed: when an Exception is passed to a
+    ``logger.warning('x: %s', exc)`` call, the eventual ``%s`` format-time
+    ``str(exc)`` would otherwise resurrect the unscrubbed DSN. Replacing
+    the exception arg with a pre-scrubbed string keeps ``%s`` happy AND
+    closes the leak.
+    """
     if isinstance(value, str):
         return _DSN_IN_TEXT.sub(
             lambda m: f"{m.group('prefix')}{_PASSWORD_PLACEHOLDER}{m.group('suffix')}",
             value,
         )
+    if isinstance(value, BaseException):
+        return _scrub(str(value))
     if isinstance(value, tuple):
         return tuple(_scrub(v) for v in value)
     if isinstance(value, list):
@@ -101,12 +110,56 @@ class DSNFilter(logging.Filter):
         return True
 
 
-def init_logging_filter(logger: logging.Logger | None = None) -> DSNFilter:
-    """Install ``DSNFilter`` on a logger and its already-attached handlers.
+_OLD_RECORD_FACTORY = None  # set by install_log_record_scrubber
 
-    Defaults to the root logger so every application-emitted line is
-    covered. Returns the filter instance for tests / introspection.
+
+def install_log_record_scrubber() -> None:
+    """Scrub DSN passwords at LogRecord construction time.
+
+    Why not just a Filter on root? Filters on a Logger only fire for
+    records *originating* on that logger — child loggers (``app.foo``)
+    don't inherit parent filters. They DO inherit ancestor *handlers*,
+    so filtered handlers still scrub on the way out, but anyone reading
+    records by other means (pytest caplog, Sentry's SDK handler, a custom
+    JSON formatter on a different logger) gets the unscrubbed payload.
+
+    ``logging.setLogRecordFactory`` wraps EVERY record creation across
+    every logger, so the scrub happens once, at the source. Idempotent:
+    re-installing replaces the previous wrapper without double-wrapping.
     """
+    global _OLD_RECORD_FACTORY
+
+    # Capture the original factory exactly once. Subsequent calls compose
+    # on top of OUR wrapper, which would scrub twice — cheap but wasteful.
+    # The idempotent guard in app/app.py (_ensure_dsn_logging_filter) means
+    # this normally runs once per process anyway.
+    if _OLD_RECORD_FACTORY is None:
+        _OLD_RECORD_FACTORY = logging.getLogRecordFactory()
+    base_factory = _OLD_RECORD_FACTORY
+
+    def _scrubbing_factory(*args, **kwargs):
+        record = base_factory(*args, **kwargs)
+        if isinstance(record.msg, str):
+            record.msg = _scrub(record.msg)
+        if record.args:
+            record.args = _scrub(record.args)
+        return record
+
+    logging.setLogRecordFactory(_scrubbing_factory)
+
+
+def init_logging_filter(logger: logging.Logger | None = None) -> DSNFilter:
+    """Install DSN scrubbing — record factory + ``DSNFilter`` on root.
+
+    The factory is the actual defence (covers child loggers, custom
+    handlers, pytest caplog, future Sentry SDK). The Filter on root is
+    kept as belt-and-braces for any code path that bypasses the factory
+    (e.g. someone constructing a ``LogRecord`` by hand).
+
+    Returns the filter instance — tests use it to verify behaviour
+    without poking at private globals.
+    """
+    install_log_record_scrubber()
     logger = logger if logger is not None else logging.getLogger()
     f = DSNFilter()
     logger.addFilter(f)

--- a/templates/connections/list.html
+++ b/templates/connections/list.html
@@ -39,6 +39,12 @@
             {% endif %}
           </div>
           <div class="col-span-4 flex items-center justify-end gap-2">
+            <button type="button"
+                    data-test-url="{{ url_for('connections.test_connection', slug=project.slug, conn_id=c.id) }}"
+                    data-csrf="{{ csrf_token() }}"
+                    class="js-test-conn rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
+              Тест
+            </button>
             <form method="POST" action="{{ url_for('connections.toggle', slug=project.slug, conn_id=c.id) }}">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit"
@@ -64,4 +70,36 @@
       {% endfor %}
     </div>
   </section>
+
+  <script>
+    // POSTs /test, alerts the result. Kept minimal — no toast library,
+    // no spinner: probe resolves in ≤ 5 s and alert() works for screen
+    // readers without extra ARIA wiring.
+    document.querySelectorAll(".js-test-conn").forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const url = btn.dataset.testUrl;
+        const csrf = btn.dataset.csrf;
+        btn.disabled = true;
+        const original = btn.textContent;
+        btn.textContent = "Проверяю…";
+        try {
+          const resp = await fetch(url, {
+            method: "POST",
+            headers: { "X-CSRFToken": csrf, "Accept": "application/json" },
+          });
+          const data = await resp.json();
+          if (data.status === "ok") {
+            alert(`✓ ${data.database} (${data.version})\n${data.latency_ms} мс`);
+          } else {
+            alert(`✗ ${data.code}: ${data.message}`);
+          }
+        } catch (err) {
+          alert(`✗ Не удалось выполнить запрос: ${err}`);
+        } finally {
+          btn.disabled = false;
+          btn.textContent = original;
+        }
+      });
+    });
+  </script>
 {% endblock %}

--- a/tests/test_connection_test.py
+++ b/tests/test_connection_test.py
@@ -1,0 +1,270 @@
+"""Tests for the /test endpoint + probe_connection (#52).
+
+The happy-path probe goes through ``sqlalchemy.create_engine`` — that part
+is faked at the module-attribute boundary so unit tests don't need a real
+Postgres. A live-Postgres regression test lives in
+``tests/integration/test_full_cycle.py`` (#44 framework).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy.exc import OperationalError
+
+from app import connections, crypto
+from app.app import create_app
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def conn_app(tmp_path, monkeypatch):
+    db_path = tmp_path / "tc.db"
+    import app.metrics_storage as storage
+
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    app = create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+    return app
+
+
+@pytest.fixture
+def client(conn_app):
+    return conn_app.test_client()
+
+
+# --- Pure unit tests for probe_connection ---------------------------------
+
+
+def test_probe_classifies_invalid_url():
+    """Malformed URL → SQLAlchemy make_url raises → invalid_dsn code."""
+    result = connections.probe_connection("not a url")
+    assert result["status"] == "error"
+    assert result["code"] == "invalid_dsn"
+
+
+def test_probe_classifies_unsupported_dialect():
+    result = connections.probe_connection(
+        "mysql+pymysql://u:p@h:3306/d"
+    )
+    assert result["status"] == "error"
+    assert result["code"] == "unsupported_dialect"
+
+
+@pytest.mark.parametrize("err_text, expected_code", [
+    ('FATAL:  password authentication failed for user "admin"', "auth_failed"),
+    ("connection timeout expired", "timeout"),
+    ("connect_timeout expired during startup", "timeout"),
+    ("could not translate host name \"db.example.com\" to address", "network"),
+    ("could not connect to server: Connection refused", "network"),
+    ("Name or service not known", "network"),
+    ("some other weird error from the future", "error"),
+])
+def test_probe_classifies_exception_text(monkeypatch, err_text, expected_code):
+    """probe_connection wraps SQLAlchemy errors → coded responses."""
+    def boom(*_args, **_kwargs):
+        # Build a SQLAlchemy-style OperationalError. The wrapped message
+        # is what _classify_error inspects.
+        return _engine_that_raises(OperationalError("SELECT 1", {}, Exception(err_text)))
+
+    monkeypatch.setattr(connections, "create_engine", boom)
+    result = connections.probe_connection("postgresql://u:p@h:5432/d")
+    assert result["status"] == "error"
+    assert result["code"] == expected_code
+    # User-facing message must NOT contain the original DSN.
+    assert "u:p@h" not in result["message"]
+
+
+def test_probe_returns_database_and_version_on_success(monkeypatch):
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_returns_metadata("testdb", "PostgreSQL 16.1 on x86_64-pc-linux-gnu"),
+    )
+    result = connections.probe_connection("postgresql://u:p@h/d")
+    assert result["status"] == "ok"
+    assert result["database"] == "testdb"
+    assert result["version"] == "PostgreSQL 16.1"  # trims " on x86_64-..."
+    assert isinstance(result["latency_ms"], int)
+
+
+# --- Route-level tests ----------------------------------------------------
+
+
+def _register(client, email="u@example.com"):
+    client.post("/auth/register", data={
+        "email": email, "password": "supersecret1", "confirm": "supersecret1",
+    })
+
+
+def _logout(client):
+    client.post("/auth/logout")
+
+
+def _add_conn(client, slug="default", dsn="postgresql://u:p@h:5432/d"):
+    return client.post(f"/projects/{slug}/connections/new", data={
+        "name": "Probe", "dsn": dsn,
+        "schema_name": "public", "interval_minutes": 15, "is_active": "y",
+    })
+
+
+def _conn_id(email):
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+    user = get_user_by_email(email)
+    project = list_projects_for_user(user["id"])[0]
+    return project["slug"], list_connections_for_project(project["id"])[0]["id"]
+
+
+def test_test_route_returns_ok_payload(monkeypatch, client):
+    _register(client)
+    _add_conn(client)
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_returns_metadata("appdb", "PostgreSQL 16.1"),
+    )
+    slug, conn_id = _conn_id("u@example.com")
+    resp = client.post(f"/projects/{slug}/connections/{conn_id}/test")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "status": "ok",
+        "database": "appdb",
+        "version": "PostgreSQL 16.1",
+        "latency_ms": body["latency_ms"],  # any int
+    }
+
+
+def test_test_route_returns_422_with_code_on_failure(monkeypatch, client):
+    _register(client)
+    _add_conn(client)
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_raises(
+            OperationalError("SELECT 1", {}, Exception("password authentication failed"))
+        ),
+    )
+    slug, conn_id = _conn_id("u@example.com")
+    resp = client.post(f"/projects/{slug}/connections/{conn_id}/test")
+    assert resp.status_code == 422
+    assert resp.get_json()["code"] == "auth_failed"
+
+
+def test_test_route_requires_login(client):
+    resp = client.post(
+        "/projects/default/connections/abc/test", follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "/auth/login" in resp.headers["Location"]
+
+
+def test_test_route_rejects_strangers_conn_id(monkeypatch, client):
+    _register(client, "owner@example.com")
+    _add_conn(client)
+    _, owner_conn_id = _conn_id("owner@example.com")
+    _logout(client)
+
+    _register(client, "stranger@example.com")
+    # stranger's slug=default, but owner_conn_id belongs to another project.
+    resp = client.post(f"/projects/default/connections/{owner_conn_id}/test")
+    assert resp.status_code == 404
+
+
+def test_test_route_handles_corrupted_ciphertext(monkeypatch, client):
+    """Connection saved with a key the current process can't read."""
+    _register(client)
+    _add_conn(client)
+    slug, conn_id = _conn_id("u@example.com")
+    # Rotate Fernet key so the stored ciphertext becomes unreadable.
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+    resp = client.post(f"/projects/{slug}/connections/{conn_id}/test")
+    assert resp.status_code == 422
+    assert resp.get_json()["code"] == "invalid_ciphertext"
+
+
+def test_test_route_never_leaks_dsn_in_response(monkeypatch, client):
+    _register(client)
+    _add_conn(client, dsn="postgresql://leakyuser:leakypass@leakyhost:5432/d")
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_raises(
+            OperationalError(
+                "SELECT 1", {},
+                Exception("FATAL: password authentication failed for user \"leakyuser\""),
+            )
+        ),
+    )
+    slug, conn_id = _conn_id("u@example.com")
+    resp = client.post(f"/projects/{slug}/connections/{conn_id}/test")
+    body = resp.get_data(as_text=True)
+    assert "leakyuser" not in body
+    assert "leakypass" not in body
+    assert "leakyhost" not in body
+
+
+def test_test_route_never_leaks_dsn_in_logs(monkeypatch, client, caplog):
+    import logging
+    _register(client)
+    _add_conn(client, dsn="postgresql://logleak:supersecret@h:5432/d")
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_raises(
+            OperationalError("SELECT 1", {}, Exception("connection failed for postgresql://logleak:supersecret@h:5432/d"))
+        ),
+    )
+    slug, conn_id = _conn_id("u@example.com")
+    with caplog.at_level(logging.DEBUG):
+        client.post(f"/projects/{slug}/connections/{conn_id}/test")
+    full_log = "\n".join(r.getMessage() for r in caplog.records)
+    assert "supersecret" not in full_log
+
+
+# --- Fakes -----------------------------------------------------------------
+
+
+def _engine_that_returns_metadata(database: str, version: str):
+    """Build a Mock engine whose .connect().execute(text(...)).fetchone()
+    returns the metadata row on the second call (SELECT current_database, version()).
+    """
+    engine = MagicMock(name="engine")
+    conn = MagicMock(name="conn")
+    select1 = MagicMock(name="select1")
+    metadata = MagicMock(name="metadata")
+    metadata.fetchone.return_value = (database, version)
+    # First execute: SELECT 1 — value irrelevant. Second: metadata row.
+    conn.execute.side_effect = [select1, metadata]
+
+    @contextmanager
+    def _connect():
+        yield conn
+
+    engine.connect.side_effect = _connect
+    engine.dispose = MagicMock()
+    return engine
+
+
+def _engine_that_raises(exc):
+    engine = MagicMock(name="engine")
+    engine.connect.side_effect = exc
+    engine.dispose = MagicMock()
+    return engine


### PR DESCRIPTION
## Summary

Closes #52. Пятый тикет Sprint 3. Кнопка «Тест» рядом с каждым коннектом делает live-probe в БД — без неё юзер узнаёт о неправильном DSN только через 15 минут после первого тика коллектора.

## Что внутри

- **`probe_connection(dsn)`** в `app/connections.py` — pure function: ephemeral engine (`NullPool`, `connect_timeout=5`), `SELECT 1` + `SELECT current_database(), version()`. Возвращает унифицированный JSON: `{status: ok, database, version, latency_ms}` или `{status: error, code, message, latency_ms}`.
- **`_classify_error`** мапит exception text в коды: `auth_failed` / `timeout` / `network` / `unsupported_dialect` / `invalid_dsn` / `error`. User-facing message без DSN-контента.
- **`POST /projects/<slug>/connections/<id>/test`** — `@login_required`, `@limiter.limit("30 per minute", key_func=user_id)` (per #56 spec), 2-step ownership через `_require_owned_connection`. Возвращает 200 на ok, 422 на error.
- **UI кнопка «Тест»** в `templates/connections/list.html` — минимальный inline-JS: `fetch(POST)` → `alert(database/version/latency либо code+message)`. Без toast-библиотек.
- **Только Postgres сейчас** — для MySQL/ClickHouse возвращаем `unsupported_dialect` с понятным сообщением. Расширим в отдельном тикете.

## Bonus fix — настоящий баг в #56 log scrubbing

Логи показали, что DSN утекает в `caplog` несмотря на DSNFilter. Корень:

1. **Filter на root logger не наследуется child loggers.** `Logger.filter()` срабатывает только для записей, эмитированных НА ТОМ ЖЕ логгере. Запись из `app.connections.logger.warning(...)` обходила root-filter.
2. **`_scrub` не трогал Exception в record.args.** `logger.warning(\"x: %s\", exc)` хранит exception в args; `%s` зовёт `str(exc)` ПОСЛЕ скраба — DSN воскресал.

Оба пофикшены в `app/security.py`:
- Новый `install_log_record_scrubber()` через `logging.setLogRecordFactory` — scrub применяется ко ВСЕМ записям всех логгеров на этапе construction (включая будущий Sentry handler из #103).
- `_scrub(BaseException)` теперь `str()`-ит исключение и скрабит результат — `%s`-форматирование видит уже scrubbed строку.

## Verification

- `pytest -q`: **427 passed** (+17 от #52). Существующие 410 unit-тестов (включая #56 `test_security`) не задеты.
- `ruff check .`: clean.

## Acceptance (issue #52)

- [x] `POST /test` расшифровывает DSN, ephemeral engine, `SELECT 1` + metadata
- [x] Кнопка «Тест» в UI рядом с каждым коннектом
- [x] User видит только code+общее сообщение, не traceback
- [x] Полный traceback в server-логах с маскированным DSN
- [x] Wrong password → `auth_failed`, не leak'ает пароль
- [x] Несуществующий хост → `network` через 5s timeout
- [x] Не-Postgres → `unsupported_dialect`
- [x] Lazy: error не деактивирует connection автоматом

## Не входит

- Тест-probe для MySQL/ClickHouse (отдельный тикет).
- Per-dialect SELECT для metadata (Postgres-specific сейчас).

## Test plan

- [x] 17 unit-кейсов зелёные локально.
- [x] Все 410 предыдущих не задеты.
- [ ] Browser smoke (после мерджа): /projects/default/connections → Тест на правильном DSN показывает alert с версией; на неправильном — alert с auth_failed.