### PR TITLE
feat(#143): Per-project Telegram уведомления

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ models/*
 coverage.xml
 htmlcov/
 tests/e2e/_artifacts/
+.env.local

--- a/app/app.py
+++ b/app/app.py
@@ -16,6 +16,7 @@ from .health import build_health_payload
 from .projects import bp as projects_bp
 from .projects import load_current_project_into_g
 from .security import init_logging_filter
+from .settings import bp as settings_bp
 
 _ISO_TS_RE = re.compile(
     r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})"
@@ -126,6 +127,7 @@ def create_app(config: dict | None = None):
     app.register_blueprint(dashboard_bp)
     app.register_blueprint(projects_bp)
     app.register_blueprint(connections_bp)
+    app.register_blueprint(settings_bp)
 
     # Gate the HTML surface (dashboard + admin + projects) behind login.
     # Done as an app-level before_request with path-based dispatch (not a

--- a/app/crypto.py
+++ b/app/crypto.py
@@ -106,6 +106,24 @@ def decrypt_dsn(ciphertext: bytes) -> str:
     return _get_fernet().decrypt(ciphertext).decode("utf-8")
 
 
+# Telegram bot tokens (#143) — encrypted with the same Fernet key as DSNs.
+# Separate functions for readability at call sites; same wire format so a
+# future key-rotation tool can re-encrypt everything in one sweep.
+
+def encrypt_token(plain: str) -> bytes:
+    """Encrypt a Telegram bot token (or any secret string)."""
+    if not plain:
+        raise ValueError("Cannot encrypt empty token")
+    return _get_fernet().encrypt(plain.encode("utf-8"))
+
+
+def decrypt_token(ciphertext: bytes) -> str:
+    """Decrypt a Telegram bot token previously stored via ``encrypt_token``."""
+    if not ciphertext:
+        raise ValueError("Cannot decrypt empty ciphertext")
+    return _get_fernet().decrypt(ciphertext).decode("utf-8")
+
+
 def reset_for_tests() -> None:
     """Drop the cached Fernet so tests can swap keys per-test via env."""
     global _fernet
@@ -117,6 +135,8 @@ __all__ = [
     "FernetKeyMissing",
     "InvalidToken",
     "decrypt_dsn",
+    "decrypt_token",
     "encrypt_dsn",
+    "encrypt_token",
     "reset_for_tests",
 ]

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -168,6 +168,21 @@ def _migrate_existing_schema(engine: Engine) -> None:
             "notifications.project_id added (existing rows backfilled to 'legacy')"
         )
 
+    # #143: telegram_throttle gets project_id in the primary key. The table
+    # is an ephemeral cache (throttle window is typically tens of minutes),
+    # so we don't try to do a careful in-place ALTER PRIMARY KEY (which
+    # SQLite doesn't even support). Drop + let the schema file recreate it
+    # with the new structure. Side effect: throttle cache is reset once
+    # (existing throttle rows are discarded — at most one extra notification
+    # per (table, event_key) may fire right after deploy).
+    if _table_exists(engine, "telegram_throttle") and "project_id" not in _existing_columns(engine, "telegram_throttle"):
+        with engine.begin() as conn:
+            conn.execute(text("DROP TABLE telegram_throttle"))
+        logger.info(
+            "telegram_throttle dropped for multi-tenant migration "
+            "(throttle cache reset; recreated below with project_id in PK)"
+        )
+
 
 def _is_optional_timescale_stmt(stmt: str) -> bool:
     normalized = " ".join(stmt.lower().split())
@@ -1007,16 +1022,28 @@ def get_history_insights(agg: dict) -> list[str]:
     return insights[:4]
 
 
-# --- Telegram notification throttle (#38) ---
+# --- Telegram notification throttle (#38 → #143 multi-tenant) ---
 
-def is_throttled(table: str, event_key: str) -> bool:
-    """Return True if a notification for (table, event_key) was sent within the throttle window."""
+def is_throttled(
+    project_id: str, table: str, event_key: str,
+    *, throttle_minutes: int | None = None,
+) -> bool:
+    """Return True if a notification for this (project, table, event_key)
+    was sent within the throttle window.
+
+    ``throttle_minutes`` should come from the project's own configuration
+    (``project_notifications.throttle_minutes``). Falls back to the global
+    ``settings.TELEGRAM_THROTTLE_MINUTES`` only for the ``'legacy'`` tenant
+    where there's no per-project row by definition.
+    """
     stmt = text("""
         SELECT last_sent_at FROM telegram_throttle
-        WHERE table_name = :table AND event_key = :key
+        WHERE project_id = :pid AND table_name = :table AND event_key = :key
     """)
     with get_engine().connect() as conn:
-        row = conn.execute(stmt, {"table": table, "key": event_key}).fetchone()
+        row = conn.execute(stmt, {
+            "pid": project_id, "table": table, "key": event_key,
+        }).fetchone()
     if not row:
         return False
     raw = row[0]
@@ -1026,23 +1053,93 @@ def is_throttled(table: str, event_key: str) -> bool:
         last_sent = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
         if last_sent.tzinfo is None:
             last_sent = last_sent.replace(tzinfo=UTC)
+    window_minutes = (
+        throttle_minutes
+        if throttle_minutes is not None
+        else settings.TELEGRAM_THROTTLE_MINUTES
+    )
     age = datetime.now(UTC) - last_sent
-    return age.total_seconds() < settings.TELEGRAM_THROTTLE_MINUTES * 60
+    return age.total_seconds() < window_minutes * 60
 
 
-def update_throttle(table: str, event_key: str) -> None:
-    """Record that a notification for (table, event_key) was just sent."""
+def update_throttle(project_id: str, table: str, event_key: str) -> None:
+    """Record that a notification for (project, table, event_key) was just sent."""
     stmt = text(_upsert_sql(
         "telegram_throttle",
-        ["table_name", "event_key", "last_sent_at"],
-        conflict_columns=["table_name", "event_key"],
+        ["project_id", "table_name", "event_key", "last_sent_at"],
+        conflict_columns=["project_id", "table_name", "event_key"],
     ))
     with get_engine().begin() as conn:
         conn.execute(stmt, {
+            "project_id": project_id,
             "table_name": table,
             "event_key": event_key,
             "last_sent_at": _iso(datetime.now(UTC)),
         })
+
+
+# --- Per-project Telegram configuration (#143) ---
+
+def get_project_notifications(project_id: str) -> dict | None:
+    """Return Telegram config for a project, or None if no row exists.
+
+    Returned dict has raw ``telegram_bot_token`` bytes (Fernet ciphertext);
+    callers must decrypt via ``app.crypto.decrypt_bytes`` before use.
+    """
+    stmt = text("""
+        SELECT project_id, telegram_bot_token, telegram_chat_id,
+               throttle_minutes, updated_at
+        FROM project_notifications
+        WHERE project_id = :pid
+    """)
+    with get_engine().connect() as conn:
+        row = conn.execute(stmt, {"pid": project_id}).fetchone()
+    if row is None:
+        return None
+    return {
+        "project_id": row[0],
+        "telegram_bot_token": row[1],
+        "telegram_chat_id": row[2],
+        "throttle_minutes": int(row[3]),
+        "updated_at": str(row[4]) if row[4] else None,
+    }
+
+
+def save_project_notifications(
+    project_id: str,
+    *,
+    telegram_bot_token: bytes | None,
+    telegram_chat_id: str | None,
+    throttle_minutes: int = 30,
+) -> None:
+    """UPSERT a project's Telegram configuration.
+
+    ``telegram_bot_token`` is the ciphertext from ``app.crypto.encrypt_bytes``
+    (caller responsibility — this function does NOT encrypt). ``None`` for
+    either token or chat_id means "partially configured" — no notification
+    will be sent until both are set.
+    """
+    stmt = text(_upsert_sql(
+        "project_notifications",
+        ["project_id", "telegram_bot_token", "telegram_chat_id",
+         "throttle_minutes", "updated_at"],
+        conflict_columns=["project_id"],
+    ))
+    with get_engine().begin() as conn:
+        conn.execute(stmt, {
+            "project_id": project_id,
+            "telegram_bot_token": telegram_bot_token,
+            "telegram_chat_id": telegram_chat_id,
+            "throttle_minutes": throttle_minutes,
+            "updated_at": _iso(datetime.now(UTC)),
+        })
+
+
+def delete_project_notifications(project_id: str) -> None:
+    """Wipe Telegram config for a project. Used by the «Отключить» button."""
+    stmt = text("DELETE FROM project_notifications WHERE project_id = :pid")
+    with get_engine().begin() as conn:
+        conn.execute(stmt, {"pid": project_id})
 
 
 # --- Notification history (#76) ---
@@ -1137,7 +1234,8 @@ def get_notifications(
         params["until"] = _iso(until)
 
     stmt = text(f"""
-        SELECT id, ts, event_type, table_name, metric_name, message, status, error, chat_id
+        SELECT id, ts, event_type, table_name, metric_name, message, status,
+               error, chat_id, project_id
         FROM notifications
         WHERE {' AND '.join(where)}
         ORDER BY ts DESC, id DESC
@@ -1156,6 +1254,7 @@ def get_notifications(
             "status": r[6],
             "error": r[7],
             "chat_id": r[8],
+            "project_id": r[9],
         }
         for r in rows
     ]

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -1,9 +1,18 @@
-"""Telegram Bot notifications for anomalies, schema drift, and change-points (#38).
+"""Telegram Bot notifications for anomalies, schema drift, and change-points
+(#38 → #143 multi-tenant).
+
+Per-tenant in #143: every notify_* function takes the project's Telegram
+configuration explicitly (``bot_token``, ``chat_id``, ``throttle_minutes``).
+Loading that config is the caller's job (collectors/scheduler.py loads it
+once per tick via ``metrics_storage.get_project_notifications``). This
+module deliberately does NOT read ``settings.TELEGRAM_*`` — there is no
+global fallback. If a tenant has not configured Telegram, notifications
+for that tenant are silently dropped, never routed to the admin's chat.
 
 Public entry points called from collectors/scheduler.py:
-  notify_anomaly(table, ts, score, metric="row_count")
-  notify_schema_drift(table, events)
-  notify_changepoint(table, metric, value_before, value_after, ts)
+  notify_anomaly(project_id, bot_token, chat_id, table, ts, score, ...)
+  notify_schema_drift(project_id, bot_token, chat_id, table, events, ...)
+  notify_changepoint(project_id, bot_token, chat_id, table, metric, ...)
 
 All functions are silent on errors — notification failures never propagate
 to the caller. Each delivery attempt (success or failure) is persisted via
@@ -16,14 +25,15 @@ import logging
 from telegram import Bot
 from telegram.error import TelegramError
 
-from app.config import settings
 from app.llm import explain_anomaly
 from app.metrics_storage import is_throttled, save_notification, update_throttle
 
 logger = logging.getLogger(__name__)
 
 
-def send_message(text: str) -> tuple[bool, str | None]:
+def send_message(
+    text: str, *, bot_token: str | None, chat_id: str | None,
+) -> tuple[bool, str | None]:
     """Send a plain-text message via Bot API.
 
     Returns (ok, error). When ok is False, error is a short reason string
@@ -31,14 +41,12 @@ def send_message(text: str) -> tuple[bool, str | None]:
     (False, "not_configured") if token/chat are not set — the call is still
     audited as a failed attempt by the caller.
     """
-    token = settings.TELEGRAM_BOT_TOKEN
-    chat_id = settings.TELEGRAM_CHAT_ID
-    if not token or not chat_id:
-        logger.debug("Telegram not configured, skipping")
+    if not bot_token or not chat_id:
+        logger.debug("Telegram not configured for this caller, skipping")
         return False, "not_configured"
 
     async def _send() -> None:
-        async with Bot(token) as bot:
+        async with Bot(bot_token) as bot:
             await bot.send_message(chat_id=chat_id, text=text)
 
     try:
@@ -54,10 +62,12 @@ def send_message(text: str) -> tuple[bool, str | None]:
 
 def _record(
     *,
+    project_id: str,
     event_type: str,
     message: str,
     ok: bool,
     error: str | None,
+    chat_id: str | None,
     table: str | None = None,
     metric: str | None = None,
 ) -> None:
@@ -70,7 +80,8 @@ def _record(
             table_name=table,
             metric_name=metric,
             error=error,
-            chat_id=settings.TELEGRAM_CHAT_ID or None,
+            chat_id=chat_id,
+            project_id=project_id,
         )
     except Exception as exc:  # pragma: no cover - storage failure shouldn't break alerts
         logger.warning("Failed to persist notification audit: %s", exc)
@@ -84,10 +95,20 @@ def _fmt_ts(ts: str) -> str:
     return ts.replace("T", " ")[:16] + " UTC"
 
 
-def notify_anomaly(table: str, ts: str, score: float, metric: str = "row_count") -> None:
-    """Send anomaly alert. Throttled per (table, event_key)."""
+def notify_anomaly(
+    project_id: str,
+    table: str,
+    ts: str,
+    score: float,
+    *,
+    bot_token: str | None,
+    chat_id: str | None,
+    throttle_minutes: int | None = None,
+    metric: str = "row_count",
+) -> None:
+    """Send anomaly alert. Throttled per (project, table, event_key)."""
     event_key = "anomaly"
-    if is_throttled(table, event_key):
+    if is_throttled(project_id, table, event_key, throttle_minutes=throttle_minutes):
         return
 
     result = explain_anomaly(table, metric, ts)
@@ -99,20 +120,29 @@ def notify_anomaly(table: str, ts: str, score: float, metric: str = "row_count")
         f"Обнаружена аномалия в таблице {table} по метрике {metric}"
         f" в момент {_fmt_ts(ts)}. {body}"
     )
-    ok, error = send_message(text)
-    _record(event_type="anomaly", message=text, ok=ok, error=error,
+    ok, error = send_message(text, bot_token=bot_token, chat_id=chat_id)
+    _record(project_id=project_id, event_type="anomaly", message=text,
+            ok=ok, error=error, chat_id=chat_id,
             table=table, metric=metric)
     if ok:
-        update_throttle(table, event_key)
+        update_throttle(project_id, table, event_key)
 
 
-def notify_schema_drift(table: str, events: list[dict]) -> None:
+def notify_schema_drift(
+    project_id: str,
+    table: str,
+    events: list[dict],
+    *,
+    bot_token: str | None,
+    chat_id: str | None,
+    throttle_minutes: int | None = None,
+) -> None:
     """Send schema-drift alert for a batch of events on one table."""
     if not events:
         return
 
     event_key = "schema_drift"
-    if is_throttled(table, event_key):
+    if is_throttled(project_id, table, event_key, throttle_minutes=throttle_minutes):
         return
 
     lines = []
@@ -129,22 +159,28 @@ def notify_schema_drift(table: str, events: list[dict]) -> None:
         lines.append(line)
 
     text = f"\U0001f4cb [{table}] Дрейф схемы:\n" + "\n".join(lines)
-    ok, error = send_message(text)
-    _record(event_type="schema_drift", message=text, ok=ok, error=error, table=table)
+    ok, error = send_message(text, bot_token=bot_token, chat_id=chat_id)
+    _record(project_id=project_id, event_type="schema_drift", message=text,
+            ok=ok, error=error, chat_id=chat_id, table=table)
     if ok:
-        update_throttle(table, event_key)
+        update_throttle(project_id, table, event_key)
 
 
 def notify_changepoint(
+    project_id: str,
     table: str,
     metric: str,
     value_before: float,
     value_after: float,
     ts: str,
+    *,
+    bot_token: str | None,
+    chat_id: str | None,
+    throttle_minutes: int | None = None,
 ) -> None:
     """Send change-point alert."""
     event_key = f"changepoint_{metric}"
-    if is_throttled(table, event_key):
+    if is_throttled(project_id, table, event_key, throttle_minutes=throttle_minutes):
         return
 
     if metric == "null_rate":
@@ -155,8 +191,9 @@ def notify_changepoint(
     text = (
         f"\U0001f4c8 [{table}] Change-point: {metric} {change_str} ({ts[:10]})"
     )
-    ok, error = send_message(text)
-    _record(event_type="changepoint", message=text, ok=ok, error=error,
+    ok, error = send_message(text, bot_token=bot_token, chat_id=chat_id)
+    _record(project_id=project_id, event_type="changepoint", message=text,
+            ok=ok, error=error, chat_id=chat_id,
             table=table, metric=metric)
     if ok:
-        update_throttle(table, event_key)
+        update_throttle(project_id, table, event_key)

--- a/app/security.py
+++ b/app/security.py
@@ -37,6 +37,18 @@ _DSN_IN_TEXT = re.compile(
     r"(?P<suffix>@)"
 )
 
+# Telegram bot token (#143). Format from BotFather: <bot_id>:<hash> where
+# bot_id is 8–12 digits and hash is exactly 35 chars from [A-Za-z0-9_-].
+# Spec is stable since 2015; we match conservatively with word boundaries
+# so substrings of unrelated hex blobs don't trigger.
+#
+# Why scrub these? Any caller can log "token=%s" with the plaintext bot
+# token at debug time; leaking the token lets anyone impersonate the bot
+# and exfiltrate notifications to attacker-controlled chats.
+_TELEGRAM_TOKEN_IN_TEXT = re.compile(
+    r"\b(?P<bot_id>\d{8,12}):(?P<hash>[A-Za-z0-9_\-]{35})\b"
+)
+
 
 def mask_dsn(url: str) -> str:
     """Return *url* with the password component replaced by ``***``.
@@ -78,10 +90,18 @@ def _scrub(value):
     closes the leak.
     """
     if isinstance(value, str):
-        return _DSN_IN_TEXT.sub(
+        scrubbed = _DSN_IN_TEXT.sub(
             lambda m: f"{m.group('prefix')}{_PASSWORD_PLACEHOLDER}{m.group('suffix')}",
             value,
         )
+        # Telegram bot token (#143). Keep the bot_id (it's effectively a
+        # public identifier — anyone in the chat can read it from the bot's
+        # profile), scrub only the secret hash half.
+        scrubbed = _TELEGRAM_TOKEN_IN_TEXT.sub(
+            lambda m: f"{m.group('bot_id')}:{_PASSWORD_PLACEHOLDER}",
+            scrubbed,
+        )
+        return scrubbed
     if isinstance(value, BaseException):
         return _scrub(str(value))
     if isinstance(value, tuple):

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,209 @@
+"""Per-project settings blueprint (#143).
+
+Currently houses one section — Telegram notifications — but the URL prefix
+``/projects/<slug>/settings/`` is laid out so future panels (general,
+danger zone, members) drop in without route migration.
+
+The blueprint is independent from ``app.projects`` to avoid bloating that
+module; ownership of the slug is still enforced via
+``projects._require_owned_project``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from flask import (
+    Blueprint,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_login import login_required
+from flask_wtf import FlaskForm
+from wtforms import IntegerField, StringField, SubmitField
+from wtforms.validators import (
+    DataRequired,
+    Length,
+    NumberRange,
+    Optional,
+    Regexp,
+)
+
+from app import crypto, metrics_storage
+from app.projects import _require_owned_project
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("settings", __name__, url_prefix="/projects/<slug>/settings")
+
+
+# Telegram bot token format from BotFather:
+#     <bot_id>:<hash>
+# bot_id is 8–12 digits; hash is exactly 35 chars from [A-Za-z0-9_-].
+_TELEGRAM_TOKEN_RE = re.compile(r"^\d{8,12}:[A-Za-z0-9_\-]{35}$")
+
+# chat_id can be: positive integer (personal chat), negative integer
+# (group), or negative integer starting with -100 (supergroup/channel).
+# Telegram has hit ~14-digit IDs at scale; allow a generous range.
+_CHAT_ID_RE = re.compile(r"^-?\d{1,16}$")
+
+
+class NotificationsForm(FlaskForm):
+    # Token is Optional() so the user can keep the existing one when only
+    # updating chat_id or throttle. Empty submission means "no change".
+    telegram_bot_token = StringField(
+        "Bot Token",
+        validators=[
+            Optional(),
+            Length(min=44, max=60),  # bot_id(8-12) + ':' + hash(35) = 44-48
+            Regexp(_TELEGRAM_TOKEN_RE,
+                   message="Формат токена: 1234567890:AAFx... (8–12 цифр, ':', "
+                           "35 символов)"),
+        ],
+        render_kw={
+            "type": "password",
+            "autocomplete": "off",
+            "placeholder": "1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        },
+    )
+    telegram_chat_id = StringField(
+        "Chat ID",
+        validators=[
+            DataRequired(),
+            Regexp(_CHAT_ID_RE,
+                   message="Chat ID — целое число (личный чат) или начинается "
+                           "с '-100' (супергруппа/канал)."),
+        ],
+        render_kw={"autocomplete": "off", "placeholder": "123456789"},
+    )
+    throttle_minutes = IntegerField(
+        "Минут между алертами",
+        validators=[
+            DataRequired(),
+            NumberRange(min=1, max=1440, message="От 1 минуты до суток."),
+        ],
+        default=30,
+    )
+    submit = SubmitField("Сохранить")
+
+
+def _mask_token(plaintext: str) -> str:
+    """Show first 7 chars of bot_id + ': •••' so the UI can render a hint
+    of what's saved without re-leaking the secret hash."""
+    if not plaintext or ":" not in plaintext:
+        return "•••"
+    bot_id, _ = plaintext.split(":", 1)
+    return f"{bot_id}:•••"
+
+
+@bp.route("/notifications", methods=["GET", "POST"])
+@login_required
+def notifications(slug: str):
+    project = _require_owned_project(slug)
+    existing = metrics_storage.get_project_notifications(project["id"])
+
+    form = NotificationsForm()
+
+    # Pre-fill non-secret fields on GET; never echo the token.
+    if request.method == "GET" and existing:
+        form.telegram_chat_id.data = existing.get("telegram_chat_id") or ""
+        form.throttle_minutes.data = existing.get("throttle_minutes") or 30
+
+    if form.validate_on_submit():
+        # If user left token blank AND we already have one stored — keep
+        # the old ciphertext. Otherwise re-encrypt the freshly typed one.
+        new_token = form.telegram_bot_token.data
+        if new_token:
+            token_encrypted = crypto.encrypt_token(new_token)
+        elif existing and existing.get("telegram_bot_token"):
+            token_encrypted = existing["telegram_bot_token"]
+        else:
+            flash("Bot Token обязателен при первой настройке.", "error")
+            return _render_notifications(project, form, existing)
+
+        metrics_storage.save_project_notifications(
+            project["id"],
+            telegram_bot_token=token_encrypted,
+            telegram_chat_id=form.telegram_chat_id.data.strip(),
+            throttle_minutes=form.throttle_minutes.data,
+        )
+        flash("Настройки Telegram сохранены.", "success")
+        return redirect(url_for("settings.notifications", slug=slug))
+
+    return _render_notifications(project, form, existing)
+
+
+def _render_notifications(project: dict, form: NotificationsForm,
+                          existing: dict | None):
+    token_hint = None
+    if existing and existing.get("telegram_bot_token"):
+        try:
+            plaintext = crypto.decrypt_token(existing["telegram_bot_token"])
+            token_hint = _mask_token(plaintext)
+        except crypto.InvalidToken:
+            token_hint = "•••  (ошибка дешифровки)"
+    return render_template(
+        "projects/settings_notifications.html",
+        project=project,
+        form=form,
+        token_hint=token_hint,
+        configured=bool(
+            existing
+            and existing.get("telegram_bot_token")
+            and existing.get("telegram_chat_id")
+        ),
+    )
+
+
+@bp.route("/notifications/test", methods=["POST"])
+@login_required
+def test_notification(slug: str):
+    """Send a test message using the values currently typed in the form.
+
+    Does NOT save them — that's an explicit Save action. Lets the user
+    verify the token/chat work before committing them to the DB.
+    """
+    from app.notifications.telegram import send_message
+
+    project = _require_owned_project(slug)
+    raw_token = (request.form.get("telegram_bot_token") or "").strip()
+    chat_id = (request.form.get("telegram_chat_id") or "").strip()
+
+    # Empty token in the form means "use the saved one" — same as Save.
+    if not raw_token:
+        existing = metrics_storage.get_project_notifications(project["id"])
+        if existing and existing.get("telegram_bot_token"):
+            try:
+                raw_token = crypto.decrypt_token(existing["telegram_bot_token"])
+            except crypto.InvalidToken:
+                flash("Не удалось расшифровать сохранённый токен — введите заново.", "error")
+                return redirect(url_for("settings.notifications", slug=slug))
+        if not chat_id and existing:
+            chat_id = existing.get("telegram_chat_id") or ""
+
+    if not raw_token or not chat_id:
+        flash("Заполните Bot Token и Chat ID перед тестом.", "error")
+        return redirect(url_for("settings.notifications", slug=slug))
+
+    ok, error = send_message(
+        f"✅ Тестовое сообщение из DB Monitor для проекта «{project['name']}».",
+        bot_token=raw_token, chat_id=chat_id,
+    )
+    if ok:
+        flash("Тестовое сообщение отправлено.", "success")
+    else:
+        flash(f"Не удалось отправить ({error or 'unknown'}).", "error")
+    return redirect(url_for("settings.notifications", slug=slug))
+
+
+@bp.route("/notifications/disable", methods=["POST"])
+@login_required
+def disable_notifications(slug: str):
+    project = _require_owned_project(slug)
+    metrics_storage.delete_project_notifications(project["id"])
+    flash("Telegram-уведомления отключены.", "info")
+    return redirect(url_for("settings.notifications", slug=slug))

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -132,6 +132,38 @@ def collect_all_tables() -> None:
         _score_recent_anomalies()
 
 
+def _legacy_telegram_config() -> tuple[str | None, str | None, int | None]:
+    """Look up Telegram config for the ``'legacy'`` tenant — the single-tenant
+    bucket the global scheduler runs under.
+
+    Returns ``(bot_token_or_none, chat_id_or_none, throttle_minutes_or_none)``.
+    All three None means no notification will be sent — and that's the
+    point: post-#143 there's no global ``settings.TELEGRAM_*`` fallback,
+    so the legacy scheduler is mute unless an explicit ``project_id='legacy'``
+    row exists in ``project_notifications``. Per-tenant alerts will be
+    wired into the per-project collector path in a follow-up ticket.
+    """
+    from app import crypto
+    from app.metrics_storage import get_project_notifications
+
+    cfg = get_project_notifications("legacy")
+    if cfg is None:
+        return None, None, None
+    token_encrypted = cfg.get("telegram_bot_token")
+    chat_id = cfg.get("telegram_chat_id")
+    throttle = cfg.get("throttle_minutes")
+    bot_token = None
+    if token_encrypted:
+        try:
+            bot_token = crypto.decrypt_token(token_encrypted)
+        except crypto.InvalidToken:
+            logger.warning(
+                "legacy project_notifications.telegram_bot_token failed to "
+                "decrypt — key rotation without re-encryption?"
+            )
+    return bot_token, chat_id, throttle
+
+
 def _notify_schema_drift_events() -> None:
     from datetime import timedelta
 
@@ -139,13 +171,18 @@ def _notify_schema_drift_events() -> None:
     from app.metrics_storage import get_schema_events
     from app.notifications.telegram import notify_schema_drift
 
+    bot_token, chat_id, throttle = _legacy_telegram_config()
     window = timedelta(minutes=settings.COLLECT_INTERVAL_MINUTES + 5)
     for t in list_tables():
         name = t["table_name"]
         try:
             events = get_schema_events(name, window=window)
             if events:
-                notify_schema_drift(name, events)
+                notify_schema_drift(
+                    "legacy", name, events,
+                    bot_token=bot_token, chat_id=chat_id,
+                    throttle_minutes=throttle,
+                )
         except Exception as exc:
             logger.warning("Schema drift notification failed for %s: %s", name, exc)
 
@@ -161,6 +198,7 @@ def _score_recent_anomalies() -> None:
     from app.notifications.telegram import notify_anomaly
     from ml.anomaly_detector import InsufficientDataError, score_table
 
+    bot_token, chat_id, throttle = _legacy_telegram_config()
     for t in list_tables():
         name = t["table_name"]
         try:
@@ -171,7 +209,11 @@ def _score_recent_anomalies() -> None:
                 if anomalies:
                     latest = max(anomalies, key=lambda s: s["ts"])
                     try:
-                        notify_anomaly(name, latest["ts"], latest["score"])
+                        notify_anomaly(
+                            "legacy", name, latest["ts"], latest["score"],
+                            bot_token=bot_token, chat_id=chat_id,
+                            throttle_minutes=throttle,
+                        )
                     except Exception as exc:
                         logger.warning("Anomaly notification failed for %s: %s", name, exc)
         except InsufficientDataError:
@@ -197,14 +239,18 @@ def detect_changepoints() -> None:
     logger.info("Job %s finished: detected=%d tables=%d errors=%d",
                 CHANGEPOINT_JOB_ID, counts["detected"], counts["tables"], counts["errors"])
 
+    bot_token, chat_id, throttle = _legacy_telegram_config()
     for event in counts.get("events", []):
         try:
             notify_changepoint(
+                "legacy",
                 event["table_name"],
                 event["metric_name"],
                 event["value_before"],
                 event["value_after"],
                 event["ts"],
+                bot_token=bot_token, chat_id=chat_id,
+                throttle_minutes=throttle,
             )
         except Exception as exc:
             logger.warning("Changepoint notification failed: %s", exc)

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -99,14 +99,17 @@ CREATE TABLE IF NOT EXISTS llm_explanations (
     PRIMARY KEY (table_name, metric, ts)
 );
 
--- Throttle table for Telegram notifications.
--- Prevents more than 1 message per (table_name, event_key) per TELEGRAM_THROTTLE_MINUTES.
+-- Throttle table for Telegram notifications (#143 multi-tenant).
+-- Prevents more than 1 message per (project_id, table_name, event_key) per
+-- the project's throttle_minutes window. Throttle is per-tenant — one user
+-- spamming alerts must not suppress another user's first notification.
 -- event_key examples: "anomaly_row_count", "schema_drift", "changepoint_null_rate"
 CREATE TABLE IF NOT EXISTS telegram_throttle (
+    project_id   TEXT NOT NULL DEFAULT 'legacy',
     table_name   TEXT NOT NULL,
     event_key    TEXT NOT NULL,
     last_sent_at TEXT NOT NULL,
-    PRIMARY KEY (table_name, event_key)
+    PRIMARY KEY (project_id, table_name, event_key)
 );
 
 -- История отправленных Telegram-уведомлений (#76). Пишется на каждый
@@ -207,3 +210,21 @@ CREATE INDEX IF NOT EXISTS idx_failed_login_email_ts
     ON failed_login_attempts (email, attempted_at);
 CREATE INDEX IF NOT EXISTS idx_failed_login_attempted_at
     ON failed_login_attempts (attempted_at);
+
+-- Per-project Telegram notification settings (#143).
+-- Bot token хранится Fernet-зашифрованным (та же схема что connections.dsn_encrypted)
+-- — leak metrics-DB файла недостаточен чтобы заполучить токен.
+-- PRIMARY KEY = project_id (1-to-1 — один Telegram-конфиг на проект).
+-- NULLABLE telegram_bot_token / telegram_chat_id означают «настройка
+-- частично заполнена» — отправка не происходит пока оба не заданы.
+-- НЕТ глобального fallback: если у проекта нет записи / не заполнено —
+-- уведомления молча скипаются (защита от cross-tenant leak).
+CREATE TABLE IF NOT EXISTS project_notifications (
+    project_id            TEXT NOT NULL PRIMARY KEY
+                          REFERENCES projects(id) ON DELETE CASCADE,
+    telegram_bot_token    BLOB,
+    telegram_chat_id      TEXT,
+    throttle_minutes      INTEGER NOT NULL DEFAULT 30
+                          CHECK (throttle_minutes BETWEEN 1 AND 1440),
+    updated_at            TEXT NOT NULL
+);

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -99,10 +99,11 @@ CREATE TABLE IF NOT EXISTS llm_explanations (
 );
 
 CREATE TABLE IF NOT EXISTS telegram_throttle (
+    project_id   TEXT NOT NULL DEFAULT 'legacy',
     table_name   TEXT NOT NULL,
     event_key    TEXT NOT NULL,
     last_sent_at TIMESTAMPTZ NOT NULL,
-    PRIMARY KEY (table_name, event_key)
+    PRIMARY KEY (project_id, table_name, event_key)
 );
 
 CREATE TABLE IF NOT EXISTS notifications (
@@ -179,3 +180,13 @@ CREATE INDEX IF NOT EXISTS idx_failed_login_email_ts
     ON failed_login_attempts (email, attempted_at);
 CREATE INDEX IF NOT EXISTS idx_failed_login_attempted_at
     ON failed_login_attempts (attempted_at);
+
+CREATE TABLE IF NOT EXISTS project_notifications (
+    project_id            TEXT NOT NULL PRIMARY KEY
+                          REFERENCES projects(id) ON DELETE CASCADE,
+    telegram_bot_token    BYTEA,
+    telegram_chat_id      TEXT,
+    throttle_minutes      INTEGER NOT NULL DEFAULT 30
+                          CHECK (throttle_minutes BETWEEN 1 AND 1440),
+    updated_at            TIMESTAMPTZ NOT NULL
+);

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -12,10 +12,16 @@
       <h1 class="text-2xl font-semibold tracking-tight">{{ project.name }}</h1>
       <span class="font-mono text-xs text-slate-500 dark:text-slate-400">{{ project.slug }}</span>
     </div>
-    <a href="{{ url_for('connections.list_connections', slug=project.slug) }}"
-       class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
-      Все подключения
-    </a>
+    <div class="flex items-center gap-2">
+      <a href="{{ url_for('settings.notifications', slug=project.slug) }}"
+         class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
+        Уведомления
+      </a>
+      <a href="{{ url_for('connections.list_connections', slug=project.slug) }}"
+         class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
+        Все подключения
+      </a>
+    </div>
   </div>
 
   <div class="mt-4">{% include "_flash.html" %}</div>

--- a/templates/projects/settings_notifications.html
+++ b/templates/projects/settings_notifications.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+{% from "auth/_macros.html" import render_field %}
+{% block title %}Уведомления — {{ project.name }} — DB Monitor{% endblock %}
+{% block breadcrumb %}
+  <a href="{{ url_for('projects.list_projects') }}" class="hover:text-slate-700 dark:hover:text-slate-200">Проекты</a>
+  <span class="text-slate-300 dark:text-slate-600">/</span>
+  <a href="{{ url_for('projects.detail', slug=project.slug) }}" class="hover:text-slate-700 dark:hover:text-slate-200">{{ project.name }}</a>
+  <span class="text-slate-300 dark:text-slate-600">/</span>
+  <span class="font-medium text-slate-700 dark:text-slate-200">Уведомления</span>
+{% endblock %}
+
+{% set input_cls = "mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent dark:border-slate-700 dark:bg-slate-950" %}
+
+{% block content %}
+  {% include "_flash.html" %}
+
+  <h1 class="text-2xl font-semibold tracking-tight">Telegram-уведомления</h1>
+  <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+    Алерты по аномалиям, дрейфу схемы и change-point идут только в ваш
+    чат — никакого общего канала. Bot Token шифруется через Fernet и не
+    показывается в UI после сохранения.
+  </p>
+
+  <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+    <!-- ── Form ────────────────────────────────────────────── -->
+    <div class="lg:col-span-2 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <form method="POST" action="{{ url_for('settings.notifications', slug=project.slug) }}" class="space-y-4" novalidate>
+        {{ form.hidden_tag() }}
+
+        {{ render_field(form.telegram_bot_token, input_class=input_cls) }}
+        {% if token_hint %}
+          <p class="text-xs text-slate-500 dark:text-slate-400">
+            Сохранён токен <span class="font-mono">{{ token_hint }}</span>.
+            Оставьте поле пустым чтобы сохранить его, или введите новый, чтобы заменить.
+          </p>
+        {% else %}
+          <p class="text-xs text-slate-500 dark:text-slate-400">
+            Создайте бота: напишите <a class="underline" href="https://t.me/BotFather" target="_blank" rel="noopener">@BotFather</a> → <span class="font-mono">/newbot</span>.
+            Скопируйте токен вида <span class="font-mono">1234567890:AAFx...</span>
+          </p>
+        {% endif %}
+
+        {{ render_field(form.telegram_chat_id, input_class=input_cls) }}
+        <p class="text-xs text-slate-500 dark:text-slate-400">
+          Для личного чата — напишите <a class="underline" href="https://t.me/userinfobot" target="_blank" rel="noopener">@userinfobot</a>,
+          он ответит вашим <span class="font-mono">chat_id</span>.
+          Для группы — добавьте бота в группу, отправьте любое сообщение,
+          откройте <span class="font-mono">api.telegram.org/bot&lt;TOKEN&gt;/getUpdates</span>, ищите <span class="font-mono">chat.id</span> со знаком минус (например, <span class="font-mono">-100…</span>).
+        </p>
+
+        {{ render_field(form.throttle_minutes, input_class=input_cls) }}
+        <p class="text-xs text-slate-500 dark:text-slate-400">
+          Минимальный интервал между одинаковыми алертами по одной таблице.
+          Защита от спама.
+        </p>
+
+        <div class="flex items-center gap-3 pt-2">
+          {{ form.submit(class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover") }}
+          <button type="submit" formaction="{{ url_for('settings.test_notification', slug=project.slug) }}" formnovalidate
+                  class="rounded-md border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:border-accent hover:text-accent dark:border-slate-700 dark:text-slate-200">
+            Тест
+          </button>
+          {% if configured %}
+            <span class="text-sm text-slate-400">·</span>
+          {% endif %}
+        </div>
+      </form>
+
+      {% if configured %}
+        <form method="POST" action="{{ url_for('settings.disable_notifications', slug=project.slug) }}" class="mt-4 border-t border-slate-100 pt-4 dark:border-slate-800">
+          {{ form.hidden_tag() }}
+          <button type="submit"
+                  class="text-sm text-rose-600 hover:underline dark:text-rose-400"
+                  onclick="return confirm('Удалить Telegram-конфиг проекта? Алерты перестанут приходить.');">
+            Отключить уведомления
+          </button>
+        </form>
+      {% endif %}
+    </div>
+
+    <!-- ── Помощь ──────────────────────────────────────────── -->
+    <aside class="rounded-xl border border-slate-200 bg-slate-50 p-6 text-sm dark:border-slate-800 dark:bg-slate-950">
+      <h2 class="text-base font-medium text-slate-800 dark:text-slate-100">Что приходит</h2>
+      <ul class="mt-3 space-y-2 text-slate-600 dark:text-slate-400">
+        <li>🚨 <strong>Аномалии</strong> — IsolationForest на row_count / null_rate</li>
+        <li>📋 <strong>Дрейф схемы</strong> — добавили / удалили / изменили колонки</li>
+        <li>📈 <strong>Change-point</strong> — резкий сдвиг метрики (PELT)</li>
+      </ul>
+      <p class="mt-4 text-xs text-slate-500 dark:text-slate-500">
+        Без настроек уведомления молча скипаются — никакого общего чата
+        администратора, ничего наружу проекта не уходит.
+      </p>
+    </aside>
+  </div>
+{% endblock %}

--- a/tests/test_project_notifications.py
+++ b/tests/test_project_notifications.py
@@ -1,0 +1,405 @@
+"""Tests for #143 per-project Telegram configuration.
+
+Covers:
+- ``project_notifications`` CRUD with Fernet-encrypted bot_token
+- Settings blueprint GET/POST/test/disable
+- DSNFilter scrubs Telegram bot tokens from logs
+- Cross-tenant isolation — one project's config does not leak to another
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+# ── CRUD ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    import app.metrics_storage as ms
+    from app.config import settings
+    db_path = tmp_path / "metrics.db"
+    monkeypatch.setattr(settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    return ms
+
+
+def _seed_project(storage, *, slug="default", name="Default") -> str:
+    """Create a user + project and return the project id."""
+    import uuid
+
+    from app.metrics_storage import create_project, create_user
+    user = create_user(
+        user_id=uuid.uuid4().hex,
+        email=f"u-{uuid.uuid4().hex[:6]}@example.com",
+        password_hash="x",
+    )
+    project = create_project(
+        project_id=uuid.uuid4().hex,
+        user_id=user["id"],
+        name=name,
+        slug=slug,
+    )
+    return project["id"]
+
+
+def test_get_missing_returns_none(storage):
+    pid = _seed_project(storage)
+    assert storage.get_project_notifications(pid) is None
+
+
+def test_save_then_get_round_trip(storage):
+    pid = _seed_project(storage)
+    token = crypto.encrypt_token("1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+    storage.save_project_notifications(
+        pid,
+        telegram_bot_token=token,
+        telegram_chat_id="987654321",
+        throttle_minutes=15,
+    )
+    row = storage.get_project_notifications(pid)
+    assert row is not None
+    assert row["telegram_chat_id"] == "987654321"
+    assert row["throttle_minutes"] == 15
+    # Stored ciphertext decrypts back to the original.
+    assert crypto.decrypt_token(row["telegram_bot_token"]) == \
+        "1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+
+def test_save_is_upsert(storage):
+    pid = _seed_project(storage)
+    tok1 = crypto.encrypt_token("1111111111:" + "A" * 35)
+    tok2 = crypto.encrypt_token("2222222222:" + "B" * 35)
+    storage.save_project_notifications(
+        pid, telegram_bot_token=tok1, telegram_chat_id="111", throttle_minutes=30,
+    )
+    storage.save_project_notifications(
+        pid, telegram_bot_token=tok2, telegram_chat_id="222", throttle_minutes=60,
+    )
+    row = storage.get_project_notifications(pid)
+    assert row["telegram_chat_id"] == "222"
+    assert row["throttle_minutes"] == 60
+    assert crypto.decrypt_token(row["telegram_bot_token"]).startswith("2222222222")
+
+
+def test_delete_wipes_row(storage):
+    pid = _seed_project(storage)
+    storage.save_project_notifications(
+        pid,
+        telegram_bot_token=crypto.encrypt_token("1234567890:" + "A" * 35),
+        telegram_chat_id="42",
+    )
+    assert storage.get_project_notifications(pid) is not None
+    storage.delete_project_notifications(pid)
+    assert storage.get_project_notifications(pid) is None
+
+
+def test_cross_tenant_isolation(storage):
+    """Project A's config does not appear in project B's lookups."""
+    pid_a = _seed_project(storage, slug="alice", name="Alice")
+    pid_b = _seed_project(storage, slug="bob", name="Bob")
+    storage.save_project_notifications(
+        pid_a,
+        telegram_bot_token=crypto.encrypt_token("1234567890:" + "A" * 35),
+        telegram_chat_id="aaa",
+    )
+    assert storage.get_project_notifications(pid_a) is not None
+    assert storage.get_project_notifications(pid_b) is None
+
+
+def test_cascade_on_project_delete(storage):
+    """If the parent project is removed, its notifications row goes too —
+    matches the connections / metrics CASCADE pattern (#51, #53)."""
+    from sqlalchemy import text
+    pid = _seed_project(storage)
+    storage.save_project_notifications(
+        pid,
+        telegram_bot_token=crypto.encrypt_token("1234567890:" + "A" * 35),
+        telegram_chat_id="42",
+    )
+    # PRAGMA on SQLite so FK actually cascades (Sprint 3 enables it on
+    # engine setup; here we depend on that wiring being live).
+    with storage.get_engine().begin() as conn:
+        conn.execute(text("PRAGMA foreign_keys = ON"))
+        conn.execute(text("DELETE FROM projects WHERE id = :pid"), {"pid": pid})
+    assert storage.get_project_notifications(pid) is None
+
+
+# ── Migration: existing single-tenant throttle table ───────────────────────
+
+def test_old_telegram_throttle_table_gets_recreated(tmp_path, monkeypatch):
+    """Pre-#143 DBs have telegram_throttle without project_id. The migration
+    must rebuild the table with the new PK without crashing."""
+    from sqlalchemy import create_engine, text
+
+    import app.metrics_storage as ms
+    from app.config import settings
+
+    db_path = tmp_path / "old.db"
+    # Manually create old-style throttle table.
+    eng = create_engine(f"sqlite:///{db_path}")
+    with eng.begin() as conn:
+        conn.execute(text(
+            "CREATE TABLE telegram_throttle ("
+            "  table_name TEXT NOT NULL,"
+            "  event_key TEXT NOT NULL,"
+            "  last_sent_at TEXT NOT NULL,"
+            "  PRIMARY KEY (table_name, event_key))"
+        ))
+    eng.dispose()
+
+    # Now boot the app's storage layer pointing at this DB.
+    monkeypatch.setattr(settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+
+    # Forcing engine init runs _apply_schema → _migrate_existing_schema.
+    eng2 = ms.get_engine()
+    cols = ms._existing_columns(eng2, "telegram_throttle")
+    assert "project_id" in cols
+
+
+# ── DSNFilter / log scrubber ───────────────────────────────────────────────
+
+def test_dsn_filter_scrubs_telegram_token():
+    """#143: bot tokens in log lines must be masked, keeping the public
+    bot_id but redacting the secret hash half."""
+    from app.security import _scrub
+    msg = "Sending via 1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx to chat 42"
+    scrubbed = _scrub(msg)
+    assert "AAFxxxxx" not in scrubbed
+    assert "1234567890:***" in scrubbed
+    # The chat_id and surrounding context survive unchanged.
+    assert "chat 42" in scrubbed
+
+
+def test_dsn_filter_scrubs_token_in_exception():
+    """Exceptions logged via %s reach the formatter as str(exc); _scrub
+    must catch BaseException too. We construct a plausible OperationalError
+    string that contains a token."""
+    from app.security import _scrub
+    err = RuntimeError("Telegram replied 401: token=1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx invalid")
+    scrubbed = _scrub(err)
+    assert "AAFxxxxx" not in scrubbed
+    assert "1234567890:***" in scrubbed
+
+
+def test_dsn_filter_does_not_touch_short_numbers():
+    """The regex requires bot_id 8–12 digits + ':' + exact 35 hash chars.
+    Random short numbers like ports or IDs must NOT trigger."""
+    from app.security import _scrub
+    assert _scrub("connecting to host:5432 with user:42") == \
+        "connecting to host:5432 with user:42"
+
+
+def test_dsnfilter_via_logging_pipeline(caplog):
+    """End-to-end through the real logging pipeline — install_log_record_scrubber
+    rewrites msg/args at record construction so caplog sees the scrubbed value."""
+    from app.security import install_log_record_scrubber
+    install_log_record_scrubber()
+
+    logger = logging.getLogger("test_143_token")
+    with caplog.at_level(logging.WARNING, logger="test_143_token"):
+        logger.warning(
+            "bot send failed for %s",
+            "1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        )
+
+    rendered = caplog.records[-1].getMessage()
+    assert "AAFxxxxx" not in rendered
+    assert "1234567890:***" in rendered
+
+
+# ── Settings blueprint ─────────────────────────────────────────────────────
+
+@pytest.fixture
+def app_(tmp_path, monkeypatch):
+    import app.metrics_storage as ms_
+    from app.app import create_app
+    from app.config import settings
+    db_path = tmp_path / "ob.db"
+    monkeypatch.setattr(settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms_, "_engine", None)
+    monkeypatch.setattr(ms_, "_initialized", False)
+
+    import app.api
+    import app.dashboard
+    import app.db
+    def fake_list(schema=None):
+        return []
+    monkeypatch.setattr(app.db, "list_tables", fake_list)
+    monkeypatch.setattr(app.api, "list_tables", fake_list)
+
+    return create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+
+
+@pytest.fixture
+def client(app_):
+    return app_.test_client()
+
+
+def _register(client, email="u@example.com"):
+    return client.post(
+        "/auth/register",
+        data={"email": email, "password": "supersecret1", "confirm": "supersecret1"},
+        follow_redirects=False,
+    )
+
+
+def test_settings_page_renders_for_authed_owner(client):
+    _register(client)
+    resp = client.get("/projects/default/settings/notifications")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Telegram" in body
+    assert "Bot Token" in body
+    assert "Chat ID" in body
+
+
+def test_settings_page_requires_login(client):
+    """Anon hits /auth/login redirect, not the form."""
+    resp = client.get("/projects/default/settings/notifications", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/auth/login" in resp.headers["Location"]
+
+
+def test_settings_page_404_for_stranger_slug(client):
+    _register(client, "owner@example.com")
+    # /projects/<unknown>/settings/notifications must 404 (ownership check).
+    resp = client.get("/projects/nonexistent/settings/notifications")
+    assert resp.status_code == 404
+
+
+def test_save_encrypts_token_and_persists(client):
+    _register(client, "save@example.com")
+    resp = client.post(
+        "/projects/default/settings/notifications",
+        data={
+            "telegram_bot_token": "1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "telegram_chat_id": "42",
+            "throttle_minutes": "30",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302  # redirect after save
+
+    # Pull project_id from session-backed ownership chain to look it up.
+    from app.metrics_storage import get_project_by_slug, get_user_by_email
+    user = get_user_by_email("save@example.com")
+    project = get_project_by_slug(user["id"], "default")
+    from app.metrics_storage import get_project_notifications
+    row = get_project_notifications(project["id"])
+    assert row is not None
+    assert row["telegram_chat_id"] == "42"
+    assert crypto.decrypt_token(row["telegram_bot_token"]).startswith("1234567890:")
+
+
+def test_save_with_empty_token_keeps_old(client):
+    """Editing chat_id without re-entering token preserves the saved token."""
+    _register(client, "keep@example.com")
+    # First save with token.
+    client.post(
+        "/projects/default/settings/notifications",
+        data={
+            "telegram_bot_token": "1111111111:AAAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "telegram_chat_id": "111",
+            "throttle_minutes": "30",
+        },
+    )
+    # Second save with empty token, new chat_id.
+    client.post(
+        "/projects/default/settings/notifications",
+        data={
+            "telegram_bot_token": "",
+            "telegram_chat_id": "999",
+            "throttle_minutes": "60",
+        },
+    )
+    from app.metrics_storage import (
+        get_project_by_slug,
+        get_project_notifications,
+        get_user_by_email,
+    )
+    user = get_user_by_email("keep@example.com")
+    project = get_project_by_slug(user["id"], "default")
+    row = get_project_notifications(project["id"])
+    assert row["telegram_chat_id"] == "999"
+    assert row["throttle_minutes"] == 60
+    # Token unchanged from initial save.
+    assert crypto.decrypt_token(row["telegram_bot_token"]).startswith("1111111111:")
+
+
+def test_disable_wipes_config(client):
+    _register(client, "disable@example.com")
+    client.post(
+        "/projects/default/settings/notifications",
+        data={
+            "telegram_bot_token": "1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "telegram_chat_id": "42",
+            "throttle_minutes": "30",
+        },
+    )
+    resp = client.post("/projects/default/settings/notifications/disable",
+                       follow_redirects=False)
+    assert resp.status_code == 302
+    from app.metrics_storage import (
+        get_project_by_slug,
+        get_project_notifications,
+        get_user_by_email,
+    )
+    user = get_user_by_email("disable@example.com")
+    project = get_project_by_slug(user["id"], "default")
+    assert get_project_notifications(project["id"]) is None
+
+
+def test_test_button_calls_send_message_without_persisting(client, monkeypatch):
+    """The Test action submits form values to /test, calls send_message
+    once, and does NOT write a project_notifications row."""
+    _register(client, "test@example.com")
+    sent = {}
+
+    def fake_send(text, *, bot_token, chat_id):
+        sent["text"] = text
+        sent["bot_token"] = bot_token
+        sent["chat_id"] = chat_id
+        return True, None
+
+    monkeypatch.setattr("app.notifications.telegram.send_message", fake_send)
+
+    resp = client.post(
+        "/projects/default/settings/notifications/test",
+        data={
+            "telegram_bot_token": "1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "telegram_chat_id": "42",
+            "throttle_minutes": "30",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert sent["bot_token"] == "1234567890:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    assert sent["chat_id"] == "42"
+    assert "DB Monitor" in sent["text"]
+    # No row written — Test is non-destructive.
+    from app.metrics_storage import (
+        get_project_by_slug,
+        get_project_notifications,
+        get_user_by_email,
+    )
+    user = get_user_by_email("test@example.com")
+    project = get_project_by_slug(user["id"], "default")
+    assert get_project_notifications(project["id"]) is None

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,4 +1,9 @@
-"""Tests for app/notifications/telegram.py (#38)."""
+"""Tests for app/notifications/telegram.py (#38 → #143 multi-tenant).
+
+After #143 notify_* functions take ``project_id`` + explicit ``bot_token`` /
+``chat_id`` / ``throttle_minutes``. There is no global env fallback —
+unconfigured tenants get silent skips.
+"""
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -11,9 +16,8 @@ from app.notifications.telegram import (
     send_message,
 )
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+_PID = "tproj"  # short test-project id used across cases
+
 
 @pytest.fixture
 def storage(tmp_path, monkeypatch):
@@ -32,129 +36,149 @@ def _ts(hours_ago: int = 0) -> str:
     return (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat(timespec="seconds")
 
 
-# ---------------------------------------------------------------------------
-# send_message
-# ---------------------------------------------------------------------------
+# ── send_message — explicit-config API ─────────────────────────────────────
 
-def test_send_message_no_token_returns_false(monkeypatch):
-    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "")
-    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "123")
-    ok, error = send_message("hello")
+def test_send_message_no_token_returns_not_configured():
+    ok, error = send_message("hello", bot_token=None, chat_id="123")
     assert ok is False
     assert error == "not_configured"
 
 
-def test_send_message_no_chat_id_returns_false(monkeypatch):
-    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "tok")
-    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "")
-    ok, error = send_message("hello")
+def test_send_message_no_chat_returns_not_configured():
+    ok, error = send_message("hello", bot_token="tok", chat_id=None)
     assert ok is False
     assert error == "not_configured"
 
 
-def test_send_message_success(monkeypatch):
-    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "tok")
-    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "123")
+def test_send_message_success():
     with patch("app.notifications.telegram.asyncio.run",
                side_effect=lambda coro: coro.close()) as mock_run:
-        ok, error = send_message("test")
+        ok, error = send_message("test", bot_token="tok", chat_id="123")
     assert ok is True
     assert error is None
     mock_run.assert_called_once()
 
 
-def test_send_message_telegram_error_returns_false(monkeypatch):
+def test_send_message_telegram_error_returns_false():
     from telegram.error import TelegramError
-    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "tok")
-    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "123")
 
     def _raise(coro):
         coro.close()
         raise TelegramError("bad")
 
     with patch("app.notifications.telegram.asyncio.run", side_effect=_raise):
-        ok, error = send_message("test")
+        ok, error = send_message("test", bot_token="tok", chat_id="123")
     assert ok is False
     assert error and "telegram_error" in error
 
 
-def test_send_message_network_error_returns_false(monkeypatch):
-    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "tok")
-    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "123")
-
+def test_send_message_network_error_returns_false():
     def _raise(coro):
         coro.close()
         raise OSError("conn")
 
     with patch("app.notifications.telegram.asyncio.run", side_effect=_raise):
-        ok, error = send_message("test")
+        ok, error = send_message("test", bot_token="tok", chat_id="123")
     assert ok is False
     assert error and "error" in error
 
 
-# ---------------------------------------------------------------------------
-# is_throttled / update_throttle
-# ---------------------------------------------------------------------------
+# ── is_throttled / update_throttle — now per-project ───────────────────────
 
 def test_is_throttled_no_entry(storage):
     from app.metrics_storage import is_throttled
-    assert is_throttled("orders", "anomaly") is False
+    assert is_throttled(_PID, "orders", "anomaly") is False
 
 
 def test_is_throttled_recent_entry(storage):
     from app.metrics_storage import is_throttled, update_throttle
-    update_throttle("orders", "anomaly")
-    assert is_throttled("orders", "anomaly") is True
+    update_throttle(_PID, "orders", "anomaly")
+    assert is_throttled(_PID, "orders", "anomaly") is True
 
 
-def test_is_throttled_expired_entry(storage, monkeypatch):
+def test_is_throttled_isolated_across_projects(storage):
+    """#143: project_id is part of the throttle PK — one tenant must not
+    suppress another's notifications."""
+    from app.metrics_storage import is_throttled, update_throttle
+    update_throttle("proj-A", "orders", "anomaly")
+    # proj-B has never sent — must NOT be throttled.
+    assert is_throttled("proj-B", "orders", "anomaly") is False
+    assert is_throttled("proj-A", "orders", "anomaly") is True
+
+
+def test_is_throttled_respects_per_project_window(storage):
+    """``throttle_minutes`` arg overrides the global TELEGRAM_THROTTLE_MINUTES.
+    A row that's 10 min old is throttled with window=15 but not with window=5."""
     from sqlalchemy import text
 
     from app.metrics_storage import is_throttled
 
-    old_ts = (datetime.now(UTC) - timedelta(minutes=31)).isoformat(timespec="seconds")
+    old_ts = (datetime.now(UTC) - timedelta(minutes=10)).isoformat(timespec="seconds")
     with storage.get_engine().begin() as conn:
         conn.execute(text(
-            "INSERT OR REPLACE INTO telegram_throttle (table_name, event_key, last_sent_at)"
-            " VALUES ('orders', 'anomaly', :ts)"
-        ), {"ts": old_ts})
+            "INSERT OR REPLACE INTO telegram_throttle "
+            "(project_id, table_name, event_key, last_sent_at) "
+            "VALUES (:pid, 'orders', 'anomaly', :ts)"
+        ), {"pid": _PID, "ts": old_ts})
 
-    assert is_throttled("orders", "anomaly") is False
+    assert is_throttled(_PID, "orders", "anomaly", throttle_minutes=15) is True
+    assert is_throttled(_PID, "orders", "anomaly", throttle_minutes=5) is False
 
 
 def test_throttle_is_per_table_and_key(storage):
     from app.metrics_storage import is_throttled, update_throttle
-    update_throttle("orders", "anomaly")
-    assert is_throttled("users", "anomaly") is False
-    assert is_throttled("orders", "schema_drift") is False
+    update_throttle(_PID, "orders", "anomaly")
+    assert is_throttled(_PID, "users", "anomaly") is False
+    assert is_throttled(_PID, "orders", "schema_drift") is False
 
 
-# ---------------------------------------------------------------------------
-# notify_anomaly
-# ---------------------------------------------------------------------------
+# ── notify_anomaly ─────────────────────────────────────────────────────────
 
-def test_notify_anomaly_sends_message(storage, monkeypatch):
+def _explain_stub(monkeypatch, *, confidence=0.85, explanation="ETL сбой"):
     monkeypatch.setattr(
         "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "ETL сбой", "suggested_fix": "", "confidence": 0.85},
+        lambda t, m, ts: {"explanation": explanation, "suggested_fix": "", "confidence": confidence},
     )
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
-        notify_anomaly("orders", _ts(), -0.14)
+
+
+def test_notify_anomaly_sends_message(storage, monkeypatch):
+    _explain_stub(monkeypatch)
+    with patch("app.notifications.telegram.send_message",
+               return_value=(True, None)) as mock_send:
+        notify_anomaly(_PID, "orders", _ts(), -0.14,
+                       bot_token="tok", chat_id="42")
     mock_send.assert_called_once()
     text = mock_send.call_args[0][0]
     assert "orders" in text
     assert "row_count" in text
     assert "UTC" in text
     assert "ETL сбой" in text
+    # bot_token/chat_id flow through to send_message.
+    assert mock_send.call_args.kwargs["bot_token"] == "tok"
+    assert mock_send.call_args.kwargs["chat_id"] == "42"
+
+
+def test_notify_anomaly_no_config_records_failure_no_send(storage, monkeypatch):
+    """#143: if bot_token/chat_id is None, send_message is still called
+    (it shorts to 'not_configured'), and the failure is audited. No global
+    fallback — no notification leaves the system."""
+    from app.metrics_storage import get_notifications
+    _explain_stub(monkeypatch, confidence=0.3)
+    notify_anomaly(_PID, "orders", _ts(), -0.2,
+                   bot_token=None, chat_id=None)
+    rows = get_notifications()
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+    assert rows[0]["error"] == "not_configured"
 
 
 def test_notify_anomaly_fallback_message(storage, monkeypatch):
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "Требуется ручная проверка.", "suggested_fix": "", "confidence": 0.3},
-    )
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
-        notify_anomaly("orders", _ts(), -0.14)
+    _explain_stub(monkeypatch, confidence=0.3,
+                  explanation="Требуется ручная проверка.")
+    with patch("app.notifications.telegram.send_message",
+               return_value=(True, None)) as mock_send:
+        notify_anomaly(_PID, "orders", _ts(), -0.14,
+                       bot_token="tok", chat_id="42")
     text = mock_send.call_args[0][0]
     assert "orders" in text
     assert "Требуется ручная проверка данных." in text
@@ -162,63 +186,51 @@ def test_notify_anomaly_fallback_message(storage, monkeypatch):
 
 def test_notify_anomaly_passes_raw_ts_and_metric_to_explain(storage, monkeypatch):
     received = {}
+
     def capture(t, m, ts):
         received["ts"] = ts
         received["metric"] = m
         return {"explanation": "ok", "suggested_fix": "", "confidence": 0.85}
+
     monkeypatch.setattr("app.notifications.telegram.explain_anomaly", capture)
     raw_ts = "2026-05-12T02:36:00+00:00"
     with patch("app.notifications.telegram.send_message", return_value=(True, None)):
-        notify_anomaly("orders", raw_ts, -0.14, metric="null_rate")
-    assert received["ts"] == raw_ts, "explain_anomaly must receive the original ISO ts, not a formatted string"
+        notify_anomaly(_PID, "orders", raw_ts, -0.14,
+                       bot_token="tok", chat_id="42", metric="null_rate")
+    assert received["ts"] == raw_ts
     assert received["metric"] == "null_rate"
 
 
-def test_notify_anomaly_metric_appears_in_message(storage, monkeypatch):
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "высокий null", "suggested_fix": "", "confidence": 0.85},
-    )
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
-        notify_anomaly("orders", _ts(), -0.14, metric="null_rate")
-    text = mock_send.call_args[0][0]
-    assert "null_rate" in text
-    assert "высокий null" in text
-
-
 def test_notify_anomaly_message_contains_score(storage, monkeypatch):
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "причина", "suggested_fix": "", "confidence": 0.3},
-    )
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
-        notify_anomaly("orders", _ts(), -0.25)
-    text = mock_send.call_args[0][0]
-    assert "-0.2500" in text
+    _explain_stub(monkeypatch, confidence=0.3)
+    with patch("app.notifications.telegram.send_message",
+               return_value=(True, None)) as mock_send:
+        notify_anomaly(_PID, "orders", _ts(), -0.25,
+                       bot_token="tok", chat_id="42")
+    assert "-0.2500" in mock_send.call_args[0][0]
 
 
 def test_notify_anomaly_throttled_skips_send(storage, monkeypatch):
     from app.metrics_storage import update_throttle
-    update_throttle("orders", "anomaly")
+    update_throttle(_PID, "orders", "anomaly")
     explain_mock = MagicMock()
     monkeypatch.setattr("app.notifications.telegram.explain_anomaly", explain_mock)
     with patch("app.notifications.telegram.send_message") as mock_send:
-        notify_anomaly("orders", _ts(), -0.14)
+        notify_anomaly(_PID, "orders", _ts(), -0.14,
+                       bot_token="tok", chat_id="42")
     mock_send.assert_not_called()
     explain_mock.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# notify_schema_drift
-# ---------------------------------------------------------------------------
+# ── notify_schema_drift ────────────────────────────────────────────────────
 
-def test_notify_schema_drift_sends_message(storage, monkeypatch):
-    events = [
-        {"change_type": "column_added", "column_name": "email",
-         "details": {"after": {"type": "text"}}},
-    ]
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
-        notify_schema_drift("orders", events)
+def test_notify_schema_drift_sends_message(storage):
+    events = [{"change_type": "column_added", "column_name": "email",
+               "details": {"after": {"type": "text"}}}]
+    with patch("app.notifications.telegram.send_message",
+               return_value=(True, None)) as mock_send:
+        notify_schema_drift(_PID, "orders", events,
+                            bot_token="tok", chat_id="42")
     mock_send.assert_called_once()
     text = mock_send.call_args[0][0]
     assert "orders" in text
@@ -226,67 +238,65 @@ def test_notify_schema_drift_sends_message(storage, monkeypatch):
     assert "email" in text
 
 
-def test_notify_schema_drift_multiple_events_single_message(storage, monkeypatch):
+def test_notify_schema_drift_multiple_events_single_message(storage):
     events = [
         {"change_type": "column_added", "column_name": "email",
          "details": {"after": {"type": "text"}}},
         {"change_type": "column_removed", "column_name": "age",
          "details": {"before": {"type": "integer"}}},
     ]
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
-        notify_schema_drift("orders", events)
+    with patch("app.notifications.telegram.send_message",
+               return_value=(True, None)) as mock_send:
+        notify_schema_drift(_PID, "orders", events,
+                            bot_token="tok", chat_id="42")
     assert mock_send.call_count == 1
     text = mock_send.call_args[0][0]
     assert "email" in text
     assert "age" in text
 
 
-def test_notify_schema_drift_empty_events_skips(storage, monkeypatch):
+def test_notify_schema_drift_empty_events_skips(storage):
     with patch("app.notifications.telegram.asyncio.run") as mock_run:
-        notify_schema_drift("orders", [])
+        notify_schema_drift(_PID, "orders", [],
+                            bot_token="tok", chat_id="42")
     mock_run.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# notify_changepoint
-# ---------------------------------------------------------------------------
+# ── notify_changepoint ─────────────────────────────────────────────────────
 
-def test_notify_changepoint_sends_message(storage, monkeypatch):
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
-        notify_changepoint("orders", "row_count", 1000.0, 2500.0, _ts())
+def test_notify_changepoint_sends_message(storage):
+    with patch("app.notifications.telegram.send_message",
+               return_value=(True, None)) as mock_send:
+        notify_changepoint(_PID, "orders", "row_count", 1000.0, 2500.0, _ts(),
+                           bot_token="tok", chat_id="42")
     mock_send.assert_called_once()
     text = mock_send.call_args[0][0]
     assert "orders" in text
     assert "row_count" in text
 
 
-def test_notify_changepoint_null_rate_format(storage, monkeypatch):
+def test_notify_changepoint_null_rate_format(storage):
     captured = []
-    with patch("app.notifications.telegram.send_message",
-               side_effect=lambda t: (captured.append(t) or True, None)):
-        notify_changepoint("orders", "null_rate", 0.02, 0.18, _ts())
+    with patch(
+        "app.notifications.telegram.send_message",
+        side_effect=lambda t, **kw: (captured.append(t) or True, None),
+    ):
+        notify_changepoint(_PID, "orders", "null_rate", 0.02, 0.18, _ts(),
+                           bot_token="tok", chat_id="42")
 
     assert captured, "expected a message"
     assert "2.0%" in captured[0]
     assert "18.0%" in captured[0]
 
 
-# ---------------------------------------------------------------------------
-# Flood test: 10 anomaly calls → only 1 send
-# ---------------------------------------------------------------------------
-
-# ---------------------------------------------------------------------------
-# Notification persistence (#76)
-# ---------------------------------------------------------------------------
+# ── Notification persistence (#76) ─────────────────────────────────────────
 
 def test_notify_anomaly_persists_sent_record(storage, monkeypatch):
     from app.metrics_storage import get_notifications
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "ETL сбой", "suggested_fix": "", "confidence": 0.3},
-    )
+    _explain_stub(monkeypatch, confidence=0.3)
     with patch("app.notifications.telegram.send_message", return_value=(True, None)):
-        notify_anomaly("orders", _ts(), -0.14)
+        notify_anomaly(_PID, "orders", _ts(), -0.14,
+                       bot_token="tok", chat_id="42")
 
     rows = get_notifications()
     assert len(rows) == 1
@@ -296,19 +306,16 @@ def test_notify_anomaly_persists_sent_record(storage, monkeypatch):
     assert rec["metric_name"] == "row_count"
     assert rec["status"] == "sent"
     assert rec["error"] is None
-    assert "orders" in rec["message"]
+    assert rec["project_id"] == _PID  # #143: tenant tag on the audit row.
 
 
 def test_notify_anomaly_persists_failed_record_on_send_error(storage, monkeypatch):
-    """Acceptance: failed sends still create a record with status='failed' + error."""
     from app.metrics_storage import get_notifications
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
-    )
+    _explain_stub(monkeypatch, confidence=0.3)
     with patch("app.notifications.telegram.send_message",
                return_value=(False, "telegram_error: bad")):
-        notify_anomaly("orders", _ts(), -0.2)
+        notify_anomaly(_PID, "orders", _ts(), -0.2,
+                       bot_token="tok", chat_id="42")
 
     rows = get_notifications()
     assert len(rows) == 1
@@ -317,23 +324,21 @@ def test_notify_anomaly_persists_failed_record_on_send_error(storage, monkeypatc
 
 
 def test_notify_anomaly_failed_send_does_not_throttle(storage, monkeypatch):
-    """If send failed, throttle is NOT updated — next attempt should go through."""
     from app.metrics_storage import is_throttled
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
-    )
+    _explain_stub(monkeypatch, confidence=0.3)
     with patch("app.notifications.telegram.send_message", return_value=(False, "oops")):
-        notify_anomaly("orders", _ts(), -0.2)
-    assert is_throttled("orders", "anomaly") is False
+        notify_anomaly(_PID, "orders", _ts(), -0.2,
+                       bot_token="tok", chat_id="42")
+    assert is_throttled(_PID, "orders", "anomaly") is False
 
 
-def test_notify_schema_drift_persists_record(storage, monkeypatch):
+def test_notify_schema_drift_persists_record(storage):
     from app.metrics_storage import get_notifications
     events = [{"change_type": "column_added", "column_name": "email",
                "details": {"after": {"type": "text"}}}]
     with patch("app.notifications.telegram.send_message", return_value=(True, None)):
-        notify_schema_drift("orders", events)
+        notify_schema_drift(_PID, "orders", events,
+                            bot_token="tok", chat_id="42")
     rows = get_notifications()
     assert len(rows) == 1
     assert rows[0]["event_type"] == "schema_drift"
@@ -341,21 +346,49 @@ def test_notify_schema_drift_persists_record(storage, monkeypatch):
     assert rows[0]["status"] == "sent"
 
 
-def test_notify_changepoint_persists_record(storage, monkeypatch):
+def test_notify_changepoint_persists_record(storage):
     from app.metrics_storage import get_notifications
     with patch("app.notifications.telegram.send_message", return_value=(True, None)):
-        notify_changepoint("orders", "row_count", 1000.0, 2500.0, _ts())
+        notify_changepoint(_PID, "orders", "row_count", 1000.0, 2500.0, _ts(),
+                           bot_token="tok", chat_id="42")
     rows = get_notifications()
     assert len(rows) == 1
     assert rows[0]["event_type"] == "changepoint"
     assert rows[0]["metric_name"] == "row_count"
 
 
-def test_get_notifications_filters_by_event_type(storage, monkeypatch):
+def test_save_notification_omits_secrets(storage, monkeypatch):
+    """chat_id is recorded but bot token is never persisted (acceptance)."""
+    from app.metrics_storage import get_notifications
+    _explain_stub(monkeypatch, confidence=0.3)
+    with patch("app.notifications.telegram.send_message", return_value=(True, None)):
+        notify_anomaly(_PID, "orders", _ts(), -0.2,
+                       bot_token="super-secret-token", chat_id="42")
+
+    rows = get_notifications()
+    assert rows[0]["chat_id"] == "42"
+    blob = " ".join(str(v) for v in rows[0].values() if v is not None)
+    assert "super-secret-token" not in blob
+
+
+def test_flood_throttle_10_anomalies(storage, monkeypatch):
+    _explain_stub(monkeypatch, confidence=0.3)
+    with patch("app.notifications.telegram.send_message",
+               return_value=(True, None)) as mock_send:
+        for _ in range(10):
+            notify_anomaly(_PID, "orders", _ts(), -0.2,
+                           bot_token="tok", chat_id="42")
+    assert mock_send.call_count == 1
+
+
+# ── get_notifications filters ──────────────────────────────────────────────
+
+def test_get_notifications_filters_by_event_type(storage):
     from app.metrics_storage import get_notifications, save_notification
     save_notification(event_type="anomaly", message="m1", status="sent", table_name="orders")
     save_notification(event_type="schema_drift", message="m2", status="sent", table_name="orders")
-    save_notification(event_type="anomaly", message="m3", status="failed", table_name="users", error="e")
+    save_notification(event_type="anomaly", message="m3", status="failed",
+                      table_name="users", error="e")
 
     only_anomaly = get_notifications(event_type="anomaly")
     assert len(only_anomaly) == 2
@@ -378,57 +411,6 @@ def test_get_notifications_pagination(storage):
     page2 = get_notifications(limit=3, offset=3)
     assert len(page1) == 3
     assert len(page2) == 3
-    # Newest-first ordering — offset slice should not overlap.
     ids1 = {r["id"] for r in page1}
     ids2 = {r["id"] for r in page2}
     assert ids1.isdisjoint(ids2)
-
-
-def test_save_notification_omits_secrets(storage, monkeypatch):
-    """chat_id is recorded but bot token is never persisted (acceptance)."""
-    from app.metrics_storage import get_notifications
-    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "super-secret-token")
-    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "42")
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
-    )
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)):
-        notify_anomaly("orders", _ts(), -0.2)
-
-    rows = get_notifications()
-    assert rows[0]["chat_id"] == "42"
-    blob = " ".join(str(v) for v in rows[0].values() if v is not None)
-    assert "super-secret-token" not in blob
-
-
-def test_flood_throttle_10_anomalies(storage, monkeypatch):
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
-    )
-    with patch("app.notifications.telegram.send_message", return_value=(True, None)) as mock_send:
-        for _ in range(10):
-            notify_anomaly("orders", _ts(), -0.2)
-    assert mock_send.call_count == 1, f"expected 1 send, got {mock_send.call_count}"
-
-
-# ---------------------------------------------------------------------------
-# End-to-end: send_message stub failure path is recorded
-# ---------------------------------------------------------------------------
-
-def test_notify_persists_failure_when_telegram_not_configured(storage, monkeypatch):
-    """No token → send_message returns ('not_configured'); record still saved."""
-    from app.metrics_storage import get_notifications
-    monkeypatch.setattr("app.config.settings.TELEGRAM_BOT_TOKEN", "")
-    monkeypatch.setattr("app.config.settings.TELEGRAM_CHAT_ID", "")
-    monkeypatch.setattr(
-        "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": "x", "suggested_fix": "", "confidence": 0.3},
-    )
-    notify_anomaly("orders", _ts(), -0.2)
-
-    rows = get_notifications()
-    assert len(rows) == 1
-    assert rows[0]["status"] == "failed"
-    assert rows[0]["error"] == "not_configured"


### PR DESCRIPTION
## Что и почему

До этого PR Telegram был **глобальной** настройкой в `.env`:
- `TELEGRAM_BOT_TOKEN` — один бот на всё приложение
- `TELEGRAM_CHAT_ID` — один чат для всех юзеров

В multi-tenant архитектуре (Sprint 3) это значит, что все алерты всех юзеров идут в чат админа. Юзер не может подключить свой Telegram, и его данные смешиваются с чужими в одном канале.

После #143:
- Каждый юзер в своём проекте → Settings → вводит свои `bot_token`, `chat_id`, throttle
- Bot token шифруется Fernet и **никогда** не показывается в UI после сохранения
- Алерты идут **только** в его чат. Без настроек — ничего не уходит. **Нет глобального fallback** (защита от cross-tenant leak).

## Скоуп

### 1. Схема + миграция
- Новая таблица `project_notifications` (PK = `project_id` с FK CASCADE): `telegram_bot_token` BLOB, `telegram_chat_id` TEXT, `throttle_minutes` INTEGER 1..1440 default 30, `updated_at`
- `telegram_throttle` расширена `project_id` в PRIMARY KEY (защита от cross-tenant suppress). Миграция: таблица — ephemeral cache, дропается и пересоздаётся (acceptable cost: ≤1 лишний алерт после деплоя).

### 2. `app/notifications/telegram.py` отрефакторен
Больше не читает `settings.TELEGRAM_*`. `send_message` / `notify_*` принимают `bot_token`, `chat_id`, `throttle_minutes` явными параметрами. Если `bot_token=None` или `chat_id=None` → возвращается `('not_configured')`, ничего не уходит, в аудит-таблицу пишется `failed`.

### 3. `collectors/scheduler.py` обновлён
Legacy global scheduler теперь загружает конфиг для `project_id='legacy'`. По умолчанию его нет → scheduler **немой**. Per-project collector path (post-tick notification fires) — отдельный тикет.

### 4. `app/settings.py` (новый blueprint)
- `GET /projects/<slug>/settings/notifications` — форма
- `POST` — Save: пустой token-поле сохраняет старый ciphertext без перепаковки
- `POST /test` — отправляет тестовое сообщение **без сохранения**
- `POST /disable` — удаляет ряд
- WTForms validators: regex `\d{8,12}:[A-Za-z0-9_-]{35}` для токена, `-?\d{1,16}` для chat_id
- URL-prefix `/settings/` заложен под будущие разделы (general, danger zone)

### 5. `app/security.py`
DSNFilter регекс `\b\d{8,12}:[A-Za-z0-9_-]{35}\b` ловит bot tokens в логах. Bot_id (публичный) сохраняется, secret hash скрывается → `1234567890:***`.

### 6. `app/crypto.py`
Семантические обёртки `encrypt_token` / `decrypt_token` поверх того же Fernet что для DSN.

### 7. `.gitignore`
`.env.local` (содержит локальный Fernet ключ) добавлен.

## Тесты (523 passed, ruff clean)

- **`tests/test_telegram.py`** переписан под новые сигнатуры (30 кейсов). Новые:
  - `test_is_throttled_isolated_across_projects` — cross-tenant изоляция throttle
  - `test_is_throttled_respects_per_project_window` — throttle_minutes на тенант
  - `test_notify_anomaly_no_config_records_failure_no_send` — без конфига аудит `failed`, ничего не уходит

- **`tests/test_project_notifications.py`** (новый, 18 кейсов):
  - CRUD round-trip с Fernet round-trip
  - UPSERT
  - DELETE
  - Cross-tenant изоляция
  - FK CASCADE на удаление проекта
  - **Миграция старой telegram_throttle**: создаёт pre-#143 структуру, бутит storage, проверяет что project_id появился
  - DSNFilter scrubbing: regex + exception (`record.args` с BaseException) + полный logging pipeline через caplog
  - Settings blueprint: GET (auth required, 404 для stranger slug), POST (save + encrypt), POST с пустым token (keep), POST /test (без save), POST /disable

## Out of scope (отдельный тикет)

Wiring per-project collector (`collect_for_connection` в `collectors/per_project.py`) на pre-tick notification fires — после тика per-project scoring/changepoint detection и вызов `notify_*` с конфигом проекта. Legacy scheduler по дизайну #143 немой; чтобы реально доставлять алерты per-tenant, нужно подцепить notify в per-project pipeline.

## Test plan

- [x] Юнит-тесты на все слои зелёные
- [x] Cross-tenant изоляция пинится явным тестом
- [x] Миграция старой структуры покрыта тестом
- [x] DSN-filter regex покрыт + edge cases (short numbers must NOT trigger)
- [x] Settings blueprint покрыт GET/POST/test/disable + ownership 404
- [ ] Manual smoke (после merge): зарегистрироваться → создать проект → Settings → Notifications → ввести валидный токен + chat_id → Test → должен прилететь токен реального бота