### PR TITLE
fix(#127): изолировать тесты strict-парсинга от реальных DB-проверок

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -131,13 +131,24 @@ def test_healthz_strict_treats_na_as_failure(client):
 
 
 @pytest.mark.parametrize("flag", ["1", "true", "yes", "TRUE", "Yes"])
-def test_strict_query_param_accepts_common_truthy_values(client, flag):
+def test_strict_query_param_accepts_common_truthy_values(client, flag, monkeypatch):
+    # Pin DB checks to "ok" — this test is about strict-param parsing, not
+    # DB connectivity. Without this, a slow ThreadPoolExecutor startup in CI
+    # can push a check past HEALTH_TIMEOUT_S and flip it to "down" → 503
+    # regardless of strict, making the assertion trivially true for wrong reasons.
+    monkeypatch.setattr("app.health._check_monitor_db", lambda: {"status": "ok"})
+    monkeypatch.setattr("app.health._check_target_db", lambda: {"status": "ok"})
     resp = client.get(f"/healthz?strict={flag}")
-    assert resp.status_code == 503  # because ratelimit is n/a in tests
+    assert resp.status_code == 503  # strict=True + ratelimit_storage n/a → 503
 
 
 @pytest.mark.parametrize("flag", ["0", "false", "no", "", "off", "blah"])
-def test_strict_query_param_falsy_values_keep_200(client, flag):
+def test_strict_query_param_falsy_values_keep_200(client, flag, monkeypatch):
+    # Pin DB checks to "ok" — this test is about strict-param parsing, not
+    # DB connectivity. A flaky "down" from a slow CI thread would cause 503
+    # even with strict=False, masking the real assertion (#127).
+    monkeypatch.setattr("app.health._check_monitor_db", lambda: {"status": "ok"})
+    monkeypatch.setattr("app.health._check_target_db", lambda: {"status": "ok"})
     resp = client.get(f"/healthz?strict={flag}")
     assert resp.status_code == 200
 


### PR DESCRIPTION
## Описание

`test_strict_query_param_falsy_values_keep_200` и `test_strict_query_param_accepts_common_truthy_values` периодически падали в CI на Python 3.13.

**Причина:** оба теста проверяют парсинг query-параметра `?strict=`, но при этом делали реальные запросы к БД через `ThreadPoolExecutor` с таймаутом 1 с. В CI на Python 3.13 executor иногда не укладывался в бюджет → `_check_target_db` или `_check_monitor_db` возвращал `down` → `/healthz` отвечал 503 вне зависимости от `strict`.

**Решение:** монкипатчить `_check_monitor_db` и `_check_target_db` → `{"status": "ok"}` в этих двух тестах. Тесты становятся детерминированными и проверяют только то, для чего написаны.

`_check_ratelimit_storage` намеренно **не** мокируется:
- в truthy-тесте: `strict=True` + `ratelimit_storage=n/a` → 503 — это именно то что проверяется
- в falsy-тесте: `strict=False` + `ratelimit_storage=n/a` → 200 — аналогично

Тесты реальной доступности БД (`test_healthz_returns_503_when_monitor_db_down` и др.) не затронуты.

## Тип изменения

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально — 79/79 по всем затронутым модулям
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы (не затронута)