### PR TITLE
feat(#54): Per-project APScheduler — job на коннекшн

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,7 +1,9 @@
 from datetime import UTC, datetime
 
 from flask import Blueprint, jsonify
+from flask_login import current_user
 
+from collectors.per_project import list_jobs_for_user, parse_job_id, user_owns_job
 from collectors.scheduler import get_scheduler
 
 bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -9,13 +11,22 @@ bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 @bp.route("/jobs")
 def list_jobs():
-    """Return all scheduled jobs with id, name, next_run_time, and trigger.
+    """Per-user collection jobs (#54).
 
-    Returns an empty list if the scheduler is not running.
+    Returns jobs whose id matches ``collect:<project_id>:<connection_id>``
+    where ``project_id`` belongs to the current user. Process-wide jobs
+    (forecast retrain, drift sweep, …) are intentionally excluded —
+    they're operator concerns, not tenant ones.
+
+    Anonymous callers (e.g. health checks, TESTING) get the full list as
+    a fallback — useful for diagnostics when the user context isn't set.
     """
     scheduler = get_scheduler()
     if scheduler is None:
         return jsonify([])
+
+    if current_user.is_authenticated:
+        return jsonify(list_jobs_for_user(scheduler, current_user.id))
 
     return jsonify([
         {
@@ -32,11 +43,21 @@ def list_jobs():
 def run_job(job_id: str):
     """Trigger a job immediately by setting its next_run_time to now.
 
-    Returns 503 if the scheduler is not running, 404 if job_id is not found.
+    Per-connection collection jobs (``collect:<pid>:<cid>``) require the
+    job's ``project_id`` to belong to ``current_user`` — 404 otherwise so
+    a guessed id leaks nothing about which jobs exist. Global ops jobs
+    (no ``collect:`` prefix) stay accessible to authenticated users.
     """
     scheduler = get_scheduler()
     if scheduler is None:
         return jsonify({"error": "scheduler not running"}), 503
+
+    if (
+        current_user.is_authenticated
+        and parse_job_id(job_id) is not None
+        and not user_owns_job(current_user.id, job_id)
+    ):
+        return jsonify({"error": f"job '{job_id}' not found"}), 404
 
     job = scheduler.get_job(job_id)
     if job is None:

--- a/app/connections.py
+++ b/app/connections.py
@@ -124,7 +124,7 @@ def new_connection(slug: str):
     project = _require_owned_project(slug)
     form = ConnectionForm()
     if form.validate_on_submit():
-        metrics_storage.create_connection(
+        conn_row = metrics_storage.create_connection(
             connection_id=uuid.uuid4().hex,
             project_id=project["id"],
             name=form.name.data.strip(),
@@ -133,6 +133,15 @@ def new_connection(slug: str):
             interval_minutes=form.interval_minutes.data,
             is_active=form.is_active.data,
         )
+        # #54: register the APScheduler job immediately if the connection
+        # is active. The scheduler is process-wide (started at app boot);
+        # add_job_for_connection no-ops if the scheduler isn't running
+        # (e.g. under TESTING).
+        if conn_row["is_active"]:
+            from collectors.per_project import add_job_for_connection
+            from collectors.scheduler import get_scheduler
+
+            add_job_for_connection(get_scheduler(), project["id"], conn_row)
         flash("Подключение добавлено.", "success")
         return redirect(url_for(
             "connections.list_connections", slug=slug,
@@ -147,6 +156,13 @@ def new_connection(slug: str):
 def delete(slug: str, conn_id: str):
     project, conn = _require_owned_connection(slug, conn_id)
     metrics_storage.delete_connection(project["id"], conn["id"])
+    # #54: drop the scheduled job AFTER the row is gone — the job body
+    # re-checks the DB and would no-op if it fires between delete and
+    # remove_job_for_connection.
+    from collectors.per_project import remove_job_for_connection
+    from collectors.scheduler import get_scheduler
+
+    remove_job_for_connection(get_scheduler(), project["id"], conn["id"])
     flash(f"Подключение «{conn['name']}» удалено.", "info")
     return redirect(url_for("connections.list_connections", slug=slug))
 
@@ -187,9 +203,22 @@ def test_connection(slug: str, conn_id: str):
 @login_required
 def toggle(slug: str, conn_id: str):
     project, conn = _require_owned_connection(slug, conn_id)
+    new_active = not conn["is_active"]
     metrics_storage.set_connection_active(
-        project["id"], conn["id"], is_active=not conn["is_active"],
+        project["id"], conn["id"], is_active=new_active,
     )
+    # #54: keep the scheduler in sync with the row's is_active flag.
+    from collectors.per_project import (
+        add_job_for_connection,
+        remove_job_for_connection,
+    )
+    from collectors.scheduler import get_scheduler
+
+    sched = get_scheduler()
+    if new_active:
+        add_job_for_connection(sched, project["id"], {**conn, "is_active": True})
+    else:
+        remove_job_for_connection(sched, project["id"], conn["id"])
     flash(
         f"Подключение «{conn['name']}» {'выключено' if conn['is_active'] else 'включено'}.",
         "info",

--- a/app/db.py
+++ b/app/db.py
@@ -1,5 +1,7 @@
 import threading
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 from sqlalchemy import create_engine, make_url, text
 from sqlalchemy.engine import Engine
@@ -10,8 +12,35 @@ _engine: Engine | None = None
 _engine_lock = threading.Lock()
 _adapter: "DBAdapter | None" = None
 
+# Per-job engine + adapter override (#54). When a per-connection scheduled
+# job runs, it sets these ContextVars to the target DSN's engine for the
+# duration of the call — every adapter method that goes through get_engine()
+# / get_adapter() picks up the override automatically. ContextVar is
+# thread-safe AND task-scoped (asyncio-friendly for future async paths).
+_engine_override: ContextVar[Engine | None] = ContextVar("_engine_override", default=None)
+_adapter_override: ContextVar["DBAdapter | None"] = ContextVar("_adapter_override", default=None)
+
+
+@contextmanager
+def using_engine(engine: Engine, adapter: "DBAdapter"):
+    """Run a block with a per-call engine + adapter override.
+
+    Used by collectors/per_project.py to make the existing adapter helpers
+    talk to a connection's DSN instead of the global ``DATABASE_URL``.
+    """
+    e_token = _engine_override.set(engine)
+    a_token = _adapter_override.set(adapter)
+    try:
+        yield
+    finally:
+        _adapter_override.reset(a_token)
+        _engine_override.reset(e_token)
+
 
 def get_engine() -> Engine:
+    override = _engine_override.get()
+    if override is not None:
+        return override
     global _engine
     if _engine is None:
         with _engine_lock:
@@ -390,6 +419,9 @@ _ADAPTERS: dict[str, type[DBAdapter]] = {
 
 
 def get_adapter() -> DBAdapter:
+    override = _adapter_override.get()
+    if override is not None:
+        return override
     global _adapter
     if _adapter is None:
         backend = make_url(settings.DATABASE_URL).get_backend_name()
@@ -401,6 +433,22 @@ def get_adapter() -> DBAdapter:
             )
         _adapter = cls()
     return _adapter
+
+
+def make_adapter_for_url(url: str) -> DBAdapter:
+    """Build a fresh adapter for a given DSN — for the per-project scheduler.
+
+    Bypasses the module-level singleton (which is keyed off ``settings.
+    DATABASE_URL``). Cheap operation — adapters hold no state.
+    """
+    backend = make_url(url).get_backend_name()
+    cls = _ADAPTERS.get(backend)
+    if cls is None:
+        raise ValueError(
+            f"Unsupported database backend: {backend!r}. "
+            f"Supported: {sorted(_ADAPTERS)}"
+        )
+    return cls()
 
 
 def list_tables(schema: str | None = None) -> list[dict]:

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -1,0 +1,272 @@
+"""Per-connection scheduled metric collection (#54).
+
+Replaces the single global ``collect_all_tables`` job (which writes to the
+'legacy' tenant) with one APScheduler job per active connection. Each job:
+
+- Lives at ``collect:<project_id>:<connection_id>`` so admin tooling and
+  logs can identify the tenant at a glance.
+- Runs at the connection's own ``interval_minutes`` (5..1440 from #51).
+- Uses ``app.db.using_engine`` to override the global engine/adapter for
+  the duration of the tick — the existing collector + adapter code does
+  not need to know about per-project mode.
+- Tags every metric with the correct ``project_id`` via #53.
+
+Lifecycle hooks:
+- ``register_jobs_for_all_active_connections(scheduler)`` — called once at
+  app startup from ``collectors/scheduler.py``.
+- ``add_job_for_connection(scheduler, project_id, connection)`` — called by
+  the connections blueprint on create / activate / interval change.
+- ``remove_job_for_connection(scheduler, project_id, connection_id)`` —
+  called on delete / deactivate.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+from apscheduler.schedulers.base import BaseScheduler
+
+from app import crypto
+from app.db import make_adapter_for_url, using_engine
+from app.metrics_storage import (
+    get_connection,
+    list_projects_for_user,
+    save_metrics,
+)
+from collectors.metrics_collector import MetricsCollector
+
+logger = logging.getLogger(__name__)
+
+# `prefix` so admin tooling and grep can spot a per-connection job at sight
+# without parsing the id structure.
+JOB_PREFIX = "collect:"
+
+
+def job_id_for(project_id: str, connection_id: str) -> str:
+    """Stable APScheduler id for the (project, connection) pair."""
+    return f"{JOB_PREFIX}{project_id}:{connection_id}"
+
+
+def parse_job_id(job_id: str) -> tuple[str, str] | None:
+    """Reverse ``job_id_for`` — returns (project_id, connection_id) or None
+    if the id isn't one of ours (e.g. global jobs from collectors/scheduler.py).
+    """
+    if not job_id.startswith(JOB_PREFIX):
+        return None
+    parts = job_id[len(JOB_PREFIX):].split(":", 1)
+    if len(parts) != 2:
+        return None
+    return parts[0], parts[1]
+
+
+# --- The job body ---------------------------------------------------------
+
+
+def collect_for_connection(project_id: str, connection_id: str) -> None:
+    """Single tick: enumerate tables on the connection's DSN, save metrics
+    tagged with the project_id.
+
+    Errors are caught + logged (the job runs hourly-ish; one bad tick must
+    not poison the whole scheduler). Plaintext DSN never reaches a log —
+    ``app.security.DSNFilter`` from #56 scrubs at LogRecord construction.
+    """
+    started = time.monotonic()
+    conn_row = get_connection(project_id, connection_id)
+    if conn_row is None or not conn_row["is_active"]:
+        logger.info("[project=%s][conn=%s] skipped — inactive/deleted",
+                    project_id, connection_id)
+        return
+
+    try:
+        dsn = crypto.decrypt_dsn(conn_row["dsn_encrypted"])
+    except crypto.InvalidToken:
+        logger.warning("[project=%s][conn=%s] DSN ciphertext invalid — "
+                       "Fernet key rotated? Re-save the connection.",
+                       project_id, connection_id)
+        return
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    # NullPool — per-tick engine, no pool to leak across runs. connect_timeout
+    # bounds the establish phase; OperationalError on a dead target bubbles
+    # up to our try/except below.
+    engine = create_engine(
+        dsn, poolclass=NullPool, connect_args={"connect_timeout": 5},
+    )
+    try:
+        adapter = make_adapter_for_url(dsn)
+    except ValueError as exc:
+        logger.warning("[project=%s][conn=%s] %s", project_id, connection_id, exc)
+        engine.dispose()
+        return
+
+    run_ts = datetime.now(UTC)
+    schema = conn_row["schema_name"]
+    rows_saved = 0
+    tables_seen = 0
+    try:
+        with using_engine(engine, adapter):
+            tables = adapter.list_tables(schema)
+            collector = MetricsCollector(schema=schema)
+            for table in tables:
+                tables_seen += 1
+                metrics = collector.collect(table["table_name"], ts=run_ts)
+                if metrics:
+                    rows_saved += save_metrics(metrics, project_id)
+    except Exception as exc:
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        logger.warning(
+            "[project=%s][conn=%s] collection failed after %dms: %s",
+            project_id, connection_id, elapsed_ms, exc,
+        )
+        engine.dispose()
+        return
+
+    engine.dispose()
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    logger.info(
+        "[project=%s][conn=%s] collected %d metrics across %d tables in %dms",
+        project_id, connection_id, rows_saved, tables_seen, elapsed_ms,
+    )
+
+
+# --- Scheduler hooks ------------------------------------------------------
+
+
+_JOB_OPTS = {
+    # APScheduler defaults that match the spec:
+    "misfire_grace_time": 60,  # tolerate 60 s late firing on busy worker
+    "max_instances": 1,        # one tick at a time — long DB doesn't stack
+    "coalesce": True,          # if multiple firings missed, run once
+    "replace_existing": True,  # idempotent add_job_for_connection on re-register
+}
+
+
+def add_job_for_connection(
+    scheduler: BaseScheduler, project_id: str, connection: dict
+) -> None:
+    """Idempotent: re-adding overwrites the existing job (same id).
+
+    Connection must be the dict shape returned by ``metrics_storage.
+    get_connection`` — needs id, interval_minutes.
+    """
+    if scheduler is None or not scheduler.running:
+        logger.debug("scheduler not running, deferring job for conn=%s",
+                     connection["id"])
+        return
+    scheduler.add_job(
+        collect_for_connection,
+        "interval",
+        minutes=int(connection["interval_minutes"]),
+        args=[project_id, connection["id"]],
+        id=job_id_for(project_id, connection["id"]),
+        name=f"collect project={project_id} conn={connection['id']}",
+        **_JOB_OPTS,
+    )
+    logger.info("[project=%s][conn=%s] registered (every %d min)",
+                project_id, connection["id"], connection["interval_minutes"])
+
+
+def remove_job_for_connection(
+    scheduler: BaseScheduler, project_id: str, connection_id: str
+) -> None:
+    """No-op if the job isn't registered — covers the "toggle off while
+    already disabled" UX path.
+    """
+    if scheduler is None or not scheduler.running:
+        return
+    jid = job_id_for(project_id, connection_id)
+    if scheduler.get_job(jid) is not None:
+        scheduler.remove_job(jid)
+        logger.info("[project=%s][conn=%s] unregistered", project_id, connection_id)
+
+
+def register_jobs_for_all_active_connections(scheduler: BaseScheduler) -> int:
+    """Boot-time enumeration: every active connection gets a scheduled job.
+
+    Called from ``collectors/scheduler.py::start_scheduler`` after the
+    scheduler starts. Returns the number of jobs registered.
+    """
+    from sqlalchemy import text
+
+    from app.metrics_storage import get_engine
+
+    # We don't have a "list ALL users" helper (no need so far), so we walk
+    # connections directly. Each active row gets a job tagged with its
+    # owning project_id.
+    with get_engine().connect() as conn:
+        rows = conn.execute(text("""
+            SELECT c.id, c.project_id, c.interval_minutes
+            FROM connections AS c
+            WHERE c.is_active = 1
+        """)).fetchall()
+
+    n = 0
+    for cid, pid, interval in rows:
+        add_job_for_connection(
+            scheduler, pid,
+            {"id": cid, "interval_minutes": int(interval)},
+        )
+        n += 1
+    logger.info("registered %d per-connection collection jobs", n)
+    return n
+
+
+# --- Helpers for /admin ---------------------------------------------------
+
+
+def list_jobs_for_user(scheduler: BaseScheduler, user_id: str) -> list[dict]:
+    """Per-user scoping for /admin/jobs: only jobs whose project_id is
+    owned by ``user_id``. Global / non-prefixed jobs are excluded — they're
+    process-wide concerns (forecast retrain, drift sweep, …) and don't
+    belong on a tenant's admin page.
+    """
+    if scheduler is None or not scheduler.running:
+        return []
+    owned_project_ids = {p["id"] for p in list_projects_for_user(user_id)}
+    out: list[dict] = []
+    for job in scheduler.get_jobs():
+        parsed = parse_job_id(job.id)
+        if parsed is None:
+            continue
+        project_id, conn_id = parsed
+        if project_id not in owned_project_ids:
+            continue
+        out.append({
+            "id": job.id,
+            "name": job.name,
+            "project_id": project_id,
+            "connection_id": conn_id,
+            "next_run_time": job.next_run_time.isoformat() if job.next_run_time else None,
+            "trigger": str(job.trigger),
+        })
+    return out
+
+
+def user_owns_job(user_id: str, job_id: str) -> bool:
+    """True iff ``job_id`` is one of ours AND its project_id belongs to ``user_id``.
+
+    Used by ``/admin/jobs/<id>/run`` to 404 on cross-tenant trigger attempts.
+    """
+    parsed = parse_job_id(job_id)
+    if parsed is None:
+        return False
+    project_id, _ = parsed
+    owned: Iterable[dict] = list_projects_for_user(user_id)
+    return any(p["id"] == project_id for p in owned)
+
+
+__all__ = [
+    "add_job_for_connection",
+    "collect_for_connection",
+    "job_id_for",
+    "list_jobs_for_user",
+    "parse_job_id",
+    "register_jobs_for_all_active_connections",
+    "remove_job_for_connection",
+    "user_owns_job",
+]

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -72,6 +72,17 @@ def start_scheduler(app) -> None:
     atexit.register(_scheduler.shutdown, wait=False)
     logger.info("Metrics scheduler started (interval=%d min)", interval)
 
+    # #54: register per-connection collection jobs for every active
+    # row in `connections`. The global `collect_all_tables` above stays
+    # registered for backward-compat (`legacy` tenant), but new tenant
+    # data flows through the per-project jobs registered here.
+    from collectors.per_project import register_jobs_for_all_active_connections
+
+    try:
+        register_jobs_for_all_active_connections(_scheduler)
+    except Exception as exc:
+        logger.warning("per-project job registration failed: %s", exc)
+
 
 def get_scheduler() -> BackgroundScheduler | None:
     return _scheduler

--- a/tests/test_per_project.py
+++ b/tests/test_per_project.py
@@ -1,0 +1,298 @@
+"""Per-connection scheduling tests (#54).
+
+We don't spin up a real APScheduler — the lifecycle is exercised with a
+``MagicMock`` standing in for the scheduler. The job body
+``collect_for_connection`` is tested against an in-memory SQLite (target
+DB == metrics DB == same file) so we can verify it actually writes rows
+tagged with the right ``project_id`` without needing a Postgres.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+from collectors.per_project import (
+    add_job_for_connection,
+    collect_for_connection,
+    job_id_for,
+    list_jobs_for_user,
+    parse_job_id,
+    register_jobs_for_all_active_connections,
+    remove_job_for_connection,
+    user_owns_job,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    """Fresh SQLite metrics DB AND scoped to a single test."""
+    db_path = tmp_path / "scheduled.db"
+    import app.metrics_storage as storage_mod
+
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    return storage_mod
+
+
+@pytest.fixture
+def fake_scheduler():
+    """MagicMock scheduler that captures add_job / remove_job / get_job."""
+    sched = MagicMock(name="scheduler")
+    sched.running = True
+    sched._jobs = {}  # MagicMock isn't dict-like by default
+
+    def _add(fn, *args, id=None, **kwargs):
+        job = MagicMock(id=id, name=kwargs.get("name", id))
+        sched._jobs[id] = job
+        return job
+
+    def _remove(jid):
+        sched._jobs.pop(jid, None)
+
+    def _get(jid):
+        return sched._jobs.get(jid)
+
+    def _list():
+        return list(sched._jobs.values())
+
+    sched.add_job.side_effect = _add
+    sched.remove_job.side_effect = _remove
+    sched.get_job.side_effect = _get
+    sched.get_jobs.side_effect = _list
+    return sched
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _seed_user_with_active_connection(storage, dsn: str):
+    """Create a user + project + active connection. Returns (user_id, project, connection)."""
+    user_id = uuid.uuid4().hex
+    storage.create_user(user_id=user_id, email=f"u{user_id[:6]}@x.io",
+                        password_hash="x")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=user_id,
+        name="P", slug="default",
+    )
+    conn = storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"],
+        name="local",
+        dsn_encrypted=crypto.encrypt_dsn(dsn),
+        schema_name="main",  # SQLite default schema
+        interval_minutes=15,
+        is_active=True,
+    )
+    return user_id, project, conn
+
+
+# --- job_id_for / parse_job_id -------------------------------------------
+
+
+def test_job_id_round_trip():
+    jid = job_id_for("proj-abc", "conn-def")
+    assert jid == "collect:proj-abc:conn-def"
+    assert parse_job_id(jid) == ("proj-abc", "conn-def")
+
+
+def test_parse_job_id_returns_none_for_non_collect_ids():
+    assert parse_job_id("collect_all_tables") is None
+    assert parse_job_id("retrain_forecasts") is None
+    assert parse_job_id("collect:single") is None
+
+
+# --- add_job_for_connection / remove ---------------------------------------
+
+
+def test_add_job_for_connection_registers_with_stable_id(fake_scheduler):
+    add_job_for_connection(fake_scheduler, "proj-X", {
+        "id": "conn-Y", "interval_minutes": 15,
+    })
+    fake_scheduler.add_job.assert_called_once()
+    call = fake_scheduler.add_job.call_args
+    assert call.kwargs["id"] == "collect:proj-X:conn-Y"
+    assert call.kwargs["minutes"] == 15  # interval honoured
+    assert call.kwargs["max_instances"] == 1
+    assert call.kwargs["coalesce"] is True
+    assert call.kwargs["replace_existing"] is True
+
+
+def test_remove_job_unregisters_only_when_present(fake_scheduler):
+    # No-op if job doesn't exist yet.
+    remove_job_for_connection(fake_scheduler, "p", "c")
+    fake_scheduler.remove_job.assert_not_called()
+
+    # Register, then remove.
+    add_job_for_connection(fake_scheduler, "p", {"id": "c", "interval_minutes": 5})
+    remove_job_for_connection(fake_scheduler, "p", "c")
+    fake_scheduler.remove_job.assert_called_once_with("collect:p:c")
+
+
+def test_add_job_no_op_when_scheduler_not_running():
+    sched = MagicMock()
+    sched.running = False
+    add_job_for_connection(sched, "p", {"id": "c", "interval_minutes": 5})
+    sched.add_job.assert_not_called()
+
+
+# --- register_jobs_for_all_active_connections -----------------------------
+
+
+def test_register_enumerates_active_connections(storage, fake_scheduler):
+    """Bootstrap: every active connection in the DB gets a job."""
+    _, project, conn1 = _seed_user_with_active_connection(
+        storage, dsn=f"sqlite:///{':memory:'}",
+    )
+    # Second active connection in the same project.
+    conn2 = storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"], name="second",
+        dsn_encrypted=crypto.encrypt_dsn("sqlite:///:memory:"),
+        schema_name="main", interval_minutes=30, is_active=True,
+    )
+    # Inactive connection — must NOT be registered.
+    storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"], name="off",
+        dsn_encrypted=crypto.encrypt_dsn("sqlite:///:memory:"),
+        schema_name="main", interval_minutes=10, is_active=False,
+    )
+
+    n = register_jobs_for_all_active_connections(fake_scheduler)
+    assert n == 2
+    registered_ids = {call.kwargs["id"] for call in fake_scheduler.add_job.call_args_list}
+    assert job_id_for(project["id"], conn1["id"]) in registered_ids
+    assert job_id_for(project["id"], conn2["id"]) in registered_ids
+
+
+# --- collect_for_connection (full path) ------------------------------------
+
+
+def test_collect_for_connection_writes_metrics_with_project_id(storage, tmp_path):
+    """End-to-end: create a real SQLite target, point a connection at it,
+    run the job, check that metrics land tagged with the right project_id.
+    """
+    # Build a target SQLite DB with a single table, populate one row so
+    # the Postgres adapter… wait — SQLite isn't a supported adapter.
+    # We need a Postgres-compatible target for the adapter path.
+    # Workaround: skip the adapter and test the job's persistence logic
+    # via a monkeypatch.
+    user_id, project, conn = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@unreachable:5432/d",
+    )
+    from collectors import metrics_collector
+
+    # Stub the heavy lifting: pretend the collector produced one row.
+    fake_rows = [{
+        "ts": datetime.now(UTC), "table_name": "users",
+        "metric_name": "row_count", "value": 42.0,
+    }]
+    import app.db as db_mod
+
+    def fake_list_tables(self, schema):
+        return [{"table_name": "users", "schema": schema}]
+    import unittest.mock as mock
+    with mock.patch.object(metrics_collector.MetricsCollector, "collect",
+                           return_value=fake_rows), \
+         mock.patch.object(db_mod.PostgresAdapter, "list_tables",
+                           autospec=True, side_effect=fake_list_tables):
+        collect_for_connection(project["id"], conn["id"])
+
+    # The metrics row should be tagged with this project's id.
+    rows = storage.get_metrics("users", "row_count", project["id"],
+                                window=__import__("datetime").timedelta(minutes=5))
+    assert len(rows) == 1
+    assert rows[0]["value"] == 42.0
+
+    # And NOT visible from another tenant.
+    other_rows = storage.get_metrics("users", "row_count", "other-tenant",
+                                      window=__import__("datetime").timedelta(minutes=5))
+    assert other_rows == []
+
+
+def test_collect_for_connection_skips_inactive(storage):
+    """Job re-checks is_active on each tick — covers the race where a
+    connection is deactivated between job-fire scheduling and the actual
+    callback.
+    """
+    user_id, project, conn = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@h/d",
+    )
+    storage.set_connection_active(project["id"], conn["id"], is_active=False)
+    # Should return without raising even though DSN host is unreachable.
+    collect_for_connection(project["id"], conn["id"])
+    # And no metrics written.
+    rows = storage.get_metrics("users", "row_count", project["id"],
+                                window=__import__("datetime").timedelta(minutes=5))
+    assert rows == []
+
+
+def test_collect_for_connection_handles_unknown_id(storage):
+    """A job that fires for a deleted connection just logs and returns."""
+    collect_for_connection("ghost-project", "ghost-conn")  # no exception
+
+
+# --- /admin/jobs scoping ---------------------------------------------------
+
+
+def test_list_jobs_for_user_filters_to_owned_projects(storage, fake_scheduler):
+    """User-A sees only their connection jobs; user-B's are hidden."""
+    user_a, project_a, conn_a = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@h/d",
+    )
+    # Second user with their own project + connection.
+    user_b = uuid.uuid4().hex
+    storage.create_user(user_id=user_b, email="b@x.io", password_hash="x")
+    project_b = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=user_b,
+        name="B", slug="default",
+    )
+    conn_b = storage.create_connection(
+        connection_id=uuid.uuid4().hex, project_id=project_b["id"],
+        name="b-conn", dsn_encrypted=crypto.encrypt_dsn("postgresql://u:p@h/d"),
+        schema_name="public", interval_minutes=15, is_active=True,
+    )
+
+    add_job_for_connection(fake_scheduler, project_a["id"],
+                            {"id": conn_a["id"], "interval_minutes": 15})
+    add_job_for_connection(fake_scheduler, project_b["id"],
+                            {"id": conn_b["id"], "interval_minutes": 15})
+    # Add a global job — must NOT appear in either user's list.
+    fake_scheduler.add_job(lambda: None, "interval", minutes=15,
+                            id="collect_all_tables", name="collect_all_tables")
+
+    a_jobs = list_jobs_for_user(fake_scheduler, user_a)
+    b_jobs = list_jobs_for_user(fake_scheduler, user_b)
+
+    assert [j["connection_id"] for j in a_jobs] == [conn_a["id"]]
+    assert [j["connection_id"] for j in b_jobs] == [conn_b["id"]]
+    # Global jobs excluded (not prefixed with collect:).
+    assert all(j["id"].startswith("collect:") for j in a_jobs + b_jobs)
+
+
+def test_user_owns_job_rejects_cross_tenant(storage):
+    user_a, project_a, conn_a = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@h/d",
+    )
+    user_b = uuid.uuid4().hex
+    storage.create_user(user_id=user_b, email="b@x.io", password_hash="x")
+    jid = job_id_for(project_a["id"], conn_a["id"])
+
+    assert user_owns_job(user_a, jid) is True
+    assert user_owns_job(user_b, jid) is False
+    # Non-collect job id → False (the caller still needs to look it up
+    # against the scheduler; user_owns_job is the tenant check only).
+    assert user_owns_job(user_a, "collect_all_tables") is False


### PR DESCRIPTION
## Summary

Closes #54. Седьмой тикет Sprint 3 multi-tenant эпика. Каждый активный коннект теперь имеет свой scheduled job, который читает из его DSN и пишет метрики с настоящим `project_id` (из #53), а не в общий `'legacy'` бакет.

## Что внутри

- **`app/db.py`** — `using_engine(engine, adapter)` контекст + `_engine_override` / `_adapter_override` ContextVar-ы. Per-job tick сетит свой engine на время тика, существующий adapter-код (PostgresAdapter и др.) работает без правок. `make_adapter_for_url(url)` — фабрика свежего адаптера для произвольного DSN.
- **`collectors/per_project.py`** — новый модуль:
  - `job_id_for(project_id, conn_id)` → `"collect:<pid>:<cid>"`
  - `collect_for_connection(...)` — тело job-а: decrypt DSN, создать NullPool engine, using_engine + MetricsCollector, save_metrics(rows, project_id). Errors в этом скоупе пойманы — один битый тик не валит scheduler.
  - `add_job_for_connection` / `remove_job_for_connection` — idempotent. Options: `misfire_grace_time=60`, `max_instances=1`, `coalesce=True`, `replace_existing=True` per spec.
  - `register_jobs_for_all_active_connections(scheduler)` — boot-time enumeration.
  - `list_jobs_for_user` / `user_owns_job` — фильтры для /admin/jobs scoping.
- **`app/connections.py`** лайфсайкл-хуки: create active → add_job; delete → remove_job; toggle → add/remove по новому состоянию.
- **`collectors/scheduler.py`** после start() регистрирует per-connection jobs. Глобальный `collect_all_tables` остаётся (`'legacy'` тенант, backward-compat).
- **`app/admin.py`**:
  - `/admin/jobs` для авторизованного юзера показывает ТОЛЬКО его `collect:<его_project_id>:*` jobs. Global ops jobs (forecast retrain, drift sweep) исключены — это операторские, не тенант-овые.
  - `/admin/jobs/<id>/run` → 404 на попытку триггера чужого collect-job-а (через `user_owns_job`).

## Тесты — `tests/test_per_project.py` (11 кейсов)

| Группа | Что проверяется |
|---|---|
| job_id | round-trip, `parse_job_id` отбивает non-collect ids |
| add/remove | стабильный id, options, no-op на не запущенном scheduler |
| register | перечисляет только `is_active=1` connections |
| collect_for_connection | end-to-end (monkeypatched MetricsCollector) — metrics с правильным project_id, изоляция от другого тенанта |
| safety | skip-if-inactive, handle-unknown-id |
| /admin scoping | два юзера видят только свои jobs; глобальные исключены; cross-tenant `run` → 404 |

## Verification

- `pytest -q`: **448 passed** (+11 от #54), 31 deselected.
- `ruff check .`: clean.

## Acceptance (issue #54)

- [x] `collect:<project_id>:<connection_id>` формат job_id
- [x] `register_jobs_for_all_active_connections` на старте
- [x] create/activate → `add_job` immediately
- [x] delete/deactivate → `remove_job`
- [x] Per-connection `interval_minutes`
- [x] `misfire_grace=60`, `max_instances=1`, `coalesce=True`
- [x] `/admin/jobs` ограничен своими, чужие в `/run` → 404
- [x] Лог префикс `[project=<id>][conn=<id>] collected N metrics in Xms`

## Не входит (Sprint 4 follow-ups)

- **Hot-reload interval change**: правка `interval_minutes` в UI не пересоздаёт job (CRUD на edit пока нет — `/connections/<id>` редактирование не реализовано; будущий тикет).
- **Job persistence across restarts**: APScheduler с in-memory store — jobs re-registered на каждый старт через `register_jobs_for_all_active_connections`. Это работает, но если worker рестартует mid-tick, тик теряется до следующего интервала.
- **Concurrency limit per project**: сейчас все коннекты тенанта могут запуститься параллельно; для лимитов нужен общий thread/proc-pool с tagging.

## Sprint 3 после этого: 7/8 done. Остался только #55 (Onboarding + landing).

## Test plan

- [x] 11 unit-кейсов зелёные.
- [x] Все 437 предыдущих не задеты.
- [ ] Manual smoke после мерджа: создать коннект через UI → `/admin/jobs` показывает `collect:<pid>:<cid>` → подождать interval → видны метрики на dashboard.