### PR TITLE
feat(#55): Onboarding flow + публичный landing — закрывает Sprint 3 эпик

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from flask import Flask, jsonify, redirect
+from flask import Flask, jsonify, redirect, render_template
 from flask_wtf.csrf import CSRFProtect
 
 from .admin import bp as admin_bp
@@ -147,10 +147,17 @@ def create_app(config: dict | None = None):
 
     @app.route("/")
     def index():
-        # Use url_for so we hit the canonical /dashboard/ trailing-slash
-        # form directly instead of /dashboard → 308 → /dashboard/.
+        """Public landing for anonymous, dashboard for signed-in users (#55).
+
+        The marketing page is the same surface a cold visitor sees; an
+        authenticated user always wants the dashboard, never the pitch.
+        """
         from flask import url_for
-        return redirect(url_for("dashboard.overview"))
+        from flask_login import current_user
+
+        if current_user.is_authenticated:
+            return redirect(url_for("dashboard.overview"))
+        return render_template("landing.html")
 
     @app.route("/healthz")
     @limiter.exempt

--- a/app/auth.py
+++ b/app/auth.py
@@ -199,9 +199,13 @@ def register():
         # user never sees an empty projects switcher. Lazy import to avoid
         # a circular dependency (projects → auth.User for current_user).
         from app.projects import create_default_project_for
-        create_default_project_for(row["id"])
-        flash("Аккаунт создан. Добро пожаловать!", "success")
-        return redirect(url_for("dashboard.overview"))
+        default_project = create_default_project_for(row["id"])
+        # Onboarding redirect (#55): land on the wizard, not an empty
+        # dashboard. The connections form detects "zero existing
+        # connections" and shows the wizard template.
+        return redirect(url_for(
+            "connections.new_connection", slug=default_project["slug"],
+        ))
     return render_template("auth/register.html", form=form)
 
 

--- a/app/connections.py
+++ b/app/connections.py
@@ -122,13 +122,18 @@ def list_connections(slug: str):
 @login_required
 def new_connection(slug: str):
     project = _require_owned_project(slug)
+    # Onboarding mode (#55): zero existing connections → render the wizard
+    # template (DSN-format hints) and auto-probe after save. Once a project
+    # has ≥1 connection, the route reverts to the plain power-user form.
+    is_first = not metrics_storage.list_connections_for_project(project["id"])
     form = ConnectionForm()
     if form.validate_on_submit():
+        raw_dsn = form.dsn.data
         conn_row = metrics_storage.create_connection(
             connection_id=uuid.uuid4().hex,
             project_id=project["id"],
             name=form.name.data.strip(),
-            dsn_encrypted=crypto.encrypt_dsn(form.dsn.data),
+            dsn_encrypted=crypto.encrypt_dsn(raw_dsn),
             schema_name=form.schema_name.data.strip(),
             interval_minutes=form.interval_minutes.data,
             is_active=form.is_active.data,
@@ -142,13 +147,36 @@ def new_connection(slug: str):
             from collectors.scheduler import get_scheduler
 
             add_job_for_connection(get_scheduler(), project["id"], conn_row)
+
+        # Onboarding auto-test (#55): on the FIRST connection, probe the
+        # DSN immediately so the user gets instant feedback instead of
+        # waiting for the next collector tick. OK → land on /dashboard
+        # with a positive flash; failure → /connections with the code so
+        # they can edit/delete and retry.
+        if is_first:
+            result = probe_connection(raw_dsn)
+            if result["status"] == "ok":
+                flash(
+                    "Подключение проверено. Сбор метрик запустится через "
+                    f"{conn_row['interval_minutes']} мин.",
+                    "success",
+                )
+                return redirect(url_for("dashboard.overview"))
+            flash(
+                "Подключение сохранено, но автоматический тест не прошёл "
+                f"({result.get('code', 'error')}). Откройте список подключений и нажмите «Тест».",
+                "error",
+            )
+            return redirect(url_for("connections.list_connections", slug=slug))
+
         flash("Подключение добавлено.", "success")
         return redirect(url_for(
             "connections.list_connections", slug=slug,
         ))
-    return render_template(
-        "connections/new.html", project=project, form=form,
+    template = (
+        "onboarding/add_connection.html" if is_first else "connections/new.html"
     )
+    return render_template(template, project=project, form=form)
 
 
 @bp.route("/<conn_id>/delete", methods=["POST"])

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -48,6 +48,17 @@ bp = Blueprint(
 @bp.route("")
 @bp.route("/")
 def overview():
+    # Onboarding empty state (#55): if the current project has zero
+    # connections yet, render the dashboard with a CTA banner instead of
+    # an empty table grid. Anonymous / legacy paths fall through to the
+    # legacy global view.
+    from app.metrics_storage import list_connections_for_project
+
+    has_connections = False
+    project = getattr(g, "current_project", None)
+    if project is not None:
+        has_connections = bool(list_connections_for_project(project["id"]))
+
     tables = []
     total_rows = 0
     null_rates = []
@@ -73,6 +84,7 @@ def overview():
         tables=tables,
         summary=summary,
         ml_last_runs=_ml_last_runs(),
+        needs_first_connection=project is not None and not has_connections,
     )
 
 

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="ru" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DB Monitor — мониторинг качества данных</title>
+    <script>
+      // Pre-paint theme application — same logic as auth/_layout.html.
+      (function () {
+        const stored = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        const theme = stored || (prefersDark ? "dark" : "light");
+        if (theme === "dark") document.documentElement.classList.add("dark");
+      })();
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: { extend: { colors: { accent: { DEFAULT: "#305496", hover: "#264079" } },
+          fontFamily: { sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"] } } },
+      };
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  </head>
+  <body class="min-h-full bg-slate-50 text-slate-800 antialiased dark:bg-slate-950 dark:text-slate-100">
+
+    <header class="border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
+      <div class="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
+        <div class="flex items-center gap-2">
+          <div class="flex h-7 w-7 items-center justify-center rounded-md bg-accent text-sm font-semibold text-white">DB</div>
+          <span class="font-semibold">DB Monitor</span>
+        </div>
+        <nav class="flex items-center gap-2 text-sm">
+          <a href="{{ url_for('auth.login') }}" class="rounded-md px-3 py-1.5 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800">Войти</a>
+          <a href="{{ url_for('auth.register') }}" class="rounded-md bg-accent px-3 py-1.5 font-medium text-white shadow-sm hover:bg-accent-hover">Создать аккаунт</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="mx-auto max-w-6xl px-6 py-16">
+
+      <section class="text-center">
+        <h1 class="text-4xl font-semibold tracking-tight sm:text-5xl">
+          Мониторинг качества данных<br class="hidden sm:block">
+          без боли и алёртов в три ночи
+        </h1>
+        <p class="mx-auto mt-5 max-w-2xl text-lg text-slate-600 dark:text-slate-400">
+          Подключите Postgres / MySQL / ClickHouse — и мы соберём метрики
+          (row_count, null_rate, drift, аномалии), нарисуем дашборд и пришлём
+          в Telegram, когда что-то поедет. Self-hosted, шифрование DSN, multi-tenant.
+        </p>
+        <div class="mt-8 flex items-center justify-center gap-3">
+          <a href="{{ url_for('auth.register') }}" class="rounded-md bg-accent px-5 py-3 text-sm font-medium text-white shadow-sm hover:bg-accent-hover">
+            Создать аккаунт →
+          </a>
+          <a href="{{ url_for('auth.login') }}" class="rounded-md border border-slate-200 px-5 py-3 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
+            Войти
+          </a>
+        </div>
+        <p class="mt-3 text-xs text-slate-500 dark:text-slate-400">
+          Нужна почта и пароль. Никаких карт.
+        </p>
+      </section>
+
+      <section class="mt-20 grid grid-cols-1 gap-6 sm:grid-cols-3">
+        {% set features = [
+          ("Live-метрики", "row_count, null_rate, size_bytes, distributions — без правок продакшен-БД. Шифрованный DSN, read-only доступ."),
+          ("ML на коробке", "Isolation Forest для аномалий, Prophet для прогноза роста, PELT для change-points, PSI/KS для drift."),
+          ("Multi-tenant", "Каждый проект изолирован: свои коннекты, свои метрики, свой шедулер. Шифрованные DSN at rest."),
+        ] %}
+        {% for title, body in features %}
+          <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <h3 class="text-base font-semibold">{{ title }}</h3>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">{{ body }}</p>
+          </div>
+        {% endfor %}
+      </section>
+
+      <section class="mt-20 rounded-xl border border-slate-200 bg-white p-8 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <h2 class="text-2xl font-semibold tracking-tight">Как это работает</h2>
+        <ol class="mt-4 space-y-3 text-sm text-slate-700 dark:text-slate-300">
+          <li><span class="inline-block w-6 font-semibold text-accent">1.</span> Регистрируетесь — мы создаём «Default» проект автоматически.</li>
+          <li><span class="inline-block w-6 font-semibold text-accent">2.</span> Добавляете подключение к своей БД (DSN шифруется Fernet).</li>
+          <li><span class="inline-block w-6 font-semibold text-accent">3.</span> Через 15 минут на дашборде появляются первые метрики.</li>
+          <li><span class="inline-block w-6 font-semibold text-accent">4.</span> Drift / change-points / anomalies прилетают в Telegram (опционально).</li>
+        </ol>
+      </section>
+
+    </main>
+
+    <footer class="border-t border-slate-200 py-8 dark:border-slate-800">
+      <div class="mx-auto max-w-6xl px-6 text-center text-xs text-slate-500 dark:text-slate-400">
+        Open source · self-hosted · MIT licence
+      </div>
+    </footer>
+
+  </body>
+</html>

--- a/templates/onboarding/add_connection.html
+++ b/templates/onboarding/add_connection.html
@@ -1,0 +1,101 @@
+{% extends "base.html" %}
+{% from "auth/_macros.html" import render_field %}
+{% block title %}Добавьте первое подключение — DB Monitor{% endblock %}
+{% block breadcrumb %}<span class="font-medium text-slate-700 dark:text-slate-200">Шаг 1 из 1 — добавьте подключение</span>{% endblock %}
+
+{% set input_cls = "mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent dark:border-slate-700 dark:bg-slate-950" %}
+
+{% block content %}
+  <div class="mx-auto max-w-3xl">
+
+    <div class="rounded-xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-200">
+      <strong>Аккаунт создан.</strong> Осталось подключить вашу БД — после
+      этого первые метрики появятся на дашборде через ~15 минут.
+    </div>
+
+    <h1 class="mt-8 text-2xl font-semibold tracking-tight">Подключение к БД</h1>
+    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+      DSN шифруется через Fernet и никогда не показывается в открытом виде после сохранения. После сохранения мы автоматически проверим подключение.
+    </p>
+
+    <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+      {# Wizard hints on the left — what DSN looks like for popular providers. #}
+      <aside class="lg:col-span-1">
+        <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Где взять DSN</h2>
+          <div class="mt-4 space-y-4 text-xs text-slate-600 dark:text-slate-300">
+
+            <div>
+              <div class="font-semibold text-slate-800 dark:text-slate-200">Supabase / pooler</div>
+              <div class="mt-1 break-all font-mono text-[11px]">
+                postgresql://postgres.&lt;project&gt;:&lt;password&gt;@aws-0-&lt;region&gt;.pooler.supabase.com:5432/postgres
+              </div>
+              <div class="mt-1 text-slate-500 dark:text-slate-400">
+                Supabase → Project Settings → Database → Connection Pooling → Session mode.
+              </div>
+            </div>
+
+            <div>
+              <div class="font-semibold text-slate-800 dark:text-slate-200">PostgreSQL (свой)</div>
+              <div class="mt-1 break-all font-mono text-[11px]">
+                postgresql://user:password@host:5432/dbname
+              </div>
+            </div>
+
+            <div>
+              <div class="font-semibold text-slate-800 dark:text-slate-200">MySQL</div>
+              <div class="mt-1 break-all font-mono text-[11px]">
+                mysql+pymysql://user:password@host:3306/dbname
+              </div>
+            </div>
+
+            <div>
+              <div class="font-semibold text-slate-800 dark:text-slate-200">ClickHouse</div>
+              <div class="mt-1 break-all font-mono text-[11px]">
+                clickhouse+native://user:password@host:9000/dbname
+              </div>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+          <strong>Совет:</strong> создайте read-only пользователя в БД. Мы только читаем <code>information_schema</code> и считаем NULL по колонкам — DML/DDL не нужны.
+        </div>
+      </aside>
+
+      {# Form — same fields as connections/new.html, different chrome. #}
+      <section class="lg:col-span-2">
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <form method="POST" action="{{ url_for('connections.new_connection', slug=project.slug) }}" class="space-y-4" novalidate>
+            {{ form.hidden_tag() }}
+
+            {{ render_field(form.name, input_class=input_cls) }}
+            {{ render_field(form.dsn, input_class=input_cls) }}
+            <p class="text-xs text-slate-500 dark:text-slate-400">
+              Скопируйте DSN из подсказок слева. Пароль скрыт после ввода.
+            </p>
+
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {{ render_field(form.schema_name, input_class=input_cls) }}
+              {{ render_field(form.interval_minutes, input_class=input_cls) }}
+            </div>
+
+            <div class="flex items-center gap-2">
+              {{ form.is_active(class="h-4 w-4 rounded border-slate-300 text-accent focus:ring-accent dark:border-slate-700 dark:bg-slate-950") }}
+              <label for="{{ form.is_active.id }}" class="text-sm text-slate-600 dark:text-slate-300">{{ form.is_active.label.text }}</label>
+            </div>
+
+            <div class="flex items-center justify-between pt-2">
+              <a href="{{ url_for('dashboard.overview') }}" class="text-sm text-slate-500 hover:text-accent dark:text-slate-400">Пропустить →</a>
+              <button type="submit" class="rounded-md bg-accent px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover">
+                Сохранить и проверить
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+    </div>
+  </div>
+{% endblock %}

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -5,6 +5,23 @@
 {% block content %}
   <h1 class="text-2xl font-semibold tracking-tight">Обзор</h1>
 
+  <div class="mt-4">{% include "_flash.html" %}</div>
+
+  {% if needs_first_connection %}
+    {# Empty state (#55): new project with zero connections. Friendly
+       CTA instead of an empty table grid. #}
+    <section class="mt-6 rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 class="text-lg font-semibold">Нет подключений</h2>
+      <p class="mx-auto mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+        Добавьте первое подключение к БД — через 15 минут на этой странице появятся метрики.
+      </p>
+      <a href="{{ url_for('connections.new_connection', slug=g.current_project.slug) }}"
+         class="mt-4 inline-block rounded-md bg-accent px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover">
+        Добавить подключение →
+      </a>
+    </section>
+  {% endif %}
+
   <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
     {% set kpis = [
       ("Мониторируется таблиц", summary.table_count|string),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -64,8 +64,10 @@ def test_register_creates_user_logs_in_and_redirects(client):
         follow_redirects=False,
     )
     assert resp.status_code == 302
-    assert resp.headers["Location"].endswith("/dashboard/")
-    # Session cookie was set — subsequent /dashboard hits land 200, not 302.
+    # #55: register now redirects to the onboarding wizard for the
+    # auto-created Default project — not directly to /dashboard.
+    assert resp.headers["Location"].endswith("/projects/default/connections/new")
+    # Session cookie was set — /dashboard is reachable (200, not 302).
     follow = client.get("/dashboard/")
     assert follow.status_code == 200
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -45,12 +45,14 @@ def test_status_class_buckets():
     assert status_class(0.95) == "crit"
 
 
-def test_root_redirects_to_dashboard(client):
+def test_root_renders_landing_for_anonymous(client):
+    # #55: / shows the public landing for anonymous visitors; authed users
+    # get the dashboard redirect (covered in test_onboarding.py).
     resp = client.get("/")
-    assert resp.status_code == 302
-    # url_for points at the canonical trailing-slash form, avoiding a
-    # secondary 308 on /dashboard → /dashboard/.
-    assert resp.headers["Location"].endswith("/dashboard/")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "DB Monitor" in body
+    assert "/auth/login" in body
 
 
 def test_overview_renders_kpis_and_table_from_storage(client):

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,213 @@
+"""Onboarding flow + landing tests for #55.
+
+Covers the acceptance bullet-list:
+- Anonymous ``/`` renders the marketing landing
+- Authenticated ``/`` redirects to /dashboard
+- Register lands on the onboarding wizard (not an empty dashboard)
+- First-connection POST auto-tests the DSN
+- /dashboard without active connections shows the empty-state banner
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def app_(tmp_path, monkeypatch):
+    db_path = tmp_path / "ob.db"
+    import app.metrics_storage as storage
+
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    # Empty target — onboarding tests never need real tables.
+    import app.api
+    import app.dashboard
+    import app.db
+    def fake_list(schema=None):
+        return []
+    monkeypatch.setattr(app.db, "list_tables", fake_list)
+    monkeypatch.setattr(app.api, "list_tables", fake_list)
+
+    from app.app import create_app
+    app = create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+    # No limiter reset — TESTING disables RATELIMIT_ENABLED, so the
+    # storage backend isn't initialised and ``limiter.reset()`` would
+    # raise on the inner assert. Tests below don't exhaust limits anyway.
+    return app
+
+
+@pytest.fixture
+def client(app_):
+    return app_.test_client()
+
+
+def _register(client, email="u@example.com"):
+    return client.post(
+        "/auth/register",
+        data={"email": email, "password": "supersecret1", "confirm": "supersecret1"},
+        follow_redirects=False,
+    )
+
+
+# --- Public landing -------------------------------------------------------
+
+
+def test_anonymous_root_renders_landing(client):
+    resp = client.get("/", follow_redirects=False)
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "DB Monitor" in body
+    # CTA links are present.
+    assert "/auth/register" in body
+    assert "/auth/login" in body
+
+
+def test_authenticated_root_redirects_to_dashboard(client):
+    _register(client)
+    resp = client.get("/", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/dashboard/")
+
+
+# --- Register lands on onboarding wizard ----------------------------------
+
+
+def test_register_redirects_to_onboarding_wizard(client):
+    resp = _register(client, "new@example.com")
+    assert resp.status_code == 302
+    # Slug for the auto-created Default project is "default".
+    assert resp.headers["Location"].endswith("/projects/default/connections/new")
+
+
+def test_onboarding_template_rendered_when_project_empty(client):
+    _register(client, "fresh@example.com")
+    resp = client.get("/projects/default/connections/new")
+    body = resp.get_data(as_text=True)
+    # Wizard-specific copy is in onboarding/add_connection.html only.
+    assert "Где взять DSN" in body
+    assert "Сохранить и проверить" in body
+
+
+def test_regular_template_rendered_when_project_has_connections(client, monkeypatch):
+    """A power-user adding their second connection sees the standard form,
+    not the wizard."""
+    _register(client, "poweruser@example.com")
+    # First connection — wizard mode. Stub probe so it doesn't try to
+    # connect to a real DB during the auto-test path.
+    import app.connections as conn_mod
+    monkeypatch.setattr(
+        conn_mod, "probe_connection",
+        lambda dsn: {"status": "ok", "database": "x", "version": "y", "latency_ms": 1},
+    )
+    client.post("/projects/default/connections/new", data={
+        "name": "First", "dsn": "postgresql://u:p@h:5432/d",
+        "schema_name": "public", "interval_minutes": 15, "is_active": "y",
+    })
+    # Second GET should now hit the non-wizard form.
+    resp = client.get("/projects/default/connections/new")
+    body = resp.get_data(as_text=True)
+    assert "Где взять DSN" not in body  # wizard sidebar absent
+    assert "Новое подключение" in body  # plain form heading
+
+
+# --- Auto-test after first connection -------------------------------------
+
+
+def test_first_connection_auto_test_success_redirects_to_dashboard(client, monkeypatch):
+    _register(client, "ok@example.com")
+    import app.connections as conn_mod
+    monkeypatch.setattr(
+        conn_mod, "probe_connection",
+        lambda dsn: {
+            "status": "ok", "database": "appdb",
+            "version": "PostgreSQL 16.1", "latency_ms": 4,
+        },
+    )
+    resp = client.post(
+        "/projects/default/connections/new",
+        data={
+            "name": "Prod", "dsn": "postgresql://u:p@h:5432/d",
+            "schema_name": "public", "interval_minutes": 15, "is_active": "y",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/dashboard/")
+
+
+def test_first_connection_auto_test_failure_redirects_to_connections_list(client, monkeypatch):
+    _register(client, "bad@example.com")
+    import app.connections as conn_mod
+    monkeypatch.setattr(
+        conn_mod, "probe_connection",
+        lambda dsn: {
+            "status": "error", "code": "auth_failed",
+            "message": "Неверный логин или пароль.", "latency_ms": 12,
+        },
+    )
+    resp = client.post(
+        "/projects/default/connections/new",
+        data={
+            "name": "Bad", "dsn": "postgresql://u:wrong@h:5432/d",
+            "schema_name": "public", "interval_minutes": 15, "is_active": "y",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    # url_for resolves to the trailing-slash form of list_connections;
+    # strip before comparing so we don't depend on the rule order.
+    assert resp.headers["Location"].rstrip("/").endswith("/projects/default/connections")
+
+    # Connection was still saved (so the user can edit/delete from the list).
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+    user = get_user_by_email("bad@example.com")
+    project = list_projects_for_user(user["id"])[0]
+    assert len(list_connections_for_project(project["id"])) == 1
+
+
+# --- /dashboard empty state -----------------------------------------------
+
+
+def test_dashboard_empty_state_when_no_connections(client):
+    _register(client, "empty@example.com")
+    resp = client.get("/dashboard/")
+    body = resp.get_data(as_text=True)
+    assert "Нет подключений" in body
+    assert "/projects/default/connections/new" in body
+
+
+def test_dashboard_no_empty_state_with_at_least_one_connection(client, monkeypatch):
+    _register(client, "stocked@example.com")
+    import app.connections as conn_mod
+    monkeypatch.setattr(
+        conn_mod, "probe_connection",
+        lambda dsn: {"status": "ok", "database": "x", "version": "y", "latency_ms": 1},
+    )
+    # Add one connection; redirect goes to /dashboard (success path).
+    client.post("/projects/default/connections/new", data={
+        "name": "Prod", "dsn": "postgresql://u:p@h:5432/d",
+        "schema_name": "public", "interval_minutes": 15, "is_active": "y",
+    })
+    resp = client.get("/dashboard/")
+    body = resp.get_data(as_text=True)
+    assert "Нет подключений" not in body


### PR DESCRIPTION
## Summary

Closes #55. Последний тикет Sprint 3 multi-tenant эпика (#48). Замыкает loop: первый visit → marketing landing → register → онбординг-визард → авто-тест коннекта → dashboard с реальными метриками.

## Что внутри

- **`templates/landing.html`** — публичная страница для анона: 3 фичи (live-метрики / ML / multi-tenant), 4-шаговый how-it-works, Sign up / Log in CTA. Pre-paint theme, тот же aesthetic что у дашборда.
- **`/` форк по auth state** (`app/app.py::index`): anon → landing, authed → /dashboard. Раньше anon ловил 302 → /auth/login.
- **Register → онбординг-визард**: после `POST /auth/register` редирект на `/projects/default/connections/new` (Default project уже авто-создавался с #50).
- **`templates/onboarding/add_connection.html`** — wizard-style: левая колонка с подсказками DSN-формата для Supabase / PostgreSQL / MySQL / ClickHouse + советом про read-only пользователя; справа форма (поля те же, что у обычной /connections/new).
- **`new_connection` switches templates**: `is_first = len(existing) == 0` → wizard; иначе — обычная форма. Power-user добавляющий N-й коннект не получает визард.
- **Auto-test первого коннекта** (#55 spec): после save вызывается `probe_connection` (из #52):
  - `status="ok"` → flash success + redirect `/dashboard`
  - иначе → flash error c кодом + redirect /connections (коннект сохраняется, юзер видит его в списке и нажимает кнопку «Тест» вручную из #52)
- **Empty state на /dashboard** когда у current_project ноль коннектов: CTA-карточка «Добавить подключение →» вместо пустой таблицы. Реализовано через `needs_first_connection` флаг в шаблоне.

## Verification

- `pytest -q`: **457 passed** (+9 от #55, 31 deselected). Существующие 448 не задеты.
- `ruff check .`: clean.

## Acceptance (issue #55)

- [x] `/` — публичный landing с CTA Sign up / Log in
- [x] После register → авто-создание Default + редирект на `/projects/default/connections/new`
- [x] `templates/onboarding/add_connection.html` wizard с DSN-подсказками
- [x] После первого коннекта — auto-test → toast «Сбор метрик запустится через 15 мин» + редирект `/dashboard`
- [x] На `/dashboard` без коннектов — empty state «Нет подключений, добавьте первое»
- [x] Anon видит маркетинг, authed — редирект на свои проекты

## Updated tests

- `test_register_creates_user_logs_in_and_redirects`: новое ожидание — редирект на `/projects/default/connections/new`.
- `test_root_redirects_to_dashboard` → переименован в `test_root_renders_landing_for_anonymous`.

## Sprint 3 status после мерджа: **8/8 done** 🎉

| Тикет | Что |
|---|---|
| #49 | Users — модель + регистрация + логин |
| #50 | Project model: CRUD «мои проекты» |
| #51 | DB connections + Fernet-шифрование DSN |
| #52 | Test-connection endpoint |
| #53 | Tenant isolation: project_id во всех метриках |
| #54 | Per-project APScheduler |
| #55 | Onboarding flow + публичный landing ← **этот PR** |
| #56 | Security hygiene: rate limit + CSRF + DSN-маскирование |

Остаётся только закрыть зонтик-эпик #48.

## Test plan

- [x] 9 unit-кейсов зелёные локально.
- [x] Все 448 предыдущих unit-теста не задеты.
- [ ] Browser smoke (после мерджа): aнон / → landing → Sign up → wizard → DSN → tested → /dashboard с empty state (без реальной БД) или с метриками (если DSN валидный).