### PR TITLE
fix(#125): убрать limiter.reset() из isolated_app — storage не инициализирован при TESTING=True

### DIFF
--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -179,12 +179,9 @@ def isolated_app(tmp_path, monkeypatch):
         "LOGIN_DISABLED": False,
         "WTF_CSRF_ENABLED": False,
     })
-    # Flask-Limiter is a module-level singleton — counters leak across
-    # tests in the same process (e.g. test_security hammers /login and
-    # exhausts the per-IP bucket). Reset so our login calls don't hit 429.
-    with app.app_context():
-        from app.auth import limiter
-        limiter.reset()
+    # No limiter.reset() — create_app sets RATELIMIT_ENABLED=False when
+    # TESTING=True, so the storage backend is never initialised and
+    # limiter.reset() would raise AssertionError (#125).
     return app
 
 


### PR DESCRIPTION
## Описание

`isolated_app` в `tests/test_tenant_isolation.py` вызывал `limiter.reset()` внутри `app_context()`, что падало с `AssertionError: self._storage is None`.

**Причина:** `create_app` при `TESTING=True` устанавливает `RATELIMIT_ENABLED=False` через `setdefault`. Flask-Limiter не инициализирует storage backend — вызов `limiter.reset()` падает на внутренний assert.

**Следствие:** два теста HTTP-изоляции тенантов (`test_api_metrics_isolates_users`, `test_api_tables_isolates_latest_row_count`) не запускались вообще — критичная гарантия «пользователь B не видит данные пользователя A» не проверялась.

**Решение:** убрать блок `limiter.reset()`. При `RATELIMIT_ENABLED=False` счётчиков нет и утечки между тестами быть не может. Паттерн задокументирован в `test_onboarding.py`.

Аналогичный случай в `test_security.py` не затронут — там явно выставлено `RATELIMIT_ENABLED: True`, storage инициализируется, `limiter.reset()` работает корректно.

## Тип изменения

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально — 58/58, включая оба ранее падавших HTTP-теста
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы (не затронута)