### PR TITLE
fix(#55): /dashboard empty-state — короткое замыкание легаси schema-discovery

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -59,10 +59,17 @@ def overview():
     if project is not None:
         has_connections = bool(list_connections_for_project(project["id"]))
 
-    tables = []
+    needs_first_connection = project is not None and not has_connections
+
+    tables: list = []
     total_rows = 0
-    null_rates = []
-    for entry in db.list_tables():
+    null_rates: list = []
+    # Skip the legacy global-DSN schema fetch entirely when the empty-state
+    # banner will render anyway. Two reasons: (1) tenant isolation — a brand
+    # new project must not surface tables from the admin's old global
+    # DATABASE_URL; (2) it would crash if that DSN is unreachable.
+    schema_entries = [] if needs_first_connection else db.list_tables()
+    for entry in schema_entries:
         name = entry["table_name"]
         snapshot = _table_snapshot(name, entry["schema"])
         if snapshot["row_count"] is None and snapshot["null_rate"] is None:
@@ -84,7 +91,7 @@ def overview():
         tables=tables,
         summary=summary,
         ml_last_runs=_ml_last_runs(),
-        needs_first_connection=project is not None and not has_connections,
+        needs_first_connection=needs_first_connection,
     )
 
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -196,6 +196,27 @@ def test_dashboard_empty_state_when_no_connections(client):
     assert "/projects/default/connections/new" in body
 
 
+def test_dashboard_empty_state_skips_legacy_global_schema_fetch(client, monkeypatch):
+    """Regression: when a fresh project has no connections, /dashboard
+    must NOT call the legacy global ``db.list_tables()`` — that would both
+    (1) leak schema from the admin's old single-tenant DATABASE_URL and
+    (2) crash if the global DSN is unreachable."""
+    _register(client, "isolated@example.com")
+    import app.dashboard as dash_mod
+
+    called = []
+
+    def boom(schema=None):
+        called.append(True)
+        raise RuntimeError("legacy list_tables() must not be called for empty projects")
+
+    monkeypatch.setattr(dash_mod.db, "list_tables", boom)
+    resp = client.get("/dashboard/")
+    assert resp.status_code == 200
+    assert called == []
+    assert "Нет подключений" in resp.get_data(as_text=True)
+
+
 def test_dashboard_no_empty_state_with_at_least_one_connection(client, monkeypatch):
     _register(client, "stocked@example.com")
     import app.connections as conn_mod


### PR DESCRIPTION
## Что и почему

При manual browser-тестинге онбординг-флоу из #55 я зарегистрировал свежего юзера и сразу зашёл на `/dashboard`. Поймал Flask error page вместо empty-state CTA. Корень — в \`overview()\` я добавил флаг \`needs_first_connection\`, но не отрезал легаси-вызов \`db.list_tables()\`, который всё ещё использует глобальный \`DATABASE_URL\` из \`.env\`.

Две проблемы:

1. **Tenant-isolation leak** (молчаливый): если у admin-а в \`.env\` есть legacy single-tenant DATABASE_URL, новый юзер без коннектов видел бы схему из admin-овской БД через дашборд. Противоречит #53, где мы изолировали метрики по \`project_id\`, но забыли отрезать schema-discovery путь.
2. **Crash при недоступном DATABASE_URL** (громкий): если глобальный DSN не резолвится (offline dev / dead Supabase / неправильный prod-config), brand-new юзер ловит 500 вместо приветственного CTA — UX полностью разломан на первом же экране.

## Фикс

Короткое замыкание в \`app/dashboard.py::overview\`:

\`\`\`python
needs_first_connection = project is not None and not has_connections
schema_entries = [] if needs_first_connection else db.list_tables()
for entry in schema_entries:
    ...
\`\`\`

Empty-state шаблон уже не использует \`tables\`/\`summary\` — рендерит только CTA-карточку, так что пустой список безопасен.

## Регрессионный тест

\`tests/test_onboarding.py::test_dashboard_empty_state_skips_legacy_global_schema_fetch\`:
- monkey-patch \`dash_mod.db.list_tables\` на функцию, которая raise RuntimeError
- регистрирует юзера
- GET /dashboard/ → 200 + «Нет подключений», вызовов нет

Пинит инвариант на будущее: empty-state НЕ должен трогать легаси-глобальный engine.

## Verification

- \`pytest tests/test_onboarding.py tests/test_dashboard.py -q\` → 31 passed (+1 от регрессии)
- \`ruff check .\` → clean
- Manual browser end-to-end: register → /dashboard рендерит empty-state даже при \`DATABASE_URL=''\` в env

## Test plan

- [x] Регрессионный тест зелёный
- [x] Full unit-suite не задет
- [x] Browser smoke: anon / → landing; register → wizard; skip wizard → /dashboard рендерит empty-state без падений