### PR TITLE
fix(#117): run column migration before index creation in _apply_schema

### DIFF
--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -71,6 +71,10 @@ def get_engine() -> Engine:
 
 
 def _apply_schema(engine: Engine) -> None:
+    # Run column migrations BEFORE the main loop so indexes that depend on
+    # newly added columns (e.g. project_id) don't fail on existing installs.
+    _migrate_existing_schema(engine)
+
     schema_path = TIMESCALE_SCHEMA_PATH if _is_postgres() else SQLITE_SCHEMA_PATH
     sql = schema_path.read_text()
     # Strip single-line -- comments, then split on ;. Handles both SQLite and
@@ -99,7 +103,6 @@ def _apply_schema(engine: Engine) -> None:
             if _is_optional_timescale_stmt(stmt):
                 continue
             raise
-    _migrate_existing_schema(engine)
 
 
 def _existing_columns(engine: Engine, table: str) -> set[str]:
@@ -115,6 +118,21 @@ def _existing_columns(engine: Engine, table: str) -> set[str]:
         return {r[1] for r in rows}
 
 
+def _table_exists(engine: Engine, table: str) -> bool:
+    with engine.connect() as conn:
+        if _is_postgres():
+            row = conn.execute(
+                text("SELECT 1 FROM information_schema.tables WHERE table_name = :t"),
+                {"t": table},
+            ).fetchone()
+        else:
+            row = conn.execute(
+                text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:t"),
+                {"t": table},
+            ).fetchone()
+    return row is not None
+
+
 def _migrate_existing_schema(engine: Engine) -> None:
     """ALTER pre-#53 tables to match the current schema file.
 
@@ -123,6 +141,8 @@ def _migrate_existing_schema(engine: Engine) -> None:
     appears unless we explicitly ALTER. Today we only need to retrofit
     ``metrics.project_id``; future migrations follow the same shape.
     """
+    if not _table_exists(engine, "metrics"):
+        return
     if "project_id" not in _existing_columns(engine, "metrics"):
         with engine.begin() as conn:
             # NOT NULL + DEFAULT works on SQLite (>=3.3) and Postgres; the


### PR DESCRIPTION
## Описание

Закрывает #117.

На существующих установках таблица `metrics` создана без колонки `project_id` (до Sprint 3 / #53). При старте приложения `_apply_schema` пыталась создать индекс по этой колонке раньше, чем `_migrate_existing_schema` её добавляла — `OperationalError` не ловился `except ProgrammingError`, и миграция никогда не запускалась.

**Изменения:**
- `_apply_schema` — вызов `_migrate_existing_schema` перенесён в начало функции (до основного цикла CREATE INDEX)
- `_table_exists` — новая вспомогательная функция с поддержкой SQLite и Postgres; используется как guard в `_migrate_existing_schema` чтобы не падать на чистой установке, где таблица ещё не создана

## Тип изменения

- [x] Bug fix

## Чеклист

- [ ] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [x] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы