### PR TITLE
fix(#137): дашборд показывал legacy-данные вместо онбординга при отсутствии проектов

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,6 +1,7 @@
 from datetime import UTC, timedelta
 
 from flask import Blueprint, g, jsonify, request
+from flask_login import current_user
 
 from .db import list_tables, table_schema
 from .metrics_storage import (
@@ -279,14 +280,21 @@ def notifications():
         from datetime import datetime
         since = datetime.now(UTC) - _RANGES[range_str]
 
+    project = getattr(g, "current_project", None)
+    if current_user.is_authenticated and project is None:
+        notif_project_id: str | None = "__no_project__"
+    else:
+        notif_project_id = project["id"] if project else "legacy"
+
     filters = {
         "event_type": event_type,
         "table_name": table,
         "status": status,
         "since": since,
     }
-    items = get_notifications(limit=limit, offset=offset, **filters)
-    total = count_notifications(**filters)
+    items = get_notifications(limit=limit, offset=offset,
+                              project_id=notif_project_id, **filters)
+    total = count_notifications(project_id=notif_project_id, **filters)
     return jsonify({"items": items, "total": total, "limit": limit, "offset": offset})
 
 

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -2,7 +2,8 @@ import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from flask import Blueprint, abort, g, render_template
+from flask import Blueprint, abort, g, redirect, render_template, url_for
+from flask_login import current_user
 
 from app import db
 from app.metrics_storage import (
@@ -18,6 +19,22 @@ from app.metrics_storage import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Sentinel used in notification filters when the user has no project — yields
+# an empty result set without a special-case branch in the query builder.
+_NO_PROJECT_ID = "__no_project__"
+
+
+def _onboarding_redirect():
+    """Return a redirect Response when an authenticated user has no projects.
+
+    Call at the top of any dashboard route that must not fall through to the
+    legacy global-DSN data path. Returns None when no redirect is needed.
+    """
+    if current_user.is_authenticated and getattr(g, "current_project", None) is None:
+        return redirect(url_for("projects.new_project"))
+    return None
+
 
 def _current_project_id() -> str:
     """g.current_project["id"] with a 'legacy' fallback — see api._current_project_id."""
@@ -50,28 +67,22 @@ bp = Blueprint(
 @bp.route("")
 @bp.route("/")
 def overview():
-    # Onboarding empty state (#55): if the current project has zero
-    # connections yet, render the dashboard with a CTA banner instead of
-    # an empty table grid. Anonymous / legacy paths fall through to the
-    # legacy global view.
     from app.metrics_storage import list_connections_for_project
 
-    has_connections = False
     project = getattr(g, "current_project", None)
-    if project is not None:
-        has_connections = bool(list_connections_for_project(project["id"]))
-
+    # #137: authenticated user with no projects → onboarding, not legacy data.
+    needs_first_project = current_user.is_authenticated and project is None
+    has_connections = bool(
+        list_connections_for_project(project["id"]) if project else False
+    )
     needs_first_connection = project is not None and not has_connections
 
     tables: list = []
     total_rows = 0
     null_rates: list = []
-    # Skip the legacy global-DSN schema fetch entirely when the empty-state
-    # banner will render anyway. Two reasons: (1) tenant isolation — a brand
-    # new project must not surface tables from the admin's old global
-    # DATABASE_URL; (2) it would crash if that DSN is unreachable.
+    skip_tables = needs_first_project or needs_first_connection
     try:
-        schema_entries = [] if needs_first_connection else db.list_tables()
+        schema_entries = [] if skip_tables else db.list_tables()
     except Exception as exc:
         logger.warning("list_tables failed in overview: %s", exc)
         schema_entries = []
@@ -96,7 +107,8 @@ def overview():
         "overview.html",
         tables=tables,
         summary=summary,
-        ml_last_runs=_ml_last_runs(),
+        ml_last_runs={} if (needs_first_project or needs_first_connection) else _ml_last_runs(),
+        needs_first_project=needs_first_project,
         needs_first_connection=needs_first_connection,
     )
 
@@ -138,6 +150,7 @@ def schema_view():
     from app.metrics_storage import get_drift_report, list_connections_for_project
 
     project = getattr(g, "current_project", None)
+    needs_first_project = current_user.is_authenticated and project is None
     has_connections = bool(
         list_connections_for_project(project["id"]) if project else False
     )
@@ -145,7 +158,8 @@ def schema_view():
 
     cutoff = datetime.now(UTC) - timedelta(days=_RECENT_SCHEMA_DAYS)
     schemas = []
-    if not needs_first_connection:
+    skip_tables = needs_first_project or needs_first_connection
+    if not skip_tables:
         try:
             _schema_entries = db.list_tables()
         except Exception as exc:
@@ -170,7 +184,10 @@ def schema_view():
                 "recent_schema_changes": recent_count,
             })
     return render_template(
-        "schema.html", schemas=schemas, needs_first_connection=needs_first_connection,
+        "schema.html",
+        schemas=schemas,
+        needs_first_project=needs_first_project,
+        needs_first_connection=needs_first_connection,
     )
 
 
@@ -183,6 +200,9 @@ def _parse_event_ts(value: str) -> datetime:
 
 @bp.route("/history")
 def history_view():
+    redir = _onboarding_redirect()
+    if redir:
+        return redir
     agg = build_history_aggregate(project_id=_current_project_id())
     runs = get_history_runs(agg, limit=12)
     daily_history = get_history_daily(agg, days=14)
@@ -199,6 +219,13 @@ def notifications_view():
     """История Telegram-уведомлений с фильтрами и пагинацией (#76)."""
     from flask import request
 
+    project = getattr(g, "current_project", None)
+    # #137: authenticated user with no projects → sentinel yields empty results.
+    if current_user.is_authenticated and project is None:
+        notif_project_id: str | None = _NO_PROJECT_ID
+    else:
+        notif_project_id = project["id"] if project else None
+
     event_type = request.args.get("event_type") or None
     status = request.args.get("status") or None
     table = request.args.get("table") or None
@@ -214,8 +241,9 @@ def notifications_view():
 
     offset = (page - 1) * _NOTIFICATION_PAGE_SIZE
     filters = {"event_type": event_type, "status": status, "table_name": table}
-    items = get_notifications(limit=_NOTIFICATION_PAGE_SIZE, offset=offset, **filters)
-    total = count_notifications(**filters)
+    items = get_notifications(limit=_NOTIFICATION_PAGE_SIZE, offset=offset,
+                              project_id=notif_project_id, **filters)
+    total = count_notifications(project_id=notif_project_id, **filters)
     pages = max(1, (total + _NOTIFICATION_PAGE_SIZE - 1) // _NOTIFICATION_PAGE_SIZE)
 
     return render_template(
@@ -235,6 +263,10 @@ def table_detail(table_name: str):
     from app.metrics_storage import get_drift_report, list_connections_for_project
 
     project = getattr(g, "current_project", None)
+    # #137: auth'd user with no projects → 404 (no legacy data leak).
+    # Anonymous users keep the legacy path (project is None, not authenticated).
+    if current_user.is_authenticated and project is None:
+        abort(404)
     has_connections = bool(
         list_connections_for_project(project["id"]) if project else False
     )

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -134,26 +134,41 @@ def _table_exists(engine: Engine, table: str) -> bool:
 
 
 def _migrate_existing_schema(engine: Engine) -> None:
-    """ALTER pre-#53 tables to match the current schema file.
+    """ALTER pre-#53/#137 tables to match the current schema file.
 
-    The CREATE TABLE statements above are no-ops on existing installations
-    (IF NOT EXISTS), so a column added after the initial deploy never
-    appears unless we explicitly ALTER. Today we only need to retrofit
-    ``metrics.project_id``; future migrations follow the same shape.
+    The CREATE TABLE statements are no-ops on existing installs (IF NOT EXISTS),
+    so columns added after initial deploy need explicit ALTER here. Each table
+    is checked independently — a partial DB (e.g. notifications without metrics)
+    still gets migrated correctly.
     """
-    if not _table_exists(engine, "metrics"):
-        return
-    if "project_id" not in _existing_columns(engine, "metrics"):
-        with engine.begin() as conn:
-            # NOT NULL + DEFAULT works on SQLite (>=3.3) and Postgres; the
-            # default backfills existing rows with the 'legacy' tenant id.
-            conn.execute(text(
-                "ALTER TABLE metrics ADD COLUMN project_id TEXT NOT NULL "
-                "DEFAULT 'legacy'"
-            ))
-        logger.info(
-            "metrics.project_id added (existing rows backfilled to 'legacy')"
-        )
+    if _table_exists(engine, "metrics"):
+        if "project_id" not in _existing_columns(engine, "metrics"):
+            with engine.begin() as conn:
+                # NOT NULL + DEFAULT works on SQLite (>=3.3) and Postgres; the
+                # default backfills existing rows with the 'legacy' tenant id.
+                conn.execute(text(
+                    "ALTER TABLE metrics ADD COLUMN project_id TEXT NOT NULL "
+                    "DEFAULT 'legacy'"
+                ))
+            logger.info(
+                "metrics.project_id added (existing rows backfilled to 'legacy')"
+            )
+
+    if _table_exists(engine, "notifications"):
+        if "project_id" not in _existing_columns(engine, "notifications"):
+            with engine.begin() as conn:
+                conn.execute(text(
+                    "ALTER TABLE notifications ADD COLUMN project_id TEXT NOT NULL "
+                    "DEFAULT 'legacy'"
+                ))
+                # Add index in the same transaction so existing DBs get it too.
+                conn.execute(text(
+                    "CREATE INDEX IF NOT EXISTS idx_notifications_project_ts "
+                    "ON notifications (project_id, ts DESC)"
+                ))
+            logger.info(
+                "notifications.project_id added (existing rows backfilled to 'legacy')"
+            )
 
 
 def _is_optional_timescale_stmt(stmt: str) -> bool:
@@ -1049,6 +1064,7 @@ def save_notification(
     error: str | None = None,
     chat_id: str | None = None,
     ts: datetime | str | None = None,
+    project_id: str = "legacy",
 ) -> int:
     """Store a Telegram notification record. Returns the new row id.
 
@@ -1057,6 +1073,7 @@ def save_notification(
     """
     payload = {
         "ts": _iso(ts or datetime.now(UTC)),
+        "project_id": project_id,
         "event_type": event_type,
         "table_name": table_name,
         "metric_name": metric_name,
@@ -1067,9 +1084,9 @@ def save_notification(
     }
     base = """
         INSERT INTO notifications
-            (ts, event_type, table_name, metric_name, message, status, error, chat_id)
+            (ts, project_id, event_type, table_name, metric_name, message, status, error, chat_id)
         VALUES
-            (:ts, :event_type, :table_name, :metric_name, :message, :status, :error, :chat_id)
+            (:ts, :project_id, :event_type, :table_name, :metric_name, :message, :status, :error, :chat_id)
     """
     # Postgres has no lastrowid — fetch the new id with RETURNING.
     sql = base + (" RETURNING id" if _is_postgres() else "")
@@ -1093,6 +1110,7 @@ def get_notifications(
     until: datetime | str | None = None,
     limit: int = 50,
     offset: int = 0,
+    project_id: str | None = None,
 ) -> list[dict]:
     """Return notification history, newest first, with optional filters.
 
@@ -1101,6 +1119,9 @@ def get_notifications(
     """
     where = ["1=1"]
     params: dict[str, Any] = {"limit": int(limit), "offset": int(offset)}
+    if project_id is not None:
+        where.append("project_id = :project_id")
+        params["project_id"] = project_id
     if event_type:
         where.append("event_type = :event_type")
         params["event_type"] = event_type
@@ -1149,10 +1170,14 @@ def count_notifications(
     status: str | None = None,
     since: datetime | str | None = None,
     until: datetime | str | None = None,
+    project_id: str | None = None,
 ) -> int:
     """Total notifications matching filters — used for pagination metadata."""
     where = ["1=1"]
     params: dict[str, Any] = {}
+    if project_id is not None:
+        where.append("project_id = :project_id")
+        params["project_id"] = project_id
     if event_type:
         where.append("event_type = :event_type")
         params["event_type"] = event_type
@@ -1441,14 +1466,24 @@ def list_projects_for_user(user_id: str) -> list[dict]:
 
 
 def delete_project(user_id: str, project_id: str) -> bool:
-    """Hard delete. Returns True if a row was removed (i.e. the project
-    existed and belonged to this user)."""
-    stmt = text(
-        "DELETE FROM projects WHERE id = :id AND user_id = :user_id"
-    )
+    """Hard delete. Returns True if a row was removed.
+
+    Ownership is verified by the WHERE user_id clause on the projects DELETE.
+    notifications are removed only when the project row was actually ours —
+    no FK cascade on SQLite, so we do it manually in the same transaction.
+    """
     with get_engine().begin() as conn:
-        result = conn.execute(stmt, {"id": project_id, "user_id": user_id})
-    return (result.rowcount or 0) > 0
+        result = conn.execute(
+            text("DELETE FROM projects WHERE id = :id AND user_id = :user_id"),
+            {"id": project_id, "user_id": user_id},
+        )
+        deleted = (result.rowcount or 0) > 0
+        if deleted:
+            conn.execute(
+                text("DELETE FROM notifications WHERE project_id = :pid"),
+                {"pid": project_id},
+            )
+    return deleted
 
 
 # --- /Projects -------------------------------------------------------------

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -141,34 +141,32 @@ def _migrate_existing_schema(engine: Engine) -> None:
     is checked independently — a partial DB (e.g. notifications without metrics)
     still gets migrated correctly.
     """
-    if _table_exists(engine, "metrics"):
-        if "project_id" not in _existing_columns(engine, "metrics"):
-            with engine.begin() as conn:
-                # NOT NULL + DEFAULT works on SQLite (>=3.3) and Postgres; the
-                # default backfills existing rows with the 'legacy' tenant id.
-                conn.execute(text(
-                    "ALTER TABLE metrics ADD COLUMN project_id TEXT NOT NULL "
-                    "DEFAULT 'legacy'"
-                ))
-            logger.info(
-                "metrics.project_id added (existing rows backfilled to 'legacy')"
-            )
+    if _table_exists(engine, "metrics") and "project_id" not in _existing_columns(engine, "metrics"):
+        with engine.begin() as conn:
+            # NOT NULL + DEFAULT works on SQLite (>=3.3) and Postgres; the
+            # default backfills existing rows with the 'legacy' tenant id.
+            conn.execute(text(
+                "ALTER TABLE metrics ADD COLUMN project_id TEXT NOT NULL "
+                "DEFAULT 'legacy'"
+            ))
+        logger.info(
+            "metrics.project_id added (existing rows backfilled to 'legacy')"
+        )
 
-    if _table_exists(engine, "notifications"):
-        if "project_id" not in _existing_columns(engine, "notifications"):
-            with engine.begin() as conn:
-                conn.execute(text(
-                    "ALTER TABLE notifications ADD COLUMN project_id TEXT NOT NULL "
-                    "DEFAULT 'legacy'"
-                ))
-                # Add index in the same transaction so existing DBs get it too.
-                conn.execute(text(
-                    "CREATE INDEX IF NOT EXISTS idx_notifications_project_ts "
-                    "ON notifications (project_id, ts DESC)"
-                ))
-            logger.info(
-                "notifications.project_id added (existing rows backfilled to 'legacy')"
-            )
+    if _table_exists(engine, "notifications") and "project_id" not in _existing_columns(engine, "notifications"):
+        with engine.begin() as conn:
+            conn.execute(text(
+                "ALTER TABLE notifications ADD COLUMN project_id TEXT NOT NULL "
+                "DEFAULT 'legacy'"
+            ))
+            # Add index in the same transaction so existing DBs get it too.
+            conn.execute(text(
+                "CREATE INDEX IF NOT EXISTS idx_notifications_project_ts "
+                "ON notifications (project_id, ts DESC)"
+            ))
+        logger.info(
+            "notifications.project_id added (existing rows backfilled to 'legacy')"
+        )
 
 
 def _is_optional_timescale_stmt(stmt: str) -> bool:

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -115,6 +115,7 @@ CREATE TABLE IF NOT EXISTS telegram_throttle (
 CREATE TABLE IF NOT EXISTS notifications (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     ts          TEXT NOT NULL,    -- ISO 8601 UTC, момент попытки отправки
+    project_id  TEXT NOT NULL DEFAULT 'legacy',  -- tenant scope (#137)
     event_type  TEXT NOT NULL,    -- anomaly | schema_drift | changepoint | forecast | root_cause
     table_name  TEXT,
     metric_name TEXT,
@@ -126,6 +127,8 @@ CREATE TABLE IF NOT EXISTS notifications (
 
 CREATE INDEX IF NOT EXISTS idx_notifications_ts
     ON notifications (ts DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_project_ts
+    ON notifications (project_id, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_notifications_event_type_ts
     ON notifications (event_type, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_notifications_table_ts

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -108,6 +108,7 @@ CREATE TABLE IF NOT EXISTS telegram_throttle (
 CREATE TABLE IF NOT EXISTS notifications (
     id          BIGSERIAL PRIMARY KEY,
     ts          TIMESTAMPTZ NOT NULL,
+    project_id  TEXT NOT NULL DEFAULT 'legacy',
     event_type  TEXT NOT NULL,
     table_name  TEXT,
     metric_name TEXT,
@@ -119,6 +120,8 @@ CREATE TABLE IF NOT EXISTS notifications (
 
 CREATE INDEX IF NOT EXISTS idx_notifications_ts
     ON notifications (ts DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_project_ts
+    ON notifications (project_id, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_notifications_event_type_ts
     ON notifications (event_type, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_notifications_table_ts

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -7,7 +7,19 @@
 
   <div class="mt-4">{% include "_flash.html" %}</div>
 
-  {% if needs_first_connection %}
+  {% if needs_first_project %}
+    {# Empty state (#137): authenticated user has no projects at all. #}
+    <section class="mt-6 rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 class="text-lg font-semibold">Нет проектов</h2>
+      <p class="mx-auto mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+        Создайте первый проект — он объединит подключения к БД и метрики в одном рабочем пространстве.
+      </p>
+      <a href="{{ url_for('projects.new_project') }}"
+         class="mt-4 inline-block rounded-md bg-accent px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover">
+        Создать проект →
+      </a>
+    </section>
+  {% elif needs_first_connection %}
     {# Empty state (#55): new project with zero connections. Friendly
        CTA instead of an empty table grid. #}
     <section class="mt-6 rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -36,6 +48,7 @@
     {% endfor %}
   </section>
 
+  {% if not needs_first_project %}
   <section class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
     <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-800">
       <h2 class="text-base font-semibold">ML</h2>
@@ -62,6 +75,7 @@
       {% endfor %}
     </div>
   </section>
+  {% endif %}
 
   <section class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
     <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-800">

--- a/templates/schema.html
+++ b/templates/schema.html
@@ -5,7 +5,19 @@
 {% block content %}
   <h1 class="text-2xl font-semibold tracking-tight">Схема</h1>
 
-  {% if needs_first_connection %}
+  {% if needs_first_project %}
+    {# Empty state (#137): no projects yet. #}
+    <section class="mt-6 rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 class="text-lg font-semibold">Нет проектов</h2>
+      <p class="mx-auto mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+        Создайте первый проект, чтобы начать мониторинг схемы.
+      </p>
+      <a href="{{ url_for('projects.new_project') }}"
+         class="mt-4 inline-block rounded-md bg-accent px-5 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover">
+        Создать проект →
+      </a>
+    </section>
+  {% elif needs_first_connection %}
     <section class="mt-6 rounded-xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <h2 class="text-lg font-semibold">Нет подключений</h2>
       <p class="mx-auto mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -212,3 +212,49 @@ def test_notifications_invalid_limit(client):
     assert resp.status_code == 400
     resp2 = client.get("/api/notifications?limit=9999")
     assert resp2.status_code == 400
+
+
+# GET /api/notifications — tenant isolation (#137)
+# ---------------------------------------------------------------------------
+
+def test_notifications_api_scoped_to_active_project(notifications_storage):
+    """Active project sees only its own notifications, not another project's."""
+    from app.app import create_app
+    from app.metrics_storage import save_notification
+    from flask import g
+
+    save_notification(event_type="anomaly", message="mine",
+                      status="sent", table_name="t", project_id="proj-a")
+    save_notification(event_type="anomaly", message="theirs",
+                      status="sent", table_name="t", project_id="proj-b")
+
+    scoped_app = create_app({"TESTING": True})
+
+    @scoped_app.before_request
+    def _inject_project():
+        g.current_project = {"id": "proj-a"}
+
+    with scoped_app.test_client() as c:
+        body = c.get("/api/notifications").get_json()
+
+    assert body["total"] == 1
+    assert body["items"][0]["message"] == "mine"
+
+
+def test_notifications_api_no_project_user_sees_empty(client, notifications_storage):
+    """Authenticated user with no project gets an empty notifications list."""
+    from unittest.mock import MagicMock, patch
+
+    from app.metrics_storage import save_notification
+
+    save_notification(event_type="anomaly", message="legacy msg",
+                      status="sent", table_name="t", project_id="legacy")
+
+    mock_user = MagicMock()
+    mock_user.is_authenticated = True
+
+    with patch("app.api.current_user", mock_user):
+        body = client.get("/api/notifications").get_json()
+
+    assert body["total"] == 0
+    assert body["items"] == []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -219,9 +219,10 @@ def test_notifications_invalid_limit(client):
 
 def test_notifications_api_scoped_to_active_project(notifications_storage):
     """Active project sees only its own notifications, not another project's."""
+    from flask import g
+
     from app.app import create_app
     from app.metrics_storage import save_notification
-    from flask import g
 
     save_notification(event_type="anomaly", message="mine",
                       status="sent", table_name="t", project_id="proj-a")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -359,9 +359,9 @@ def logged_in_no_project_client(tmp_path, monkeypatch):
             "confirm": "supersecret1",
         })
         from app.metrics_storage import (
+            delete_project,
             get_user_by_email,
             list_projects_for_user,
-            delete_project,
         )
         user = get_user_by_email("noproj@example.com")
         for p in list_projects_for_user(user["id"]):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -333,3 +333,114 @@ def test_schema_view_survives_list_tables_exception(client):
          patch("app.dashboard.get_latest_metric", return_value=None):
         resp = client.get("/dashboard/schema")
     assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# #137 — no-project guards: authenticated user with zero projects
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def logged_in_no_project_client(tmp_path, monkeypatch):
+    """Client logged in as a user who has NO projects (simulates deleted-project state)."""
+    db_path = tmp_path / "monitor.db"
+    import app.metrics_storage as storage
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    app = create_app({"TESTING": True, "WTF_CSRF_ENABLED": False})
+    with app.test_client() as c:
+        # Register + immediately delete the auto-created default project so the
+        # user is left authenticated but with zero projects.
+        c.post("/auth/register", data={
+            "email": "noproj@example.com",
+            "password": "supersecret1",
+            "confirm": "supersecret1",
+        })
+        from app.metrics_storage import (
+            get_user_by_email,
+            list_projects_for_user,
+            delete_project,
+        )
+        user = get_user_by_email("noproj@example.com")
+        for p in list_projects_for_user(user["id"]):
+            delete_project(user["id"], p["id"])
+        yield c
+
+
+def test_overview_no_project_skips_list_tables(logged_in_no_project_client):
+    """overview() must not call db.list_tables() when the user has no projects."""
+    with patch("app.dashboard.db.list_tables") as mock_list, \
+         patch("app.dashboard._ml_last_runs") as mock_ml:
+        resp = logged_in_no_project_client.get("/dashboard")
+    assert resp.status_code == 200
+    mock_list.assert_not_called()
+    mock_ml.assert_not_called()
+    body = resp.get_data(as_text=True)
+    assert "Создать проект" in body
+
+
+def test_schema_no_project_skips_list_tables(logged_in_no_project_client):
+    """schema_view() must not call db.list_tables() when user has no projects."""
+    with patch("app.dashboard.db.list_tables") as mock_list:
+        resp = logged_in_no_project_client.get("/dashboard/schema")
+    assert resp.status_code == 200
+    mock_list.assert_not_called()
+    body = resp.get_data(as_text=True)
+    assert "Создать проект" in body
+
+
+def test_history_no_project_redirects_to_new_project(logged_in_no_project_client):
+    """history_view() redirects to /projects/new when user has no projects."""
+    resp = logged_in_no_project_client.get("/dashboard/history", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/projects/new" in resp.headers["Location"]
+
+
+def test_notifications_no_project_shows_empty(logged_in_no_project_client):
+    """notifications_view() shows empty list (not legacy data) when user has no projects."""
+    from app.metrics_storage import save_notification
+    # Write a notification with legacy project_id — must NOT appear.
+    save_notification(event_type="anomaly", message="LEGACY_MARKER",
+                      status="sent", project_id="legacy")
+
+    resp = logged_in_no_project_client.get("/dashboard/notifications")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "LEGACY_MARKER" not in body
+    assert "Нет уведомлений" in body
+
+
+def test_delete_project_cascades_notifications(tmp_path, monkeypatch):
+    """delete_project() removes the project's notifications but not other projects'."""
+    import app.metrics_storage as storage
+    db_path = tmp_path / "cascade.db"
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    from app.metrics_storage import (
+        create_project,
+        create_user,
+        delete_project,
+        get_notifications,
+        save_notification,
+    )
+
+    # Projects require an existing user row (FK on user_id).
+    user = create_user("user-cascade-id", "user-cascade@example.com", "hash")
+    proj_a = create_project("proj-a", user["id"], "A", "proj-a")
+    proj_b = create_project("proj-b", user["id"], "B", "proj-b")
+
+    save_notification(event_type="anomaly", message="A_MSG",
+                      status="sent", project_id=proj_a["id"])
+    save_notification(event_type="anomaly", message="B_MSG",
+                      status="sent", project_id=proj_b["id"])
+
+    delete_project(user["id"], proj_a["id"])
+
+    remaining = get_notifications()
+    messages = [n["message"] for n in remaining]
+    assert "A_MSG" not in messages
+    assert "B_MSG" in messages


### PR DESCRIPTION
## Описание

Аутентифицированный пользователь без проектов видел на дашборде таблицы, строки и ML-результаты из глобального `DATABASE_URL` вместо онбординг-баннера.

**Корень проблемы:** `needs_first_connection = project is not None and not has_connections` давал `False` при `project=None`, поэтому `db.list_tables()` и `_ml_last_runs()` вызывались даже для пользователей без единого проекта.

## Тип изменения

- [x] Bug fix

## Что изменено

### `app/dashboard.py`
- `_NO_PROJECT_ID = "__no_project__"` — sentinel для фильтра уведомлений, даёт пустой результат без дополнительной ветки в query-builder
- `_onboarding_redirect()` — хелпер, возвращает redirect на `/projects/new` когда пользователь аутентифицирован и `g.current_project is None`
- `overview()` / `schema_view()`: добавлен флаг `needs_first_project`; `skip_tables = needs_first_project OR needs_first_connection` — `db.list_tables()` и `_ml_last_runs()` не вызываются ни в одном из этих случаев; `ml_last_runs={}` при `skip_tables=True` → ML-секция показывает "—" вместо глобальных таймстемпов
- `history_view()`: `_onboarding_redirect()` в начале вместо пустой истории из глобальных данных
- `table_detail()`: `abort(404)` для аутентифицированных пользователей без проектов; анонимный/legacy путь сохранён
- `notifications_view()`: `_NO_PROJECT_ID` sentinel → пустой список без утечки чужих уведомлений

### `app/metrics_storage.py`
- `_migrate_existing_schema()`: убрано раннее `return`; каждая таблица (`metrics`, `notifications`) проверяется независимо. Добавлена миграция `notifications.project_id` + индекс `idx_notifications_project_ts`
- `save_notification()`: новый параметр `project_id: str = "legacy"`
- `get_notifications()`, `count_notifications()`: фильтр по `project_id`
- `delete_project()`: каскадное удаление `notifications` в одной транзакции; ownership проверяется через `WHERE user_id` — `notifications` удаляются только если проект действительно наш (SQLite не поддерживает FK cascade через ALTER)

### `scripts/metrics_schema.sql`, `scripts/timescale_schema.sql`
- `project_id TEXT NOT NULL DEFAULT 'legacy'` и индекс в `CREATE TABLE notifications` для новых инсталляций

### `templates/overview.html`, `templates/schema.html`
- Баннер "Нет проектов" с CTA "Создать проект →" перед существующим баннером "Нет подключений"
- ML-секция скрыта при `needs_first_project`; при `needs_first_connection` показывается с "—" в колонке "Последний запуск"

### `tests/test_dashboard.py`
- Фикстура `logged_in_no_project_client`
- 5 новых тестов: overview/schema пропускают `db.list_tables()`, history редиректит, notifications пуст, delete_project каскадно удаляет только свои уведомления

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально (492 теста, без e2e/playwright)
- [x] Если изменена схема БД — обновлены `scripts/metrics_schema.sql` и `scripts/timescale_schema.sql`

## Связанные issues

- Closes #137
- Создан #145 — cascade deletion metrics при удалении проекта (out of scope)
- Создан #146 — anomaly_scores / changepoints / drift_reports не скоупированы по project_id (pre-existing, history shows global anomaly data)
- Создан #147 — дашборд использует глобальный DATABASE_URL вместо DSN проекта (pre-existing, обнаружен в процессе тестирования)