### PR TITLE
feat: первый сбор метрик при добавлении коннекта — сразу, не через интервал

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -146,7 +146,11 @@ def new_connection(slug: str):
             from collectors.per_project import add_job_for_connection
             from collectors.scheduler import get_scheduler
 
-            add_job_for_connection(get_scheduler(), project["id"], conn_row)
+            # First tick immediately so the user sees metrics on /dashboard
+            # right after save instead of waiting up to interval_minutes.
+            add_job_for_connection(
+                get_scheduler(), project["id"], conn_row, run_immediately=True,
+            )
 
         # Onboarding auto-test (#55): on the FIRST connection, probe the
         # DSN immediately so the user gets instant feedback instead of
@@ -244,7 +248,12 @@ def toggle(slug: str, conn_id: str):
 
     sched = get_scheduler()
     if new_active:
-        add_job_for_connection(sched, project["id"], {**conn, "is_active": True})
+        # Same as create: kick the first tick now — toggling on is a
+        # deliberate user action expecting fresh metrics promptly.
+        add_job_for_connection(
+            sched, project["id"], {**conn, "is_active": True},
+            run_immediately=True,
+        )
     else:
         remove_job_for_connection(sched, project["id"], conn["id"])
     flash(

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -153,17 +153,27 @@ _JOB_OPTS = {
 
 
 def add_job_for_connection(
-    scheduler: BaseScheduler, project_id: str, connection: dict
+    scheduler: BaseScheduler, project_id: str, connection: dict,
+    *, run_immediately: bool = False,
 ) -> None:
     """Idempotent: re-adding overwrites the existing job (same id).
 
     Connection must be the dict shape returned by ``metrics_storage.
     get_connection`` — needs id, interval_minutes.
+
+    ``run_immediately`` schedules the very first tick at "now" instead of
+    "now + interval". Set when the user has just added/toggled-on the
+    connection so they see metrics right away rather than waiting up to
+    24 h on a daily interval. Not set during boot-time re-registration,
+    where firing every active job at once would thunder the target DBs.
     """
     if scheduler is None or not scheduler.running:
         logger.debug("scheduler not running, deferring job for conn=%s",
                      connection["id"])
         return
+    extra: dict = {}
+    if run_immediately:
+        extra["next_run_time"] = datetime.now(UTC)
     scheduler.add_job(
         collect_for_connection,
         "interval",
@@ -172,9 +182,13 @@ def add_job_for_connection(
         id=job_id_for(project_id, connection["id"]),
         name=f"collect project={project_id} conn={connection['id']}",
         **_JOB_OPTS,
+        **extra,
     )
-    logger.info("[project=%s][conn=%s] registered (every %d min)",
-                project_id, connection["id"], connection["interval_minutes"])
+    logger.info(
+        "[project=%s][conn=%s] registered (every %d min%s)",
+        project_id, connection["id"], connection["interval_minutes"],
+        ", first tick now" if run_immediately else "",
+    )
 
 
 def remove_job_for_connection(

--- a/tests/test_per_project.py
+++ b/tests/test_per_project.py
@@ -128,6 +128,30 @@ def test_add_job_for_connection_registers_with_stable_id(fake_scheduler):
     assert call.kwargs["max_instances"] == 1
     assert call.kwargs["coalesce"] is True
     assert call.kwargs["replace_existing"] is True
+    # Default: NO next_run_time → APScheduler waits "now + interval"
+    # before the first tick. Boot-time re-registration depends on this
+    # to avoid a thundering herd across all active connections.
+    assert "next_run_time" not in call.kwargs
+
+
+def test_add_job_for_connection_run_immediately_sets_next_run_time_now(fake_scheduler):
+    """run_immediately=True schedules the first tick at "now" instead of
+    "now + interval" — used when the user just added/toggled-on a
+    connection and expects metrics promptly, not on the next interval."""
+    from datetime import UTC, datetime
+
+    before = datetime.now(UTC)
+    add_job_for_connection(
+        fake_scheduler, "proj-X",
+        {"id": "conn-Y", "interval_minutes": 1440},  # daily — would otherwise wait 24h
+        run_immediately=True,
+    )
+    after = datetime.now(UTC)
+    call = fake_scheduler.add_job.call_args
+    nrt = call.kwargs["next_run_time"]
+    assert before <= nrt <= after
+    # The interval cadence is still honoured for subsequent ticks.
+    assert call.kwargs["minutes"] == 1440
 
 
 def test_remove_job_unregisters_only_when_present(fake_scheduler):


### PR DESCRIPTION
## Что и почему

До этого PR APScheduler-job регистрировался с \`interval\`-триггером без явного \`next_run_time\` → первый fire ставился на \`now + interval\`. На дефолтном \`interval_minutes=15\` юзер ждал 15 минут после save до первых метрик. На \`interval=1440\` (раз в сутки) — целые сутки.

Это плохой UX особенно сразу после онбординга (#55): юзер только что зарегистрировался, добавил DSN, попал на /dashboard — и видит пустой empty-state ещё 15 минут.

## Решение

Опциональный флаг \`run_immediately\` в \`add_job_for_connection\`:

\`\`\`python
extra = {}
if run_immediately:
    extra["next_run_time"] = datetime.now(UTC)
scheduler.add_job(..., **extra)
\`\`\`

APScheduler fire-ит сразу (в background-треде), юзер уже редиректнут на /dashboard. Дальше — обычный interval cadence.

## Call-сайты

- \`connections.new_connection\` (создание) → \`run_immediately=True\`
- \`connections.toggle\` (включение коннекта) → \`run_immediately=True\`
- \`register_jobs_for_all_active_connections\` (boot) → **default False**

Boot-режим намеренно не меняется: если admin рестартует сервер с 100 активными коннектами, мы НЕ хотим чтобы все 100 одновременно ударили в свои target-БД. Они дождутся обычного interval-тика.

## UX-сценарий

1. Регистрация → онбординг → POST коннекта с валидным DSN
2. \`probe_connection\` → ok → flash + redirect /dashboard
3. APScheduler fire-ит \`collect_for_connection\` немедленно (1-3 сек в фоне)
4. Юзер видит empty-state, делает refresh через ~5 сек — метрики уже там

## Тесты

\`tests/test_per_project.py\`:

- \`test_add_job_for_connection_registers_with_stable_id\` дополнен ассертом \`"next_run_time" not in call.kwargs\` — пин дефолта (защищает boot-режим от случайной регрессии в будущем).
- Новый \`test_add_job_for_connection_run_immediately_sets_next_run_time_now\` — с флагом \`next_run_time ∈ [now_before, now_after]\`, interval сохранён.

## Verification

- \`pytest tests/test_per_project.py tests/test_connections.py tests/test_onboarding.py -q\` → 45 passed, 1 deselected (pyiceberg test — не связан)
- \`ruff check\` → clean

## Test plan

- [x] Юнит-тесты на дефолтное и run_immediately поведение
- [x] Boot-режим не задет (assert pin)
- [ ] Manual smoke после merge: добавить коннект, увидеть метрики в течение секунд, а не минут