### PR TITLE
test(#128): live smoke test для IcebergAdapter — REST catalog + MinIO через Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE ?= db-monitoring
 PORT  ?= 5001
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg
 
 build:
 	docker build -t $(IMAGE) .
@@ -79,6 +79,23 @@ timescale-migrate:
 	python -m scripts.migrate_metrics_to_timescale \
 		--source sqlite:///monitor.db \
 		--target postgresql://postgres:dev@localhost:5433/metrics $(ARGS)
+
+# ── Apache Iceberg smoke test (#128) ─────────────────────────────────
+iceberg-up:
+	docker compose --profile iceberg up -d minio iceberg-rest
+	@echo "Waiting for MinIO to become healthy..."
+	@until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-minio 2>/dev/null)" = "healthy" ]; do sleep 1; done
+	@echo "Waiting for Iceberg REST catalog..."
+	@sleep 5
+	@echo "MinIO:        http://localhost:9000  (user=minioadmin pass=minioadmin)"
+	@echo "MinIO UI:     http://localhost:9001"
+	@echo "Iceberg REST: http://localhost:8181"
+
+iceberg-down:
+	docker compose --profile iceberg down
+
+smoke-iceberg: ## Run live smoke test against local Iceberg REST + MinIO (requires make iceberg-up)
+	python -m scripts.smoke_iceberg
 
 # Ruff: linter + import sort + pyupgrade in one tool. Config in pyproject.toml.
 # Runs locally via venv (fast, no docker round-trip). Same command runs in CI.

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ iceberg-up:
 	@i=0; until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-minio 2>/dev/null)" = "healthy" ]; do \
 		i=$$((i+1)); [ $$i -gt 60 ] && echo "ERROR: MinIO did not become healthy in 60s" && exit 1; sleep 1; done
 	@echo "Waiting for Iceberg REST catalog..."
-	@i=0; until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-iceberg-rest 2>/dev/null)" = "healthy" ]; do \
-		i=$$((i+1)); [ $$i -gt 60 ] && echo "ERROR: Iceberg REST did not become healthy in 60s" && exit 1; sleep 1; done
+	@i=0; until curl -sf http://localhost:8181/v1/config >/dev/null 2>&1; do \
+		i=$$((i+1)); [ $$i -gt 60 ] && echo "ERROR: Iceberg REST did not become ready in 60s" && exit 1; sleep 1; done
 	@echo "MinIO:        http://localhost:9000  (user=minioadmin pass=minioadmin)"
 	@echo "MinIO UI:     http://localhost:9001"
 	@echo "Iceberg REST: http://localhost:8181"

--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,11 @@ timescale-migrate:
 iceberg-up:
 	docker compose --profile iceberg up -d minio iceberg-rest
 	@echo "Waiting for MinIO to become healthy..."
-	@until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-minio 2>/dev/null)" = "healthy" ]; do sleep 1; done
+	@i=0; until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-minio 2>/dev/null)" = "healthy" ]; do \
+		i=$$((i+1)); [ $$i -gt 60 ] && echo "ERROR: MinIO did not become healthy in 60s" && exit 1; sleep 1; done
 	@echo "Waiting for Iceberg REST catalog..."
-	@until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-iceberg-rest 2>/dev/null)" = "healthy" ]; do sleep 1; done
+	@i=0; until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-iceberg-rest 2>/dev/null)" = "healthy" ]; do \
+		i=$$((i+1)); [ $$i -gt 60 ] && echo "ERROR: Iceberg REST did not become healthy in 60s" && exit 1; sleep 1; done
 	@echo "MinIO:        http://localhost:9000  (user=minioadmin pass=minioadmin)"
 	@echo "MinIO UI:     http://localhost:9001"
 	@echo "Iceberg REST: http://localhost:8181"

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ iceberg-up:
 	@echo "Waiting for MinIO to become healthy..."
 	@until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-minio 2>/dev/null)" = "healthy" ]; do sleep 1; done
 	@echo "Waiting for Iceberg REST catalog..."
-	@sleep 5
+	@until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-iceberg-rest 2>/dev/null)" = "healthy" ]; do sleep 1; done
 	@echo "MinIO:        http://localhost:9000  (user=minioadmin pass=minioadmin)"
 	@echo "MinIO UI:     http://localhost:9001"
 	@echo "Iceberg REST: http://localhost:8181"
@@ -95,6 +95,8 @@ iceberg-down:
 	docker compose --profile iceberg down
 
 smoke-iceberg: ## Run live smoke test against local Iceberg REST + MinIO (requires make iceberg-up)
+	@curl -sf http://localhost:8181/v1/config >/dev/null 2>&1 || \
+		(echo "Iceberg REST не запущен. Сначала выполни: make iceberg-up" && exit 1)
 	python -m scripts.smoke_iceberg
 
 # Ruff: linter + import sort + pyupgrade in one tool. Config in pyproject.toml.

--- a/README.md
+++ b/README.md
@@ -379,6 +379,18 @@ MONITORED_SCHEMA=my_glue_database
 
 NULL-статистика во всех SQL-диалектах считается через `COUNT(*) - COUNT(col)` (PostgreSQL дополнительно использует `FILTER (WHERE col IS NULL)` как более идиоматичный вариант). `column_distribution` собирается через `SELECT col, COUNT(*) GROUP BY col ORDER BY 2 DESC LIMIT 20` — пропускает text/json/blob/uuid колонки (top-N по высокой кардинальности — шум, не сигнал).
 
+### Live smoke test для Iceberg
+
+Поднимает локальный REST-каталог + MinIO через Docker Compose и прогоняет адаптер против реального Iceberg-кластера:
+
+```bash
+make iceberg-up       # запустить MinIO (9000/9001) + Iceberg REST (8181)
+make smoke-iceberg    # создать таблицу, записать данные, проверить адаптер
+make iceberg-down     # остановить
+```
+
+Скрипт (`scripts/smoke_iceberg.py`) создаёт namespace + таблицу с 5 строками и 2 NULL-полями, затем проверяет все методы адаптера: `list_tables`, `table_schema`, `table_stats` (row_count, size_bytes), `column_nulls` (из manifest metadata, без сканирования), `column_distribution` (→ []).
+
 ---
 
 ## Запуск в Docker

--- a/app/db.py
+++ b/app/db.py
@@ -446,6 +446,7 @@ class IcebergAdapter(DBAdapter):
         elif catalog_type == "glue":
             from pyiceberg.catalog.glue import GlueCatalog
 
+            props.pop("uri", None)  # uri is REST-only; drop it if accidentally passed
             self._catalog = GlueCatalog("glue", **props)
         else:
             raise ValueError(

--- a/app/db.py
+++ b/app/db.py
@@ -434,21 +434,18 @@ class IcebergAdapter(DBAdapter):
         parsed = urlparse(url)
         catalog_type = parsed.scheme.split("+", 1)[1]  # "rest" or "glue"
         qs = parse_qs(parsed.query)
-        warehouse = (qs.get("warehouse") or [None])[0]
+
+        # All query params become catalog props (warehouse, s3.endpoint, etc.)
+        props: dict = {key: values[0] for key, values in qs.items()}
 
         if catalog_type == "rest":
             from pyiceberg.catalog.rest import RestCatalog
 
-            props: dict = {"uri": f"http://{parsed.netloc}"}
-            if warehouse:
-                props["warehouse"] = warehouse
+            props["uri"] = f"http://{parsed.netloc}"
             self._catalog = RestCatalog("rest", **props)
         elif catalog_type == "glue":
             from pyiceberg.catalog.glue import GlueCatalog
 
-            props = {}
-            if warehouse:
-                props["warehouse"] = warehouse
             self._catalog = GlueCatalog("glue", **props)
         else:
             raise ValueError(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
     ports:
       - "8181:8181"
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 8181 || exit 1"]
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8181' 2>/dev/null || exit 1"]
       interval: 2s
       timeout: 3s
       retries: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,11 @@ services:
       AWS_REGION: us-east-1
     ports:
       - "8181:8181"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8181/v1/config"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
     depends_on:
       minio:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,48 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # ── Apache Iceberg smoke-test backend (#128) ─────────────────────────
+  # Start with: make iceberg-up   Stop with: make iceberg-down
+  #
+  # MinIO — S3-совместимое хранилище для файлов Iceberg-таблиц.
+  minio:
+    image: minio/minio:latest
+    container_name: db-monitoring-minio
+    profiles: ["iceberg"]
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+
+  # Iceberg REST-каталог — хранит метаданные таблиц, смотрит в MinIO.
+  iceberg-rest:
+    image: tabulario/iceberg-rest:latest
+    container_name: db-monitoring-iceberg-rest
+    profiles: ["iceberg"]
+    environment:
+      CATALOG_WAREHOUSE: s3://iceberg-smoke/warehouse
+      CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
+      CATALOG_S3_ENDPOINT: http://minio:9000
+      CATALOG_S3_ACCESS__KEY__ID: minioadmin
+      CATALOG_S3_SECRET__ACCESS__KEY: minioadmin
+      CATALOG_S3_PATH__STYLE__ACCESS: "true"
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: us-east-1
+    ports:
+      - "8181:8181"
+    depends_on:
+      minio:
+        condition: service_healthy
+
 volumes:
   pg_data:
   timescale_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
     ports:
       - "8181:8181"
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8181/v1/config"]
+      test: ["CMD-SHELL", "nc -z localhost 8181 || exit 1"]
       interval: 2s
       timeout: 3s
       retries: 20

--- a/scripts/smoke_iceberg.py
+++ b/scripts/smoke_iceberg.py
@@ -95,7 +95,7 @@ def create_bucket() -> None:
 # ── Step 2: create namespace + table, write data ──────────────────────────────
 
 
-def setup_catalog():
+def setup_catalog() -> None:
     print("\n[2/3] Iceberg catalog setup")
     try:
         import pyarrow as pa
@@ -113,8 +113,8 @@ def setup_catalog():
     }
     catalog = RestCatalog("rest", uri=f"http://{REST_HOST}", warehouse=WAREHOUSE, **s3_props)
 
-    # Namespace
-    existing_ns = [ns[0] for ns in catalog.list_namespaces()]
+    # Namespace — join tuple parts to handle multi-level namespaces safely
+    existing_ns = [".".join(ns) for ns in catalog.list_namespaces()]
     if NAMESPACE not in existing_ns:
         catalog.create_namespace(NAMESPACE)
         _ok(f"namespace {NAMESPACE!r} created")
@@ -139,8 +139,11 @@ def setup_catalog():
     else:
         _ok(f"table {NAMESPACE}.{TABLE!r} already exists")
 
-    # Write data (creates snapshot + manifest metadata)
+    # Write data only if table is empty — keeps the script idempotent on re-runs.
     table = catalog.load_table((NAMESPACE, TABLE))
+    if table.current_snapshot() is not None:
+        _ok("table already has data — skipping append")
+        return
     arrow_schema = pa.schema([
         pa.field("id", pa.int64(), nullable=False),
         pa.field("customer", pa.string(), nullable=True),
@@ -161,11 +164,6 @@ def setup_catalog():
 def run_adapter() -> None:
     print("\n[3/3] IcebergAdapter assertions")
     print(f"  DSN: {DSN}")
-
-    # Point PyIceberg at local MinIO (env vars used by RestCatalog file I/O)
-    os.environ.setdefault("AWS_ACCESS_KEY_ID", MINIO_USER)
-    os.environ.setdefault("AWS_SECRET_ACCESS_KEY", MINIO_PASSWORD)
-    os.environ.setdefault("AWS_REGION", "us-east-1")
 
     from app.db import make_adapter_for_url
     adapter = make_adapter_for_url(DSN)

--- a/scripts/smoke_iceberg.py
+++ b/scripts/smoke_iceberg.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
 import time
+import uuid
 from urllib.parse import urlencode
 
 # ── Config ────────────────────────────────────────────────────────────────────
@@ -67,7 +69,7 @@ def _fail(msg: str) -> None:
 
 
 def create_bucket() -> None:
-    print("\n[1/3] MinIO bucket")
+    print("\n[1/4] MinIO bucket")
     try:
         import boto3
         from botocore.exceptions import ClientError
@@ -96,10 +98,11 @@ def create_bucket() -> None:
 
 
 def setup_catalog() -> None:
-    print("\n[2/3] Iceberg catalog setup")
+    print("\n[2/4] Iceberg catalog setup")
     try:
         import pyarrow as pa
         from pyiceberg.catalog.rest import RestCatalog
+        from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchTableError
         from pyiceberg.schema import Schema
         from pyiceberg.types import IntegerType, LongType, NestedField, StringType
     except ImportError:
@@ -113,37 +116,35 @@ def setup_catalog() -> None:
     }
     catalog = RestCatalog("rest", uri=f"http://{REST_HOST}", warehouse=WAREHOUSE, **s3_props)
 
-    # Namespace — join tuple parts to handle multi-level namespaces safely
-    existing_ns = [".".join(ns) for ns in catalog.list_namespaces()]
-    if NAMESPACE not in existing_ns:
-        catalog.create_namespace(NAMESPACE)
-        _ok(f"namespace {NAMESPACE!r} created")
-    else:
-        _ok(f"namespace {NAMESPACE!r} already exists")
+    # Always drop + recreate so row/null counts are deterministic on re-runs.
+    try:
+        catalog.drop_table((NAMESPACE, TABLE))
+        _ok(f"dropped stale table {NAMESPACE}.{TABLE!r}")
+    except NoSuchTableError:
+        pass
+    try:
+        catalog.drop_namespace(NAMESPACE)
+        _ok(f"dropped stale namespace {NAMESPACE!r}")
+    except NoSuchNamespaceError:
+        pass
 
-    # Table
-    existing_tables = [t[-1] for t in catalog.list_tables(NAMESPACE)]
-    if TABLE not in existing_tables:
-        schema = Schema(
-            NestedField(1, "id", LongType(), required=True),
-            NestedField(2, "customer", StringType(), required=False),
-            NestedField(3, "amount", IntegerType(), required=False),
-        )
-        catalog.create_table(
-            identifier=(NAMESPACE, TABLE),
-            schema=schema,
-            location=f"{WAREHOUSE}/{NAMESPACE}/{TABLE}",
-            properties={"write.target-file-size-bytes": "536870912"},
-        )
-        _ok(f"table {NAMESPACE}.{TABLE!r} created")
-    else:
-        _ok(f"table {NAMESPACE}.{TABLE!r} already exists")
+    catalog.create_namespace(NAMESPACE)
+    _ok(f"namespace {NAMESPACE!r} created")
 
-    # Write data only if table is empty — keeps the script idempotent on re-runs.
+    schema = Schema(
+        NestedField(1, "id", LongType(), required=True),
+        NestedField(2, "customer", StringType(), required=False),
+        NestedField(3, "amount", IntegerType(), required=False),
+    )
+    catalog.create_table(
+        identifier=(NAMESPACE, TABLE),
+        schema=schema,
+        location=f"{WAREHOUSE}/{NAMESPACE}/{TABLE}",
+        properties={"write.target-file-size-bytes": "536870912"},
+    )
+    _ok(f"table {NAMESPACE}.{TABLE!r} created")
+
     table = catalog.load_table((NAMESPACE, TABLE))
-    if table.current_snapshot() is not None:
-        _ok("table already has data — skipping append")
-        return
     arrow_schema = pa.schema([
         pa.field("id", pa.int64(), nullable=False),
         pa.field("customer", pa.string(), nullable=True),
@@ -162,7 +163,7 @@ def setup_catalog() -> None:
 
 
 def run_adapter() -> None:
-    print("\n[3/3] IcebergAdapter assertions")
+    print("\n[3/4] IcebergAdapter assertions")
     print(f"  DSN: {DSN}")
 
     from app.db import make_adapter_for_url
@@ -219,6 +220,78 @@ def run_adapter() -> None:
     _ok("column_distribution ✓ (empty — no scan by design)")
 
 
+# ── Step 4: full scheduler path ──────────────────────────────────────────────
+
+
+def run_collector() -> None:
+    """Smoke the full per-project scheduler path:
+
+    decrypt DSN → make_adapter_for_url → using_engine(None, adapter)
+    → MetricsCollector → save_metrics(project_id) → verify row_count saved.
+    """
+    print("\n[4/4] Collector path (collect_for_connection)")
+
+    # Isolated temp SQLite monitoring DB — never touches the real monitor.db.
+    fd, db_path = tempfile.mkstemp(suffix="_smoke_monitor.db")
+    os.close(fd)
+
+    import app.metrics_storage as storage
+    storage.settings.MONITOR_DB_URL = f"sqlite:///{db_path}"
+    storage._engine = None        # force get_engine() to rebuild with new URL
+    storage._initialized = False
+
+    # Fresh Fernet key so DSN encryption/decryption is self-contained.
+    from cryptography.fernet import Fernet
+    os.environ["FERNET_KEY"] = Fernet.generate_key().decode()
+    import app.crypto as crypto_mod
+    crypto_mod._fernet = None     # force re-init with new key
+
+    from app import crypto
+    from app.metrics_storage import (
+        create_connection,
+        create_project,
+        create_user,
+        get_metrics,
+    )
+    from collectors.per_project import collect_for_connection
+
+    user_id = str(uuid.uuid4())
+    project_id = str(uuid.uuid4())
+    connection_id = str(uuid.uuid4())
+
+    create_user(user_id, "smoke@example.com", "smoke-hash")
+    create_project(project_id, user_id, "Smoke Iceberg Project", "smoke-iceberg")
+    dsn_encrypted = crypto.encrypt_dsn(DSN)
+    create_connection(
+        connection_id=connection_id,
+        project_id=project_id,
+        name="Smoke Iceberg Connection",
+        dsn_encrypted=dsn_encrypted,
+        schema_name=NAMESPACE,
+        interval_minutes=15,
+        is_active=True,
+    )
+    _ok(f"project + connection inserted (project={project_id[:8]}…)")
+
+    try:
+        collect_for_connection(project_id, connection_id)
+        _ok("collect_for_connection() completed")
+
+        # row_count must have been saved for the 'orders' table
+        rows = get_metrics(TABLE, "row_count", project_id)
+        if not rows:
+            _fail(f"no 'row_count' metric saved for table {TABLE!r} — check collector logs")
+        row_count_val = rows[-1]["value"]
+        if row_count_val != len(ROWS["id"]):
+            _fail(f"expected row_count={len(ROWS['id'])}, got {row_count_val}")
+        _ok(f"row_count metric = {int(row_count_val)} ✓")
+    finally:
+        try:
+            os.unlink(db_path)
+        except OSError:
+            pass
+
+
 # ── Entrypoint ────────────────────────────────────────────────────────────────
 
 
@@ -234,6 +307,7 @@ def main() -> None:
     create_bucket()
     setup_catalog()
     run_adapter()
+    run_collector()
     elapsed = time.monotonic() - t0
 
     print(f"\n{'=' * 60}")

--- a/scripts/smoke_iceberg.py
+++ b/scripts/smoke_iceberg.py
@@ -1,0 +1,247 @@
+"""Live smoke test for IcebergAdapter (#128).
+
+Verifies the full adapter stack against a real Iceberg REST catalog + MinIO.
+All assertions mirror what the scheduled collector would see in production.
+
+Prerequisites — start with ``make iceberg-up``:
+  - MinIO on localhost:9000       (MINIO_ROOT_USER/PASSWORD = minioadmin)
+  - Iceberg REST on localhost:8181 (warehouse → s3://iceberg-smoke/warehouse)
+
+Usage::
+
+    make smoke-iceberg
+    # or directly:
+    python -m scripts.smoke_iceberg
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from urllib.parse import urlencode
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://localhost:9000")
+MINIO_USER = os.getenv("MINIO_ROOT_USER", "minioadmin")
+MINIO_PASSWORD = os.getenv("MINIO_ROOT_PASSWORD", "minioadmin")
+BUCKET = "iceberg-smoke"
+WAREHOUSE = f"s3://{BUCKET}/warehouse"
+
+REST_HOST = os.getenv("ICEBERG_REST_HOST", "localhost:8181")
+
+# S3 properties forwarded to IcebergAdapter so file I/O hits MinIO, not AWS.
+_DSN_PARAMS = urlencode({
+    "warehouse": WAREHOUSE,
+    "s3.endpoint": MINIO_ENDPOINT,
+    "s3.access-key-id": MINIO_USER,
+    "s3.secret-access-key": MINIO_PASSWORD,
+    "s3.path-style-access": "true",
+})
+DSN = f"iceberg+rest://{REST_HOST}?{_DSN_PARAMS}"
+
+NAMESPACE = "smoke_ns"
+TABLE = "orders"
+
+# Rows: id, customer (1 NULL), amount (1 NULL)
+ROWS = {
+    "id":       [1,       2,     3,     4,      5],
+    "customer": ["Alice", "Bob", None,  "Dave", "Eve"],
+    "amount":   [100,     200,   150,   None,   300],
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _ok(msg: str) -> None:
+    print(f"  ✓ {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  ✗ {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+# ── Step 1: create MinIO bucket ───────────────────────────────────────────────
+
+
+def create_bucket() -> None:
+    print("\n[1/3] MinIO bucket")
+    try:
+        import boto3
+        from botocore.exceptions import ClientError
+    except ImportError:
+        _fail("boto3 not installed — run: pip install boto3")
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=MINIO_ENDPOINT,
+        aws_access_key_id=MINIO_USER,
+        aws_secret_access_key=MINIO_PASSWORD,
+        region_name="us-east-1",
+    )
+    try:
+        s3.create_bucket(Bucket=BUCKET)
+        _ok(f"bucket {BUCKET!r} created")
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+            _ok(f"bucket {BUCKET!r} already exists")
+        else:
+            _fail(f"MinIO error: {e}")
+
+
+# ── Step 2: create namespace + table, write data ──────────────────────────────
+
+
+def setup_catalog():
+    print("\n[2/3] Iceberg catalog setup")
+    try:
+        import pyarrow as pa
+        from pyiceberg.catalog.rest import RestCatalog
+        from pyiceberg.schema import Schema
+        from pyiceberg.types import IntegerType, LongType, NestedField, StringType
+    except ImportError:
+        _fail("pyiceberg[pyarrow] not installed — run: pip install 'pyiceberg[pyarrow]>=0.7.0'")
+
+    s3_props = {
+        "s3.endpoint": MINIO_ENDPOINT,
+        "s3.access-key-id": MINIO_USER,
+        "s3.secret-access-key": MINIO_PASSWORD,
+        "s3.path-style-access": "true",
+    }
+    catalog = RestCatalog("rest", uri=f"http://{REST_HOST}", warehouse=WAREHOUSE, **s3_props)
+
+    # Namespace
+    existing_ns = [ns[0] for ns in catalog.list_namespaces()]
+    if NAMESPACE not in existing_ns:
+        catalog.create_namespace(NAMESPACE)
+        _ok(f"namespace {NAMESPACE!r} created")
+    else:
+        _ok(f"namespace {NAMESPACE!r} already exists")
+
+    # Table
+    existing_tables = [t[-1] for t in catalog.list_tables(NAMESPACE)]
+    if TABLE not in existing_tables:
+        schema = Schema(
+            NestedField(1, "id", LongType(), required=True),
+            NestedField(2, "customer", StringType(), required=False),
+            NestedField(3, "amount", IntegerType(), required=False),
+        )
+        catalog.create_table(
+            identifier=(NAMESPACE, TABLE),
+            schema=schema,
+            location=f"{WAREHOUSE}/{NAMESPACE}/{TABLE}",
+            properties={"write.target-file-size-bytes": "536870912"},
+        )
+        _ok(f"table {NAMESPACE}.{TABLE!r} created")
+    else:
+        _ok(f"table {NAMESPACE}.{TABLE!r} already exists")
+
+    # Write data (creates snapshot + manifest metadata)
+    table = catalog.load_table((NAMESPACE, TABLE))
+    arrow_schema = pa.schema([
+        pa.field("id", pa.int64(), nullable=False),
+        pa.field("customer", pa.string(), nullable=True),
+        pa.field("amount", pa.int32(), nullable=True),
+    ])
+    arrow_table = pa.table({
+        "id":       pa.array(ROWS["id"], type=pa.int64()),
+        "customer": pa.array(ROWS["customer"], type=pa.string()),
+        "amount":   pa.array(ROWS["amount"], type=pa.int32()),
+    }, schema=arrow_schema)
+    table.append(arrow_table)
+    _ok(f"wrote {len(ROWS['id'])} rows (1 NULL in customer, 1 NULL in amount)")
+
+
+# ── Step 3: run adapter and assert ───────────────────────────────────────────
+
+
+def run_adapter() -> None:
+    print("\n[3/3] IcebergAdapter assertions")
+    print(f"  DSN: {DSN}")
+
+    # Point PyIceberg at local MinIO (env vars used by RestCatalog file I/O)
+    os.environ.setdefault("AWS_ACCESS_KEY_ID", MINIO_USER)
+    os.environ.setdefault("AWS_SECRET_ACCESS_KEY", MINIO_PASSWORD)
+    os.environ.setdefault("AWS_REGION", "us-east-1")
+
+    from app.db import make_adapter_for_url
+    adapter = make_adapter_for_url(DSN)
+
+    # list_tables
+    tables = adapter.list_tables(NAMESPACE)
+    print(f"\n  list_tables({NAMESPACE!r}) → {tables}")
+    if not any(t["table_name"] == TABLE for t in tables):
+        _fail(f"table {TABLE!r} not found in list_tables result")
+    _ok("list_tables ✓")
+
+    # table_schema
+    schema = adapter.table_schema(TABLE, NAMESPACE)
+    print(f"  table_schema → {schema}")
+    if len(schema) != 3:
+        _fail(f"expected 3 fields, got {len(schema)}")
+    names = {f["name"] for f in schema}
+    if names != {"id", "customer", "amount"}:
+        _fail(f"unexpected field names: {names}")
+    _ok("table_schema ✓")
+
+    # table_stats
+    stats = adapter.table_stats(TABLE, NAMESPACE)
+    print(f"  table_stats  → {stats}")
+    if stats is None:
+        _fail("table_stats returned None")
+    if stats["row_count"] != len(ROWS["id"]):
+        _fail(f"expected row_count={len(ROWS['id'])}, got {stats['row_count']}")
+    if stats["size_bytes"] <= 0:
+        _fail(f"expected size_bytes > 0, got {stats['size_bytes']}")
+    if stats["last_analyze"] is None:
+        _fail("last_analyze is None (no snapshot?)")
+    _ok("table_stats ✓")
+
+    # column_nulls
+    nulls = adapter.column_nulls(TABLE, NAMESPACE)
+    print(f"  column_nulls → {nulls}")
+    if not nulls:
+        _fail("column_nulls returned empty list")
+    customer_stats = next((c for c in nulls if c["column"] == "customer"), None)
+    amount_stats = next((c for c in nulls if c["column"] == "amount"), None)
+    if customer_stats is None or customer_stats["null_count"] != 1:
+        _fail(f"customer null_count: expected 1, got {customer_stats}")
+    if amount_stats is None or amount_stats["null_count"] != 1:
+        _fail(f"amount null_count: expected 1, got {amount_stats}")
+    _ok("column_nulls ✓")
+
+    # column_distribution — must return [] (no scan)
+    dist = adapter.column_distribution(TABLE, NAMESPACE)
+    print(f"  column_distribution → {dist}")
+    if dist != []:
+        _fail(f"expected [], got {dist}")
+    _ok("column_distribution ✓ (empty — no scan by design)")
+
+
+# ── Entrypoint ────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Iceberg adapter live smoke test")
+    print(f"  REST catalog : http://{REST_HOST}")
+    print(f"  MinIO        : {MINIO_ENDPOINT}")
+    print(f"  Warehouse    : {WAREHOUSE}")
+    print("=" * 60)
+
+    t0 = time.monotonic()
+    create_bucket()
+    setup_catalog()
+    run_adapter()
+    elapsed = time.monotonic() - t0
+
+    print(f"\n{'=' * 60}")
+    print(f"✅  All checks passed in {elapsed:.1f}s")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_iceberg.py
+++ b/scripts/smoke_iceberg.py
@@ -16,6 +16,7 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 import tempfile
@@ -286,10 +287,8 @@ def run_collector() -> None:
             _fail(f"expected row_count={len(ROWS['id'])}, got {row_count_val}")
         _ok(f"row_count metric = {int(row_count_val)} ✓")
     finally:
-        try:
+        with contextlib.suppress(OSError):
             os.unlink(db_path)
-        except OSError:
-            pass
 
 
 # ── Entrypoint ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Описание

Закрывает #128 — live smoke test для `IcebergAdapter` против локального Iceberg REST-каталога + MinIO.

**Что сделано:**

- `docker-compose.yml` — добавлены сервисы `minio` и `iceberg-rest` под профилем `iceberg`; не запускаются вместе с основным стеком, только через `make iceberg-up`
- `Makefile` — цели `iceberg-up` / `iceberg-down` / `smoke-iceberg`
- `scripts/smoke_iceberg.py` — новый smoke-скрипт в три шага:
  1. Создаёт S3-бакет в MinIO через boto3
  2. Создаёт namespace + таблицу `orders` (5 строк, 1 NULL в `customer`, 1 NULL в `amount`) через PyIceberg + PyArrow
  3. Прогоняет все методы `IcebergAdapter` и проверяет результаты
- `app/db.py` — фикс `IcebergAdapter.__init__`: теперь все query-параметры DSN (не только `warehouse`) пробрасываются в `RestCatalog`/`GlueCatalog` как catalog properties. Без этого `column_nulls` получал `ACCESS_DENIED` при чтении manifest-файлов, потому что `s3.endpoint` не попадал в `table.io` и PyIceberg шёл на настоящий AWS.
- `README.md` — секция "Live smoke test для Iceberg" с командами

**Как запустить:**
```bash
make iceberg-up
make smoke-iceberg
make iceberg-down
```

## Тип изменения

- [x] New feature
- [x] Bug fix (s3.endpoint в IcebergAdapter)

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest tests/test_iceberg_adapter.py` — 22/22 passed
- [x] smoke test прошёл локально (все 5 проверок за 3.3s)