### PR TITLE
fix: classifier распознаёт Supabase tenant_not_found как отдельный код

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -280,6 +280,16 @@ _NETWORK_HINTS = (
     "temporary failure in name resolution",
     "unable to connect",
 )
+# Supavisor (Supabase's connection pooler) replies with this when the
+# tenant slug in the username doesn't match a live project — typically
+# means the project was deleted or the project ref is wrong. Distinct
+# from auth_failed: the password isn't even evaluated, the tenant just
+# doesn't exist.
+_SUPABASE_TENANT_HINTS = (
+    "tenant or user not found",
+    "tenant/user not found",
+    "(enotfound) tenant",
+)
 
 
 def _classify_error(exc: BaseException) -> tuple[str, str]:
@@ -290,6 +300,12 @@ def _classify_error(exc: BaseException) -> tuple[str, str]:
     to the browser without the filter. Phrasing is deliberately generic.
     """
     msg = str(exc).lower()
+    if any(h in msg for h in _SUPABASE_TENANT_HINTS):
+        return (
+            "supabase_tenant_not_found",
+            "Supabase project не найден. Проверьте, что проект активен "
+            "и project ref в username верный.",
+        )
     if any(h in msg for h in _AUTH_HINTS):
         return "auth_failed", "Неверный логин или пароль."
     if any(h in msg for h in _TIMEOUT_HINTS):

--- a/tests/test_connection_test.py
+++ b/tests/test_connection_test.py
@@ -75,6 +75,17 @@ def test_probe_classifies_unsupported_dialect():
     ("could not translate host name \"db.example.com\" to address", "network"),
     ("could not connect to server: Connection refused", "network"),
     ("Name or service not known", "network"),
+    # Supavisor / Supabase pooler: project deleted or wrong project ref.
+    # Message comes verbatim from libpq, so test both casings Supavisor
+    # has shipped over the years.
+    (
+        "FATAL:  (ENOTFOUND) tenant/user postgres.deadproj not found",
+        "supabase_tenant_not_found",
+    ),
+    (
+        "FATAL:  Tenant or user not found",
+        "supabase_tenant_not_found",
+    ),
     ("some other weird error from the future", "error"),
 ])
 def test_probe_classifies_exception_text(monkeypatch, err_text, expected_code):


### PR DESCRIPTION
## Корень

Реальный manual-кейс: юзер подключил pooler-DSN для deleted Supabase-проекта:

\`\`\`
postgresql://postgres.<ref>:<pwd>@aws-0-<region>.pooler.supabase.com:5432/postgres
\`\`\`

Supavisor (Supabase connection pooler) ответил:

\`\`\`
FATAL: (ENOTFOUND) tenant/user postgres.<ref> not found
\`\`\`

Это специфичная Supabase ситуация:
- TCP коннект до shared pooler-хоста проходит
- tenant slug в username не сматчился → проект **удалён** или project ref неверный
- Это **не** auth_failed: пароль вообще не оценивался

В UI юзер видел обобщённое «Ошибка подключения (см. логи сервера)» — приходится лезть в server logs, где он увидит psycopg2-traceback вместо понятного указания на проблему.

## Фикс

Новый код \`supabase_tenant_not_found\` в \`_classify_error\`:

\`\`\`python
_SUPABASE_TENANT_HINTS = (
    "tenant or user not found",
    "tenant/user not found",
    "(enotfound) tenant",
)
\`\`\`

Сообщение юзеру: **«Supabase project не найден. Проверьте, что проект активен и project ref в username верный.»** Actionable — гонит в Supabase Dashboard, а не в логи.

Проверяется раньше \`auth_failed\` потому что Supavisor-сообщение про tenant приоритетнее любых fallback-классификаций.

## Тесты

Parametrized в \`tests/test_connection_test.py\` пинит обе исторические формы Supavisor:
- \`FATAL: (ENOTFOUND) tenant/user postgres.deadproj not found\` (старая)
- \`FATAL: Tenant or user not found\` (новая)

## Verification

- \`pytest tests/test_connection_test.py -q\` → 19 passed (+2 кейса)
- \`ruff check\` → clean
- Manual repro: \`probe_connection(<dead-project-dsn>)\` теперь возвращает \`code: 'supabase_tenant_not_found'\` с понятным сообщением

## Test plan

- [x] Юнит-тесты на оба варианта строки от Supavisor
- [x] Live проверка с реальным deleted-проектом
- [x] Не задевает существующую классификацию (auth/timeout/network)