### PR TITLE
fix(#120): schema_view и table_detail — empty-state при отсутствии подключений

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -129,29 +129,38 @@ def _fmt_ts(value: str | None) -> str | None:
 
 @bp.route("/schema")
 def schema_view():
-    from app.metrics_storage import get_drift_report
+    from app.metrics_storage import get_drift_report, list_connections_for_project
+
+    project = getattr(g, "current_project", None)
+    has_connections = bool(
+        list_connections_for_project(project["id"]) if project else False
+    )
+    needs_first_connection = project is not None and not has_connections
 
     cutoff = datetime.now(UTC) - timedelta(days=_RECENT_SCHEMA_DAYS)
     schemas = []
-    for entry in db.list_tables():
-        name = entry["table_name"]
-        snapshot = _table_snapshot(name, entry["schema"])
-        cols = _columns_with_nulls(name, entry["schema"], snapshot["row_count"])
-        drift_by_col = {d["column"]: d for d in get_drift_report(name)}
-        for c in cols:
-            d = drift_by_col.get(c["name"])
-            c["drift"] = d  # None when no snapshots exist for this column
-        schema_events = get_schema_events(name, window=timedelta(days=30))
-        recent_count = sum(
-            1 for e in schema_events if _parse_event_ts(e["ts"]) >= cutoff
-        )
-        schemas.append({
-            **entry,
-            "columns": cols,
-            "schema_events": schema_events,
-            "recent_schema_changes": recent_count,
-        })
-    return render_template("schema.html", schemas=schemas)
+    if not needs_first_connection:
+        for entry in db.list_tables():
+            name = entry["table_name"]
+            snapshot = _table_snapshot(name, entry["schema"])
+            cols = _columns_with_nulls(name, entry["schema"], snapshot["row_count"])
+            drift_by_col = {d["column"]: d for d in get_drift_report(name)}
+            for c in cols:
+                d = drift_by_col.get(c["name"])
+                c["drift"] = d
+            schema_events = get_schema_events(name, window=timedelta(days=30))
+            recent_count = sum(
+                1 for e in schema_events if _parse_event_ts(e["ts"]) >= cutoff
+            )
+            schemas.append({
+                **entry,
+                "columns": cols,
+                "schema_events": schema_events,
+                "recent_schema_changes": recent_count,
+            })
+    return render_template(
+        "schema.html", schemas=schemas, needs_first_connection=needs_first_connection,
+    )
 
 
 def _parse_event_ts(value: str) -> datetime:
@@ -212,7 +221,14 @@ def notifications_view():
 
 @bp.route("/schema/<table_name>")
 def table_detail(table_name: str):
-    from app.metrics_storage import get_drift_report
+    from app.metrics_storage import get_drift_report, list_connections_for_project
+
+    project = getattr(g, "current_project", None)
+    has_connections = bool(
+        list_connections_for_project(project["id"]) if project else False
+    )
+    if project is not None and not has_connections:
+        abort(404)
 
     entries = {t["table_name"]: t for t in db.list_tables()}
     if table_name not in entries:

--- a/templates/schema.html
+++ b/templates/schema.html
@@ -4,6 +4,19 @@
 
 {% block content %}
   <h1 class="text-2xl font-semibold tracking-tight">Схема</h1>
+
+  {% if needs_first_connection %}
+    <section class="mt-6 rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 class="text-lg font-semibold">Нет подключений</h2>
+      <p class="mx-auto mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+        Добавьте первое подключение к БД — схема появится здесь автоматически.
+      </p>
+      <a href="{{ url_for('connections.new_connection', slug=g.current_project.slug) }}"
+         class="mt-4 inline-block rounded-md bg-accent px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover">
+        Добавить подключение →
+      </a>
+    </section>
+  {% else %}
   <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">{{ schemas|length }} таблиц в схеме <span class="font-mono">{{ schemas[0].schema if schemas else "" }}</span></p>
 
   <div class="mt-6 space-y-4">
@@ -95,4 +108,5 @@
       </div>
     {% endfor %}
   </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Описание

Закрывает #120.

PR #119 закрыл `/dashboard/`, но `/dashboard/schema` и `/dashboard/schema/<table>` всё ещё вызывали `db.list_tables()` через глобальный `DATABASE_URL`. При недоступном Supabase — 500.

**Изменения:**
- `schema_view` — добавлена проверка `needs_first_connection`; если нет подключений — рендерит empty-state CTA вместо вызова `db.list_tables()`
- `table_detail` — при отсутствии подключений возвращает 404 (таблицы реально не существуют для нового юзера)
- `templates/schema.html` — добавлен блок empty-state по аналогии с `overview.html`

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально (458 passed, 5 skipped)
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы