### PR TITLE
feat(#111): Apache Iceberg adapter — REST и Glue каталоги

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ make timescale-down                                 # остановить
 | PostgreSQL    | `postgresql://`, `postgresql+psycopg2://` | `psycopg2-binary`   | `pg_stat_user_tables` + `pg_total_relation_size` |
 | MySQL/MariaDB | `mysql://`, `mysql+pymysql://`         | `PyMySQL`             | `information_schema.tables` (`table_rows`, `data_length+index_length`) |
 | ClickHouse    | `clickhouse://`, `clickhouse+native://` | `clickhouse-sqlalchemy` | `system.tables` + `system.parts.modification_time` |
+| Apache Iceberg | `iceberg+rest://`, `iceberg+glue://` | `pyiceberg[pyarrow,glue]`  | snapshot summary metadata (без полного скана) |
 
 Примеры DSN:
 
@@ -348,16 +349,25 @@ DATABASE_URL=mysql+pymysql://user:password@host:3306/dbname
 
 # ClickHouse (native protocol, порт 9000)
 DATABASE_URL=clickhouse+native://user:password@host:9000/dbname
+
+# Apache Iceberg — REST-каталог (Polaris, Nessie, Gravitino, Tabular и др.)
+DATABASE_URL=iceberg+rest://localhost:8181?warehouse=s3://my-bucket/warehouse
+MONITORED_SCHEMA=my_namespace
+
+# Apache Iceberg — AWS Glue (AWS credentials из env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+DATABASE_URL=iceberg+glue://?warehouse=s3://my-bucket/warehouse
+MONITORED_SCHEMA=my_glue_database
 ```
 
-`MONITORED_SCHEMA` для MySQL/ClickHouse трактуется как имя БД (database). Для ClickHouse значение по умолчанию обычно `default`.
+`MONITORED_SCHEMA` для MySQL/ClickHouse трактуется как имя БД (database). Для ClickHouse значение по умолчанию обычно `default`. Для Iceberg — это namespace каталога.
 
 **Особенности диалектов:**
 - **MySQL** — `table_rows` в InnoDB это оценка оптимизатора; для трендовой аналитики достаточно, для точных счётчиков — нет. `update_time` может быть `NULL` на партиционированных таблицах.
 - **ClickHouse** — `null_count` для не-`Nullable` колонок всегда 0 (по дизайну). `last_modified` собирается из `system.parts` (`max(modification_time)`).
+- **Apache Iceberg** — `row_count` и `null_count` читаются из snapshot/manifest metadata без полного скана данных, что критично для таблиц с миллиардами строк. `column_distribution` не поддерживается (возвращает пустой список). Требует PyIceberg ≥ 0.7. Для S3/MinIO нужны `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` (или IAM-роль). REST-каталог подключается по `http://` — для HTTPS используйте обратный прокси на стороне каталога или отслеживайте issue #124.
 - **MS SQL** — пока не поддерживается (требует ODBC-драйвер вне Python).
 
-NULL-статистика во всех диалектах считается через `COUNT(*) - COUNT(col)` (PostgreSQL дополнительно использует `FILTER (WHERE col IS NULL)` как более идиоматичный вариант). `column_distribution` собирается через `SELECT col, COUNT(*) GROUP BY col ORDER BY 2 DESC LIMIT 20` — пропускает text/json/blob/uuid колонки (top-N по высокой кардинальности — шум, не сигнал).
+NULL-статистика во всех SQL-диалектах считается через `COUNT(*) - COUNT(col)` (PostgreSQL дополнительно использует `FILTER (WHERE col IS NULL)` как более идиоматичный вариант). `column_distribution` собирается через `SELECT col, COUNT(*) GROUP BY col ORDER BY 2 DESC LIMIT 20` — пропускает text/json/blob/uuid колонки (top-N по высокой кардинальности — шум, не сигнал).
 
 ---
 

--- a/app/db.py
+++ b/app/db.py
@@ -2,6 +2,8 @@ import threading
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from contextvars import ContextVar
+from datetime import UTC, datetime
+from urllib.parse import parse_qs, urlparse
 
 from sqlalchemy import create_engine, make_url, text
 from sqlalchemy.engine import Engine
@@ -22,19 +24,22 @@ _adapter_override: ContextVar["DBAdapter | None"] = ContextVar("_adapter_overrid
 
 
 @contextmanager
-def using_engine(engine: Engine, adapter: "DBAdapter"):
+def using_engine(engine: "Engine | None", adapter: "DBAdapter"):
     """Run a block with a per-call engine + adapter override.
 
     Used by collectors/per_project.py to make the existing adapter helpers
     talk to a connection's DSN instead of the global ``DATABASE_URL``.
+    ``engine`` may be None for catalog-based adapters (e.g. IcebergAdapter)
+    that don't use SQLAlchemy — only the adapter override is set in that case.
     """
-    e_token = _engine_override.set(engine)
+    e_token = _engine_override.set(engine) if engine is not None else None
     a_token = _adapter_override.set(adapter)
     try:
         yield
     finally:
         _adapter_override.reset(a_token)
-        _engine_override.reset(e_token)
+        if e_token is not None:
+            _engine_override.reset(e_token)
 
 
 def get_engine() -> Engine:
@@ -411,11 +416,185 @@ class ClickHouseAdapter(DBAdapter):
         return _column_nulls_generic(self, table_name, schema)
 
 
+class IcebergAdapter(DBAdapter):
+    """Apache Iceberg adapter — reads metadata from Iceberg catalogs.
+
+    Supports REST (iceberg+rest://) and AWS Glue (iceberg+glue://) backends.
+    Uses PyIceberg catalog API instead of SQLAlchemy — never calls get_engine().
+
+    DSN format:
+        iceberg+rest://host:port?warehouse=s3://bucket/path
+        iceberg+glue://?warehouse=s3://bucket/path
+
+    ``null_count`` and ``row_count`` are read from Iceberg snapshot/manifest
+    metadata — no full table scan, even on billion-row tables.
+    """
+
+    def __init__(self, url: str):
+        parsed = urlparse(url)
+        catalog_type = parsed.scheme.split("+", 1)[1]  # "rest" or "glue"
+        qs = parse_qs(parsed.query)
+        warehouse = (qs.get("warehouse") or [None])[0]
+
+        if catalog_type == "rest":
+            from pyiceberg.catalog.rest import RestCatalog
+
+            props: dict = {"uri": f"http://{parsed.netloc}"}
+            if warehouse:
+                props["warehouse"] = warehouse
+            self._catalog = RestCatalog("rest", **props)
+        elif catalog_type == "glue":
+            from pyiceberg.catalog.glue import GlueCatalog
+
+            props = {}
+            if warehouse:
+                props["warehouse"] = warehouse
+            self._catalog = GlueCatalog("glue", **props)
+        else:
+            raise ValueError(
+                f"Unsupported Iceberg catalog type: {catalog_type!r}. "
+                "Use iceberg+rest:// or iceberg+glue://"
+            )
+
+    def quote_ident(self, identifier: str) -> str:
+        return identifier  # PyIceberg uses Python API, no SQL quoting
+
+    def list_tables(self, schema: str) -> list[dict]:
+        from pyiceberg.exceptions import NoSuchNamespaceError
+
+        try:
+            identifiers = self._catalog.list_tables(schema)
+        except NoSuchNamespaceError:
+            return []
+        # list_tables returns [(namespace, table_name), ...]
+        return [{"table_name": ident[-1], "schema": schema} for ident in identifiers]
+
+    def table_stats(self, table_name: str, schema: str) -> dict | None:
+        from pyiceberg.exceptions import NoSuchTableError
+
+        try:
+            table = self._catalog.load_table((schema, table_name))
+        except NoSuchTableError:
+            return None
+
+        snapshot = table.current_snapshot()
+        if snapshot is None:
+            return {
+                "table_name": table_name, "schema": schema,
+                "row_count": 0, "size_bytes": 0, "last_analyze": None,
+            }
+
+        summary = snapshot.summary
+        row_count = int(summary.get("total-records", 0) or 0)
+        size_bytes = int(summary.get("total-files-size", 0) or 0)
+        last_analyze = datetime.fromtimestamp(
+            snapshot.timestamp_ms / 1000, tz=UTC
+        ).isoformat()
+        return {
+            "table_name": table_name,
+            "schema": schema,
+            "row_count": row_count,
+            "size_bytes": size_bytes,
+            "last_analyze": last_analyze,
+        }
+
+    def table_schema(self, table_name: str, schema: str) -> list[dict]:
+        from pyiceberg.exceptions import NoSuchTableError
+
+        try:
+            table = self._catalog.load_table((schema, table_name))
+        except NoSuchTableError:
+            return []
+        return [
+            {
+                "name": field.name,
+                "type": str(field.field_type),
+                "nullable": field.optional,
+            }
+            for field in table.schema().fields
+        ]
+
+    def column_nulls(self, table_name: str, schema: str) -> list[dict]:
+        """Read null counts from manifest metadata — no full data scan."""
+        from pyiceberg.exceptions import NoSuchTableError
+        from pyiceberg.manifest import ManifestEntryStatus
+
+        try:
+            table = self._catalog.load_table((schema, table_name))
+        except NoSuchTableError:
+            return []
+
+        snapshot = table.current_snapshot()
+        if snapshot is None:
+            return []
+
+        iceberg_schema = table.schema()
+        null_counts: dict[int, int] = {}   # field_id → total null count
+        value_counts: dict[int, int] = {}  # field_id → total value count
+
+        for manifest in snapshot.manifests(table.io):
+            for entry in manifest.fetch_manifest_entry(table.io):
+                if entry.status == ManifestEntryStatus.DELETED:
+                    continue
+                df = entry.data_file
+                for fid, cnt in (df.null_value_counts or {}).items():
+                    null_counts[fid] = null_counts.get(fid, 0) + cnt
+                for fid, cnt in (df.value_counts or {}).items():
+                    value_counts[fid] = value_counts.get(fid, 0) + cnt
+
+        result = []
+        for field in iceberg_schema.fields:
+            fid = field.field_id
+            nulls = null_counts.get(fid, 0)
+            total = value_counts.get(fid, 0)
+            result.append({
+                "column": field.name,
+                "data_type": str(field.field_type),
+                "null_count": nulls,
+                "null_rate": round(nulls / total, 4) if total else 0.0,
+            })
+        return result
+
+    def column_distribution(
+        self, table_name: str, schema: str, top_n: int = 20
+    ) -> list[dict]:
+        # Iceberg manifest metadata has no distribution info. A full PyArrow
+        # scan would defeat the no-scan value prop on large tables.
+        return []
+
+
+def _adapter_key(url: str) -> str:
+    """Return the _ADAPTERS registry key for ``url``.
+
+    Standard SQLAlchemy URLs delegate to make_url().get_backend_name().
+    Iceberg URLs (iceberg+rest://, iceberg+glue://) are handled separately
+    because SQLAlchemy doesn't know the dialect and get_backend_name() would
+    return only "iceberg", losing the catalog-type suffix we need.
+    """
+    if url.lower().startswith("iceberg+"):
+        return url.split("://")[0].lower()  # "iceberg+rest" or "iceberg+glue"
+    return make_url(url).get_backend_name()
+
+
 _ADAPTERS: dict[str, type[DBAdapter]] = {
     "postgresql": PostgresAdapter,
     "mysql": MySQLAdapter,
     "clickhouse": ClickHouseAdapter,
+    "iceberg+rest": IcebergAdapter,
+    "iceberg+glue": IcebergAdapter,
 }
+
+
+def _make_adapter(cls: type[DBAdapter], url: str) -> DBAdapter:
+    """Instantiate an adapter, passing ``url`` for catalog-based adapters.
+
+    Catalog-based adapters (IcebergAdapter) need the raw DSN to connect to
+    their catalog API — they don't use SQLAlchemy. SQL adapters take no args.
+    If you add a new catalog-based adapter, add it to this condition.
+    """
+    if issubclass(cls, IcebergAdapter):
+        return cls(url)
+    return cls()
 
 
 def get_adapter() -> DBAdapter:
@@ -424,14 +603,15 @@ def get_adapter() -> DBAdapter:
         return override
     global _adapter
     if _adapter is None:
-        backend = make_url(settings.DATABASE_URL).get_backend_name()
-        cls = _ADAPTERS.get(backend)
+        url = settings.DATABASE_URL
+        key = _adapter_key(url)
+        cls = _ADAPTERS.get(key)
         if cls is None:
             raise ValueError(
-                f"Unsupported database backend: {backend!r}. "
+                f"Unsupported database backend: {key!r}. "
                 f"Supported: {sorted(_ADAPTERS)}"
             )
-        _adapter = cls()
+        _adapter = _make_adapter(cls, url)
     return _adapter
 
 
@@ -441,14 +621,14 @@ def make_adapter_for_url(url: str) -> DBAdapter:
     Bypasses the module-level singleton (which is keyed off ``settings.
     DATABASE_URL``). Cheap operation — adapters hold no state.
     """
-    backend = make_url(url).get_backend_name()
-    cls = _ADAPTERS.get(backend)
+    key = _adapter_key(url)
+    cls = _ADAPTERS.get(key)
     if cls is None:
         raise ValueError(
-            f"Unsupported database backend: {backend!r}. "
+            f"Unsupported database backend: {key!r}. "
             f"Supported: {sorted(_ADAPTERS)}"
         )
-    return cls()
+    return _make_adapter(cls, url)
 
 
 def list_tables(schema: str | None = None) -> list[dict]:

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -88,20 +88,24 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
                        project_id, connection_id)
         return
 
-    from sqlalchemy import create_engine
-    from sqlalchemy.pool import NullPool
+    # Iceberg uses a catalog API (not SQLAlchemy) — skip engine creation.
+    # For all other dialects, create a per-tick NullPool engine so connections
+    # don't leak across scheduler runs.
+    engine = None
+    if not dsn.lower().startswith("iceberg+"):
+        from sqlalchemy import create_engine
+        from sqlalchemy.pool import NullPool
 
-    # NullPool — per-tick engine, no pool to leak across runs. connect_timeout
-    # bounds the establish phase; OperationalError on a dead target bubbles
-    # up to our try/except below.
-    engine = create_engine(
-        dsn, poolclass=NullPool, connect_args={"connect_timeout": 5},
-    )
+        engine = create_engine(
+            dsn, poolclass=NullPool, connect_args={"connect_timeout": 5},
+        )
+
     try:
         adapter = make_adapter_for_url(dsn)
     except ValueError as exc:
         logger.warning("[project=%s][conn=%s] %s", project_id, connection_id, exc)
-        engine.dispose()
+        if engine:
+            engine.dispose()
         return
 
     run_ts = datetime.now(UTC)
@@ -123,10 +127,12 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
             "[project=%s][conn=%s] collection failed after %dms: %s",
             project_id, connection_id, elapsed_ms, exc,
         )
-        engine.dispose()
+        if engine:
+            engine.dispose()
         return
 
-    engine.dispose()
+    if engine:
+        engine.dispose()
     elapsed_ms = int((time.monotonic() - started) * 1000)
     logger.info(
         "[project=%s][conn=%s] collected %d metrics across %d tables in %dms",

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,9 @@ cryptography==44.0.0
 # Security hygiene (#56) — rate-limit auth endpoints to slow down brute-force.
 # In-memory storage by default; can switch to Redis via FLASK_LIMITER_STORAGE_URI.
 Flask-Limiter==3.8.0
+
+# Apache Iceberg adapter (#111). pyarrow extra brings PyArrow (S3 file I/O);
+# glue extra brings boto3 for AWS Glue catalog. Both catalog backends are
+# supported: iceberg+rest:// (REST catalog) and iceberg+glue:// (AWS Glue).
+# Note: in pyiceberg >=0.7 the old [s3] extra was renamed to [pyarrow].
+pyiceberg[pyarrow,glue]>=0.7.0,<1.0.0

--- a/tests/test_iceberg_adapter.py
+++ b/tests/test_iceberg_adapter.py
@@ -1,0 +1,342 @@
+"""Unit tests for IcebergAdapter (#111).
+
+All tests mock the PyIceberg catalog — no real Iceberg cluster needed.
+Integration tests (MinIO + testcontainers) live in #124.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REST_DSN = "iceberg+rest://localhost:8181?warehouse=s3://bucket/wh"
+GLUE_DSN = "iceberg+glue://?warehouse=s3://bucket/wh"
+
+
+def _make_field(field_id: int, name: str, type_str: str, optional: bool = True):
+    f = MagicMock()
+    f.field_id = field_id
+    f.name = name
+    f.field_type = type_str
+    f.optional = optional
+    return f
+
+
+def _make_manifest_entry(null_value_counts: dict, value_counts: dict, record_count: int = 100):
+    from pyiceberg.manifest import ManifestEntryStatus
+
+    entry = MagicMock()
+    entry.status = ManifestEntryStatus.EXISTING
+    entry.data_file.null_value_counts = null_value_counts
+    entry.data_file.value_counts = value_counts
+    entry.data_file.record_count = record_count
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# _adapter_key
+# ---------------------------------------------------------------------------
+
+def test_adapter_key_rest():
+    from app.db import _adapter_key
+    assert _adapter_key(REST_DSN) == "iceberg+rest"
+
+
+def test_adapter_key_glue():
+    from app.db import _adapter_key
+    assert _adapter_key(GLUE_DSN) == "iceberg+glue"
+
+
+def test_adapter_key_postgres():
+    from app.db import _adapter_key
+    assert _adapter_key("postgresql://user:pass@host/db") == "postgresql"
+
+
+def test_adapter_key_clickhouse():
+    from app.db import _adapter_key
+    assert _adapter_key("clickhouse+native://user:pass@host:9000/db") == "clickhouse"
+
+
+# ---------------------------------------------------------------------------
+# IcebergAdapter construction
+# ---------------------------------------------------------------------------
+
+def test_rest_adapter_init():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        mock_cls.assert_called_once_with(
+            "rest", uri="http://localhost:8181", warehouse="s3://bucket/wh"
+        )
+        assert adapter._catalog is mock_cls.return_value
+
+
+def test_glue_adapter_init():
+    with patch("pyiceberg.catalog.glue.GlueCatalog") as mock_cls:
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(GLUE_DSN)
+        mock_cls.assert_called_once_with("glue", warehouse="s3://bucket/wh")
+
+
+def test_unsupported_catalog_type_raises():
+    from app.db import IcebergAdapter
+    with pytest.raises(ValueError, match="Unsupported Iceberg catalog type"):
+        IcebergAdapter("iceberg+hive://host:9083")
+
+
+# ---------------------------------------------------------------------------
+# list_tables
+# ---------------------------------------------------------------------------
+
+def test_list_tables_rest():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        mock_catalog = mock_cls.return_value
+        mock_catalog.list_tables.return_value = [
+            ("myns", "orders"),
+            ("myns", "users"),
+        ]
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.list_tables("myns")
+
+    assert result == [
+        {"table_name": "orders", "schema": "myns"},
+        {"table_name": "users", "schema": "myns"},
+    ]
+
+
+def test_list_tables_unknown_namespace_returns_empty():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        from pyiceberg.exceptions import NoSuchNamespaceError
+
+        mock_catalog = mock_cls.return_value
+        mock_catalog.list_tables.side_effect = NoSuchNamespaceError("myns")
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.list_tables("myns")
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# table_schema
+# ---------------------------------------------------------------------------
+
+def test_table_schema():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        mock_catalog = mock_cls.return_value
+        mock_table = MagicMock()
+        mock_catalog.load_table.return_value = mock_table
+        mock_table.schema.return_value.fields = [
+            _make_field(1, "id", "long", optional=False),
+            _make_field(2, "email", "string", optional=True),
+        ]
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.table_schema("users", "myns")
+
+    assert result == [
+        {"name": "id", "type": "long", "nullable": False},
+        {"name": "email", "type": "string", "nullable": True},
+    ]
+    mock_catalog.load_table.assert_called_once_with(("myns", "users"))
+
+
+def test_table_schema_unknown_table_returns_empty():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        from pyiceberg.exceptions import NoSuchTableError
+
+        mock_cls.return_value.load_table.side_effect = NoSuchTableError("users")
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.table_schema("users", "myns")
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# table_stats
+# ---------------------------------------------------------------------------
+
+def test_table_stats_from_snapshot_summary():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        mock_table = mock_cls.return_value.load_table.return_value
+        mock_snapshot = MagicMock()
+        mock_snapshot.timestamp_ms = 1_700_000_000_000
+        mock_snapshot.summary.get.side_effect = lambda k, d=0: {
+            "total-records": "42",
+            "total-files-size": "1024",
+        }.get(k, d)
+        mock_table.current_snapshot.return_value = mock_snapshot
+
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.table_stats("orders", "myns")
+
+    assert result["table_name"] == "orders"
+    assert result["row_count"] == 42
+    assert result["size_bytes"] == 1024
+    assert result["last_analyze"] is not None
+
+
+def test_table_stats_no_snapshot_returns_zeros():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        mock_table = mock_cls.return_value.load_table.return_value
+        mock_table.current_snapshot.return_value = None
+
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.table_stats("orders", "myns")
+
+    assert result["row_count"] == 0
+    assert result["size_bytes"] == 0
+    assert result["last_analyze"] is None
+
+
+def test_table_stats_unknown_table_returns_none():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        from pyiceberg.exceptions import NoSuchTableError
+
+        mock_cls.return_value.load_table.side_effect = NoSuchTableError("orders")
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.table_stats("orders", "myns")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# column_nulls — manifest metadata path (no full scan)
+# ---------------------------------------------------------------------------
+
+def test_column_nulls_from_manifest_metadata():
+    """Null counts come from manifest entries, not a data scan."""
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        mock_table = mock_cls.return_value.load_table.return_value
+        mock_snapshot = MagicMock()
+        mock_table.current_snapshot.return_value = mock_snapshot
+
+        # Schema: two fields with field_ids 1 and 2
+        mock_table.schema.return_value.fields = [
+            _make_field(1, "id", "long", optional=False),
+            _make_field(2, "email", "string", optional=True),
+        ]
+
+        # One manifest with one entry: 5 nulls in field 2, 0 in field 1
+        entry = _make_manifest_entry(
+            null_value_counts={1: 0, 2: 5},
+            value_counts={1: 100, 2: 100},
+        )
+        mock_manifest = MagicMock()
+        mock_manifest.fetch_manifest_entry.return_value = [entry]
+        mock_snapshot.manifests.return_value = [mock_manifest]
+
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.column_nulls("users", "myns")
+
+    assert len(result) == 2
+    id_stats = next(r for r in result if r["column"] == "id")
+    email_stats = next(r for r in result if r["column"] == "email")
+    assert id_stats["null_count"] == 0
+    assert id_stats["null_rate"] == 0.0
+    assert email_stats["null_count"] == 5
+    assert email_stats["null_rate"] == 0.05
+
+
+def test_column_nulls_skips_deleted_manifest_entries():
+    """DELETED manifest entries must not contribute to null counts."""
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        from pyiceberg.manifest import ManifestEntryStatus
+
+        mock_table = mock_cls.return_value.load_table.return_value
+        mock_snapshot = MagicMock()
+        mock_table.current_snapshot.return_value = mock_snapshot
+        mock_table.schema.return_value.fields = [_make_field(1, "id", "long")]
+
+        deleted_entry = _make_manifest_entry({1: 99}, {1: 100})
+        deleted_entry.status = ManifestEntryStatus.DELETED
+        live_entry = _make_manifest_entry({1: 2}, {1: 50})
+
+        mock_manifest = MagicMock()
+        mock_manifest.fetch_manifest_entry.return_value = [deleted_entry, live_entry]
+        mock_snapshot.manifests.return_value = [mock_manifest]
+
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.column_nulls("users", "myns")
+
+    assert result[0]["null_count"] == 2  # only live_entry counted
+
+
+def test_column_nulls_no_snapshot_returns_empty():
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        mock_cls.return_value.load_table.return_value.current_snapshot.return_value = None
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        assert adapter.column_nulls("users", "myns") == []
+
+
+# ---------------------------------------------------------------------------
+# column_distribution — graceful skip
+# ---------------------------------------------------------------------------
+
+def test_column_distribution_returns_empty():
+    with patch("pyiceberg.catalog.rest.RestCatalog"):
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        assert adapter.column_distribution("orders", "myns") == []
+
+
+# ---------------------------------------------------------------------------
+# quote_ident — no SQL quoting for Iceberg
+# ---------------------------------------------------------------------------
+
+def test_quote_ident_passthrough():
+    with patch("pyiceberg.catalog.rest.RestCatalog"):
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        assert adapter.quote_ident("my_table") == "my_table"
+
+
+# ---------------------------------------------------------------------------
+# make_adapter_for_url integration
+# ---------------------------------------------------------------------------
+
+def test_make_adapter_for_url_returns_iceberg_adapter():
+    with patch("pyiceberg.catalog.rest.RestCatalog"):
+        from app.db import IcebergAdapter, make_adapter_for_url
+        adapter = make_adapter_for_url(REST_DSN)
+        assert isinstance(adapter, IcebergAdapter)
+
+
+def test_make_adapter_for_url_glue():
+    with patch("pyiceberg.catalog.glue.GlueCatalog"):
+        from app.db import IcebergAdapter, make_adapter_for_url
+        adapter = make_adapter_for_url(GLUE_DSN)
+        assert isinstance(adapter, IcebergAdapter)
+
+
+# ---------------------------------------------------------------------------
+# using_engine with engine=None — Iceberg path
+# ---------------------------------------------------------------------------
+
+def test_using_engine_none_does_not_set_engine_override():
+    """engine=None must leave _engine_override untouched; adapter override must work."""
+    with patch("pyiceberg.catalog.rest.RestCatalog"):
+        from app.db import IcebergAdapter, _engine_override, get_adapter, using_engine
+        adapter = IcebergAdapter(REST_DSN)
+
+    original_engine = _engine_override.get()
+    with using_engine(None, adapter):
+        assert _engine_override.get() is original_engine, (
+            "_engine_override should not be set when engine=None"
+        )
+        assert get_adapter() is adapter, "adapter override must be active inside the block"
+
+    from app.db import _adapter_override
+    assert _adapter_override.get() is None, "adapter override must be cleared after the block"

--- a/tests/test_iceberg_adapter.py
+++ b/tests/test_iceberg_adapter.py
@@ -78,7 +78,7 @@ def test_rest_adapter_init():
 def test_glue_adapter_init():
     with patch("pyiceberg.catalog.glue.GlueCatalog") as mock_cls:
         from app.db import IcebergAdapter
-        adapter = IcebergAdapter(GLUE_DSN)
+        IcebergAdapter(GLUE_DSN)
         mock_cls.assert_called_once_with("glue", warehouse="s3://bucket/wh")
 
 


### PR DESCRIPTION
## Описание

Добавляет поддержку Apache Iceberg как мониторируемого источника данных (#111).

Ключевое техническое решение: `row_count`, `size_bytes` и `null_count` читаются из snapshot/manifest metadata через PyIceberg catalog API — **без полного скана данных**. Это делает мониторинг Iceberg-таблиц с миллиардами строк таким же дешёвым, как и с обычными SQL-таблицами.

Поддерживаемые каталоги:
- **REST** (`iceberg+rest://host:port?warehouse=s3://bucket/path`) — Polaris, Nessie, Gravitino, Tabular и любой REST-совместимый каталог
- **AWS Glue** (`iceberg+glue://?warehouse=s3://bucket/path`) — credentials из env (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`)

### Изменения по файлам

**`app/db.py`**
- Новый класс `IcebergAdapter(DBAdapter)` — реализует все методы интерфейса: `list_tables`, `table_stats`, `table_schema`, `column_nulls`, `column_distribution` (→ `[]`, сканирование нецелесообразно), `quote_ident` (→ passthrough)
- `_adapter_key(url)` — обходит ограничение SQLAlchemy: `make_url().get_backend_name()` возвращает только `"iceberg"`, теряя суффикс каталога; кастомная функция сохраняет `"iceberg+rest"` / `"iceberg+glue"`
- `_make_adapter(cls, url)` — фабрика, передающая DSN каталожным адаптерам (SQL-адаптеры аргументов не принимают)
- `using_engine(engine=None, adapter)` — при `engine=None` не трогает `_engine_override`; только `_adapter_override` устанавливается/сбрасывается
- Импорты `datetime`, `UTC`, `urlparse`, `parse_qs` вынесены на уровень модуля

**`collectors/per_project.py`**
- `collect_for_connection` пропускает `create_engine` для `iceberg+*` DSN (`engine = None`); все `engine.dispose()` защищены `if engine:`

**`requirements.txt`**
- `pyiceberg[pyarrow,glue]>=0.7.0,<1.0.0` (в ≥0.7 бывший `[s3]` extra переименован в `[pyarrow]`)

**`README.md`**
- Iceberg в таблице поддерживаемых СУБД, DSN-примеры, dialect notes (no-scan гарантия, HTTP-only для REST, AWS env vars)

**`tests/test_iceberg_adapter.py`** (новый файл)
- 22 unit-теста; все мокируют PyIceberg catalog — реальный кластер не нужен
- Покрыты: `_adapter_key`, инициализация REST/Glue, все публичные методы адаптера, граничные случаи (нет снапшота, нет таблицы, DELETED manifest entries), `using_engine(None, ...)`

Интеграционные тесты с MinIO + testcontainers → issue #124.

## Тип изменения

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation

## Чеклист

- [x] Тесты написаны / обновлены (22 новых unit-теста, 144/144 релевантных тестов зелёные)
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы (схема БД не затронута)