### PR TITLE
fix(#138): демо-скрипты не передавали project_id в multi-tenant хранилище

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-IMAGE ?= db-monitoring
-PORT  ?= 5001
+IMAGE         ?= db-monitoring
+PORT          ?= 5001
+PROJECT_ID    ?= legacy
+CONNECTION_ID ?=
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg demo-ids
 
 build:
 	docker build -t $(IMAGE) .
@@ -13,7 +15,8 @@ reset-db:
 	docker compose run --rm --build app python -m scripts.reset_db
 
 reset-metrics:
-	docker compose run --rm --build app python -m scripts.seed_metrics_db --reset
+	docker compose run --rm --build app python -m scripts.seed_metrics_db \
+		--reset --project-id $(PROJECT_ID)
 	$(MAKE) warmup-ml
 
 warmup-ml:
@@ -53,12 +56,28 @@ test:
 test-integration:
 	pytest -m integration -v $(ARGS)
 
-# Live demo pipeline (#75) — stream synthetic events into the target Postgres
+# Live demo pipeline (#75/#138) — stream synthetic events into the target Postgres
 # and run collector + ML on every tick so the dashboard updates in real time.
 # Requires the target Postgres running (`make db-up`) and the app on :5001
 # (`make server`).
+# For project-scoped demo: make live-demo PROJECT_ID=<id> CONNECTION_ID=<id>
+# Get IDs via: make demo-ids
 live-demo:
-	python -m scripts.live_demo $(ARGS)
+	python -m scripts.live_demo \
+		--project-id $(PROJECT_ID) \
+		$(if $(CONNECTION_ID),--connection-id $(CONNECTION_ID),) \
+		$(ARGS)
+
+# Print PROJECT_ID and CONNECTION_ID for the demo account (demo@dbmonitor.app).
+demo-ids:
+	docker compose run --rm app python -c "\
+from app.metrics_storage import get_user_by_email, list_projects_for_user, list_connections_for_project; \
+user = get_user_by_email('demo@dbmonitor.app'); \
+project = list_projects_for_user(user['id'])[0]; \
+conns = list_connections_for_project(project['id']); \
+print(f'PROJECT_ID={project[\"id\"]}'); \
+print(f'CONNECTION_ID={conns[0][\"id\"]}') \
+"
 
 # E2E dashboard tests (#45) — Playwright + headless Chromium against the live
 # Flask app. One-time setup: `playwright install chromium`.

--- a/scripts/live_demo.py
+++ b/scripts/live_demo.py
@@ -108,19 +108,24 @@ def _insert_batch(engine, rows: list[dict]) -> None:
         conn.execute(_INSERT_SQL, rows)
 
 
-def _run_collector_tick() -> int:
+def _run_collector_tick(project_id: str, connection_id: str | None) -> int:
     """Re-import inside the tick so each call sees the latest module state.
 
     Returns the row_count metric stored for `events` after collection — gives
     a printable per-tick progress signal without an extra DB round-trip.
     """
-    from collectors.scheduler import collect_all_tables
-
-    collect_all_tables()
+    if connection_id:
+        from collectors.per_project import collect_for_connection
+        collect_for_connection(project_id, connection_id)
+        metric_project_id = project_id
+    else:
+        from collectors.scheduler import collect_all_tables
+        collect_all_tables()
+        # Global collector writes to 'legacy' regardless of project_id arg.
+        metric_project_id = "legacy"
 
     from app.metrics_storage import get_latest_metric
-    # #53: live_demo runs against the global collector → 'legacy' tenant.
-    latest = get_latest_metric("events", "row_count", "legacy")
+    latest = get_latest_metric("events", "row_count", metric_project_id)
     return int(latest["value"]) if latest else 0
 
 
@@ -168,7 +173,25 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true",
                         help="Print plan and exit without touching the DB.")
     parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument(
+        "--project-id", default="legacy",
+        help="project_id демо-проекта для записи метрик (default: legacy).",
+    )
+    parser.add_argument(
+        "--connection-id", default=None,
+        help=(
+            "connection_id подключения к Postgres. Обязателен когда "
+            "--project-id != legacy; при отсутствии используется "
+            "глобальный коллектор (пишет в legacy)."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.project_id != "legacy" and args.connection_id is None:
+        parser.error(
+            "--connection-id обязателен когда --project-id != legacy. "
+            "Получи его через: make demo-ids"
+        )
 
     _setup_logging(args.verbose)
     _install_sigint_handler()
@@ -205,7 +228,7 @@ def main() -> None:
         rows = [_generate_event_row(user_ids, is_incident) for _ in range(n_rows)]
         _insert_batch(engine, rows)
 
-        stored_row_count = _run_collector_tick()
+        stored_row_count = _run_collector_tick(args.project_id, args.connection_id)
         cp_summary = ""
         if args.changepoints:
             cp = _run_changepoint_pass()

--- a/scripts/seed_metrics_db.py
+++ b/scripts/seed_metrics_db.py
@@ -631,7 +631,7 @@ NOTIFICATION_PROFILES: tuple[NotificationProfile, ...] = (
 )
 
 
-def _generate_notifications(end: datetime, days: int) -> int:
+def _generate_notifications(end: datetime, days: int, project_id: str = "legacy") -> int:
     """Запись синтетических Telegram-уведомлений в `notifications`.
     Возвращает количество созданных строк.
 
@@ -653,6 +653,7 @@ def _generate_notifications(end: datetime, days: int) -> int:
             error=p.error,
             chat_id="seed",
             ts=ts,
+            project_id=project_id,
         )
         saved += 1
     return saved
@@ -682,17 +683,41 @@ def _generate_schema_events(
     return rows
 
 
-def _purge_existing() -> int:
-    """Очистить таблицу metrics и все производные от неё (anomaly_scores,
-    changepoints, drift_reports). Их ts ссылаются на ts метрик — после
-    reset они становятся осиротевшими и засоряют дашборд (см. issue с
-    badge ≠ точкам на графике, когда часть anomaly_scores не матчится
-    со свежими метриками)."""
+def _purge_existing(project_id: str = "legacy") -> int:
+    """Очистить metrics и производные таблицы перед ресидом.
+
+    При project_id != "legacy" таблицы с project_id-колонкой (metrics,
+    notifications) чистятся scoped; остальные (anomaly_scores, changepoints,
+    drift_reports, schema_events, schema_snapshots) — глобально, потому что
+    project_id-скоупинга в них ещё нет (#146).
+    """
+    # Таблицы с project_id — scoped при non-legacy reset.
+    _SCOPED = {"metrics", "notifications"}
+    # Таблицы без project_id — всегда глобальный DELETE.
+    _GLOBAL = [t for t in _PURGE_TABLES if t not in _SCOPED]
+
     deleted = 0
     with get_monitor_engine().begin() as conn:
-        for table_name in _PURGE_TABLES:
-            result = conn.execute(text(f"DELETE FROM {table_name}"))
-            deleted += result.rowcount or 0
+        if project_id != "legacy":
+            for table_name in _SCOPED:
+                result = conn.execute(
+                    text(f"DELETE FROM {table_name} WHERE project_id = :pid"),
+                    {"pid": project_id},
+                )
+                deleted += result.rowcount or 0
+            if _GLOBAL:
+                logger.warning(
+                    "--reset с project_id=%s: таблицы %s очищены глобально — "
+                    "project_id-скоупинг для них будет в отдельной задаче (#146)",
+                    project_id, ", ".join(_GLOBAL),
+                )
+            for table_name in _GLOBAL:
+                result = conn.execute(text(f"DELETE FROM {table_name}"))
+                deleted += result.rowcount or 0
+        else:
+            for table_name in _PURGE_TABLES:
+                result = conn.execute(text(f"DELETE FROM {table_name}"))
+                deleted += result.rowcount or 0
     return deleted
 
 
@@ -702,6 +727,7 @@ def main(
     reset: bool = False,
     seed: int = 42,
     schema: str | None = None,
+    project_id: str = "legacy",
 ) -> dict:
     rng = random.Random(seed)
     end = datetime.now(UTC).replace(second=0, microsecond=0)
@@ -711,7 +737,7 @@ def main(
         logger.warning("В target DB не найдено таблиц — сидить нечего")
         return {"snapshots": 0, "rows": 0, "deleted": 0, "ticks": 0}
 
-    deleted = _purge_existing() if reset else 0
+    deleted = _purge_existing(project_id) if reset else 0
 
     timestamps = _build_timestamps(end, days, interval_minutes)
     all_rows: list[dict] = []
@@ -721,11 +747,10 @@ def main(
         all_rows.extend(_generate_distribution_rows(snap, days, end))
         schema_event_rows.extend(_generate_schema_events(snap, days, end))
 
-    # #53: seeder writes to the 'legacy' tenant — same bucket the global
-    # collector uses, and where existing rows get backfilled by the migration.
-    saved = save_metrics(all_rows, "legacy")
+    # #138: project_id passed via CLI; default is 'legacy' for backwards compat.
+    saved = save_metrics(all_rows, project_id)
     schema_events_saved = save_schema_events(schema_event_rows) if schema_event_rows else 0
-    notifications_saved = _generate_notifications(end, days)
+    notifications_saved = _generate_notifications(end, days, project_id)
     print(
         f"Засеяно {saved} строк метрик по {len(snapshots)} таблицам "
         f"({len(timestamps)} тиков, {days} дн.), "
@@ -751,9 +776,17 @@ if __name__ == "__main__":
     parser.add_argument("--interval-minutes", type=int, default=60)
     parser.add_argument(
         "--reset", action="store_true",
-        help="Удалить все существующие строки metrics перед сидом",
+        help=(
+            "Удалить существующие данные перед сидом. При --project-id != legacy "
+            "metrics/notifications чистятся scoped; остальные таблицы — глобально."
+        ),
     )
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--project-id", default="legacy",
+        help="project_id для записи метрик и уведомлений (default: legacy)",
+    )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
-    main(args.days, args.interval_minutes, reset=args.reset, seed=args.seed)
+    main(args.days, args.interval_minutes, reset=args.reset, seed=args.seed,
+         project_id=args.project_id)

--- a/tests/test_live_demo.py
+++ b/tests/test_live_demo.py
@@ -1,0 +1,66 @@
+"""Tests for live_demo._run_collector_tick tenant scoping (#138)."""
+from unittest.mock import patch
+
+
+def test_run_collector_tick_with_connection_calls_per_project():
+    """_run_collector_tick с connection_id вызывает collect_for_connection."""
+    mock_latest = {"value": 42.0}
+    with (
+        patch("collectors.per_project.collect_for_connection") as mock_collect,
+        patch("app.metrics_storage.get_latest_metric", return_value=mock_latest),
+    ):
+        from scripts.live_demo import _run_collector_tick
+        result = _run_collector_tick("proj-a", "conn-a")
+
+    mock_collect.assert_called_once_with("proj-a", "conn-a")
+    assert result == 42
+
+
+def test_run_collector_tick_with_connection_reads_from_project():
+    """_run_collector_tick с connection_id читает метрику из project_id, не из legacy."""
+    with (
+        patch("collectors.per_project.collect_for_connection"),
+        patch("app.metrics_storage.get_latest_metric", return_value=None) as mock_get,
+    ):
+        from scripts.live_demo import _run_collector_tick
+        _run_collector_tick("proj-a", "conn-a")
+
+    args = mock_get.call_args
+    assert args[0][2] == "proj-a", "должен читать метрику из proj-a, не из legacy"
+
+
+def test_run_collector_tick_no_connection_uses_global_collector():
+    """_run_collector_tick без connection_id использует глобальный collect_all_tables."""
+    with (
+        patch("collectors.scheduler.collect_all_tables") as mock_collect,
+        patch("app.metrics_storage.get_latest_metric", return_value=None),
+    ):
+        from scripts.live_demo import _run_collector_tick
+        _run_collector_tick("legacy", None)
+
+    mock_collect.assert_called_once()
+
+
+def test_run_collector_tick_no_connection_reads_from_legacy():
+    """_run_collector_tick без connection_id читает метрику из 'legacy', не из project_id."""
+    with (
+        patch("collectors.scheduler.collect_all_tables"),
+        patch("app.metrics_storage.get_latest_metric", return_value=None) as mock_get,
+    ):
+        from scripts.live_demo import _run_collector_tick
+        _run_collector_tick("some-project", None)
+
+    args = mock_get.call_args
+    assert args[0][2] == "legacy", "без connection_id collector пишет в legacy"
+
+
+def test_live_demo_cli_requires_connection_id_for_non_legacy():
+    """--project-id != legacy без --connection-id завершается с ошибкой."""
+    import subprocess
+    result = subprocess.run(
+        ["python", "-m", "scripts.live_demo",
+         "--project-id", "proj-x", "--dry-run"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "connection-id" in result.stderr.lower()

--- a/tests/test_seed_metrics_db.py
+++ b/tests/test_seed_metrics_db.py
@@ -27,6 +27,7 @@ from scripts.seed_metrics_db import (
     _drift_factor,
     _generate_distribution_rows,
     _generate_metric_rows,
+    _generate_notifications,
     _generate_schema_events,
     _null_rate_at,
     _numeric_buckets,
@@ -604,6 +605,90 @@ def test_main_no_tables_returns_zero(monitor_storage, monkeypatch):
     assert main(days=1, interval_minutes=60) == {
         "snapshots": 0, "rows": 0, "deleted": 0, "ticks": 0,
     }
+
+
+# --- #138: project_id scoping ---
+
+def test_main_writes_metrics_with_project_id(monitor_storage, stub_target):
+    """main(..., project_id='proj-a') сохраняет метрики с project_id='proj-a'."""
+    stub_target({"users": {"row_count": 100, "size_bytes": 10_000, "columns": []}})
+
+    main(days=1, interval_minutes=60, project_id="proj-a")
+
+    with monitor_storage.get_engine().connect() as conn:
+        n = conn.execute(
+            text("SELECT COUNT(*) FROM metrics WHERE project_id = 'proj-a'")
+        ).scalar()
+    assert n > 0
+
+
+def test_generate_notifications_uses_project_id(monitor_storage):
+    """_generate_notifications(..., project_id='proj-a') пишет только proj-a."""
+    end = datetime.now(UTC)
+    _generate_notifications(end, days=1, project_id="proj-a")
+
+    with monitor_storage.get_engine().connect() as conn:
+        proj_a = conn.execute(
+            text("SELECT COUNT(*) FROM notifications WHERE project_id = 'proj-a'")
+        ).scalar()
+        legacy = conn.execute(
+            text("SELECT COUNT(*) FROM notifications WHERE project_id = 'legacy'")
+        ).scalar()
+    assert proj_a > 0
+    assert legacy == 0
+
+
+def test_reset_scoped_leaves_other_project_metrics(monitor_storage, stub_target):
+    """--reset с project_id='proj-a' удаляет только proj-a из metrics/notifications,
+    не трогая proj-b."""
+    now = datetime.now(UTC)
+    monitor_storage.save_metrics([{
+        "ts": now, "table_name": "t", "metric_name": "row_count", "value": 1,
+    }], "proj-a")
+    monitor_storage.save_metrics([{
+        "ts": now, "table_name": "t", "metric_name": "row_count", "value": 2,
+    }], "proj-b")
+    monitor_storage.save_notification(
+        event_type="anomaly", message="a", status="sent",
+        table_name="t", project_id="proj-a",
+    )
+    monitor_storage.save_notification(
+        event_type="anomaly", message="b", status="sent",
+        table_name="t", project_id="proj-b",
+    )
+
+    stub_target({"users": {"row_count": 100, "size_bytes": 10_000, "columns": []}})
+    main(days=1, interval_minutes=60, reset=True, project_id="proj-a")
+
+    with monitor_storage.get_engine().connect() as conn:
+        a_metrics = conn.execute(
+            text("SELECT COUNT(*) FROM metrics WHERE project_id = 'proj-a'")
+        ).scalar()
+        b_metrics = conn.execute(
+            text("SELECT COUNT(*) FROM metrics WHERE project_id = 'proj-b'")
+        ).scalar()
+        a_notif = conn.execute(
+            text("SELECT COUNT(*) FROM notifications WHERE project_id = 'proj-a' AND message = 'a'")
+        ).scalar()
+        b_notif = conn.execute(
+            text("SELECT COUNT(*) FROM notifications WHERE project_id = 'proj-b'")
+        ).scalar()
+    # proj-a стёрт (reset), новые метрики записаны под proj-a
+    assert b_metrics == 1, "proj-b metrics must survive reset of proj-a"
+    assert b_notif == 1, "proj-b notifications must survive reset of proj-a"
+    # proj-a прежние данные удалены, новые записаны
+    assert a_metrics > 0, "new proj-a metrics must be written after reset"
+    assert a_notif == 0, "old proj-a notification must be deleted by reset"
+
+
+def test_seed_cli_help_contains_project_id():
+    """--help содержит --project-id."""
+    import subprocess
+    result = subprocess.run(
+        ["python", "-m", "scripts.seed_metrics_db", "--help"],
+        capture_output=True, text=True,
+    )
+    assert "--project-id" in result.stdout
 
 
 # --- per-table profiles ---


### PR DESCRIPTION
## Описание

`seed_metrics_db.py` писал все метрики и уведомления в `project_id='legacy'`. `live_demo.py` вызывал глобальный `collect_all_tables()`. Пользователь с реальным проектом видел пустой дашборд после `make reset-metrics` и `make live-demo`.

## Тип изменения

- [x] Bug fix

## Что изменено

### `scripts/seed_metrics_db.py`
- `main()` принимает `project_id: str = "legacy"` (default — backward compat)
- `save_metrics(all_rows, project_id)` вместо хардкода `'legacy'`
- `_generate_notifications()` пробрасывает `project_id` в `save_notification()`
- `_purge_existing(project_id)`: при `project_id != "legacy"` — scoped DELETE для `metrics` и `notifications`; остальные таблицы (`anomaly_scores`, `changepoints`, `drift_reports`, `schema_events`, `schema_snapshots`) чистятся глобально + WARNING в лог (#146)
- `--project-id` CLI аргумент, default=`"legacy"`

### `scripts/live_demo.py`
- `--project-id` (default=`"legacy"`) и `--connection-id` (default=`None`) CLI args
- Валидация: `project_id != "legacy"` без `connection_id` → `parser.error` с подсказкой `make demo-ids`
- `_run_collector_tick(project_id, connection_id)`: при `connection_id` вызывает `collect_for_connection(project_id, connection_id)` и читает метрику из `project_id`; без `connection_id` — fallback на `collect_all_tables()` + читает из `'legacy'`

### `Makefile`
- `PROJECT_ID ?= legacy`, `CONNECTION_ID ?=` — переменные с backward-compat дефолтами
- `reset-metrics`: передаёт `--project-id $(PROJECT_ID)`
- `live-demo`: передаёт `--project-id` + `--connection-id` если задан
- `demo-ids`: новая цель — печатает `PROJECT_ID` и `CONNECTION_ID` для `demo@dbmonitor.app`

## Чеклист

- [x] Тесты написаны / обновлены (112 passed)
- [x] `pytest` проходит локально
- [x] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы

## Связанные issues

- Closes #138
- #146 — anomaly_scores/changepoints/drift_reports без project_id (out of scope, задокументировано в коде)