### PR TITLE
fix(#147): дашборд использует DSN проекта вместо глобального DATABASE_URL

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -4,8 +4,10 @@ from pathlib import Path
 
 from flask import Blueprint, abort, g, redirect, render_template, url_for
 from flask_login import current_user
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
 
-from app import db
+from app import crypto, db
 from app.metrics_storage import (
     build_history_aggregate,
     count_notifications,
@@ -41,6 +43,93 @@ def _current_project_id() -> str:
     project = getattr(g, "current_project", None)
     return project["id"] if project else "legacy"
 
+
+def _project_connections(project: dict | None) -> list[dict]:
+    if project is None:
+        return []
+    from app.metrics_storage import list_connections_for_project
+
+    return list_connections_for_project(project["id"])
+
+
+def _active_connection(connections: list[dict]) -> dict | None:
+    return next((c for c in connections if c.get("is_active")), None)
+
+
+def _with_project_adapter(conn_row: dict, fn):
+    """Run a live metadata callback against a project's connection DSN.
+
+    Dashboard live schema reads must never fall back to the global DATABASE_URL
+    once a project connection exists. On connection/DSN errors, return an empty
+    list and let the page render without leaking legacy schema.
+    """
+    engine = None
+    try:
+        dsn = crypto.decrypt_dsn(conn_row["dsn_encrypted"])
+        adapter = db.make_adapter_for_url(dsn)
+        if not dsn.lower().startswith("iceberg+"):
+            engine = create_engine(
+                dsn,
+                poolclass=NullPool,
+                connect_args=db.connect_args_for_url(dsn),
+            )
+        with db.using_engine(engine, adapter):
+            return fn(adapter, conn_row["schema_name"])
+    except crypto.InvalidToken:
+        logger.warning(
+            "project connection DSN ciphertext invalid: project=%s conn=%s",
+            conn_row.get("project_id"), conn_row.get("id"),
+        )
+        return []
+    except Exception as exc:
+        logger.warning(
+            "project connection metadata fetch failed: project=%s conn=%s error=%s",
+            conn_row.get("project_id"), conn_row.get("id"), exc,
+        )
+        return []
+    finally:
+        if engine is not None:
+            engine.dispose()
+
+
+def _list_tables_for_dashboard(
+    project: dict | None, connections: list[dict] | None = None
+) -> list[dict]:
+    if project is None:
+        return db.list_tables()
+
+    source_connections = (
+        connections if connections is not None else _project_connections(project)
+    )
+    conn_row = _active_connection(source_connections)
+    if conn_row is None:
+        return []
+    return _with_project_adapter(
+        conn_row,
+        lambda adapter, schema: adapter.list_tables(schema),
+    )
+
+
+def _table_schema_for_dashboard(
+    project: dict | None,
+    connections: list[dict] | None,
+    table_name: str,
+    schema: str,
+) -> list[dict]:
+    if project is None:
+        return db.table_schema(table_name, schema=schema)
+
+    source_connections = (
+        connections if connections is not None else _project_connections(project)
+    )
+    conn_row = _active_connection(source_connections)
+    if conn_row is None:
+        return []
+    return _with_project_adapter(
+        conn_row,
+        lambda adapter, conn_schema: adapter.table_schema(table_name, conn_schema),
+    )
+
 _NOTIFICATION_EVENT_LABELS = {
     "anomaly": "Аномалия",
     "schema_drift": "Дрейф схемы",
@@ -67,14 +156,11 @@ bp = Blueprint(
 @bp.route("")
 @bp.route("/")
 def overview():
-    from app.metrics_storage import list_connections_for_project
-
     project = getattr(g, "current_project", None)
     # #137: authenticated user with no projects → onboarding, not legacy data.
     needs_first_project = current_user.is_authenticated and project is None
-    has_connections = bool(
-        list_connections_for_project(project["id"]) if project else False
-    )
+    connections = _project_connections(project)
+    has_connections = bool(connections)
     needs_first_connection = project is not None and not has_connections
 
     tables: list = []
@@ -82,7 +168,9 @@ def overview():
     null_rates: list = []
     skip_tables = needs_first_project or needs_first_connection
     try:
-        schema_entries = [] if skip_tables else db.list_tables()
+        schema_entries = [] if skip_tables else _list_tables_for_dashboard(
+            project, connections
+        )
     except Exception as exc:
         logger.warning("list_tables failed in overview: %s", exc)
         schema_entries = []
@@ -147,13 +235,12 @@ def _fmt_ts(value: str | None) -> str | None:
 
 @bp.route("/schema")
 def schema_view():
-    from app.metrics_storage import get_drift_report, list_connections_for_project
+    from app.metrics_storage import get_drift_report
 
     project = getattr(g, "current_project", None)
     needs_first_project = current_user.is_authenticated and project is None
-    has_connections = bool(
-        list_connections_for_project(project["id"]) if project else False
-    )
+    connections = _project_connections(project)
+    has_connections = bool(connections)
     needs_first_connection = project is not None and not has_connections
 
     cutoff = datetime.now(UTC) - timedelta(days=_RECENT_SCHEMA_DAYS)
@@ -161,14 +248,20 @@ def schema_view():
     skip_tables = needs_first_project or needs_first_connection
     if not skip_tables:
         try:
-            _schema_entries = db.list_tables()
+            _schema_entries = _list_tables_for_dashboard(project, connections)
         except Exception as exc:
             logger.warning("list_tables failed in schema_view: %s", exc)
             _schema_entries = []
         for entry in _schema_entries:
             name = entry["table_name"]
             snapshot = _table_snapshot(name, entry["schema"])
-            cols = _columns_with_nulls(name, entry["schema"], snapshot["row_count"])
+            schema_cols = _table_schema_for_dashboard(
+                project, connections, name, entry["schema"]
+            )
+            cols = _columns_with_nulls(
+                name, entry["schema"], snapshot["row_count"],
+                schema_columns=schema_cols,
+            )
             drift_by_col = {d["column"]: d for d in get_drift_report(name)}
             for c in cols:
                 d = drift_by_col.get(c["name"])
@@ -197,7 +290,6 @@ def _parse_event_ts(value: str) -> datetime:
     return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
 
 
-
 @bp.route("/history")
 def history_view():
     redir = _onboarding_redirect()
@@ -213,6 +305,7 @@ def history_view():
         daily_history=daily_history,
         insights=insights,
     )
+
 
 @bp.route("/notifications")
 def notifications_view():
@@ -260,25 +353,30 @@ def notifications_view():
 
 @bp.route("/schema/<table_name>")
 def table_detail(table_name: str):
-    from app.metrics_storage import get_drift_report, list_connections_for_project
+    from app.metrics_storage import get_drift_report
 
     project = getattr(g, "current_project", None)
     # #137: auth'd user with no projects → 404 (no legacy data leak).
     # Anonymous users keep the legacy path (project is None, not authenticated).
     if current_user.is_authenticated and project is None:
         abort(404)
-    has_connections = bool(
-        list_connections_for_project(project["id"]) if project else False
-    )
+    connections = _project_connections(project)
+    has_connections = bool(connections)
     if project is not None and not has_connections:
         abort(404)
 
-    entries = {t["table_name"]: t for t in db.list_tables()}
+    entries = {
+        t["table_name"]: t
+        for t in _list_tables_for_dashboard(project, connections)
+    }
     if table_name not in entries:
         abort(404)
     schema = entries[table_name]["schema"]
     snapshot = _table_snapshot(table_name, schema)
-    columns = _columns_with_nulls(table_name, schema, snapshot["row_count"])
+    schema_cols = _table_schema_for_dashboard(project, connections, table_name, schema)
+    columns = _columns_with_nulls(
+        table_name, schema, snapshot["row_count"], schema_columns=schema_cols
+    )
     drift_by_col = {d["column"]: d for d in get_drift_report(table_name)}
     for c in columns:
         c["drift"] = drift_by_col.get(c["name"])
@@ -291,9 +389,19 @@ def table_detail(table_name: str):
     )
 
 
-def _columns_with_nulls(table_name: str, schema: str, row_count: int | None) -> list[dict]:
+def _columns_with_nulls(
+    table_name: str,
+    schema: str,
+    row_count: int | None,
+    *,
+    schema_columns: list[dict] | None = None,
+) -> list[dict]:
     """Combine info_schema column list with stored per-column null counts."""
-    cols = db.table_schema(table_name, schema=schema)
+    cols = (
+        schema_columns
+        if schema_columns is not None
+        else db.table_schema(table_name, schema=schema)
+    )
     null_counts = get_latest_null_counts(table_name, _current_project_id())
     result = []
     for c in cols:

--- a/app/db.py
+++ b/app/db.py
@@ -55,12 +55,13 @@ def get_engine() -> Engine:
                     pool_size=5,
                     max_overflow=2,
                     pool_pre_ping=True,
-                    connect_args=_connect_args(settings.DATABASE_URL),
+                    connect_args=connect_args_for_url(settings.DATABASE_URL),
                 )
     return _engine
 
 
-def _connect_args(url: str) -> dict:
+def connect_args_for_url(url: str) -> dict:
+    """SQLAlchemy connect_args used for short metadata connections."""
     backend = make_url(url).get_backend_name()
     if backend == "postgresql":
         return {"connect_timeout": 5}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,9 +1,17 @@
 from unittest.mock import patch
 
 import pytest
+from cryptography.fernet import Fernet
 
+from app import crypto
 from app.app import _fmt_iso_in_text, create_app
 from app.dashboard import status_class
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
 
 
 @pytest.fixture
@@ -33,6 +41,39 @@ def _latest_factory(values: dict):
             return v
         return {"ts": "2026-04-29T10:00:00+00:00", "value": v, "tags": None}
     return _side_effect
+
+
+def _login_with_project_connection(
+    client,
+    *,
+    email: str = "tenant@example.com",
+    dsn: str = "postgresql://u:p@tenant-db:5432/app",
+    schema_name: str = "analytics",
+) -> dict:
+    client.post("/auth/register", data={
+        "email": email,
+        "password": "supersecret1",
+        "confirm": "supersecret1",
+    })
+
+    from app.metrics_storage import (
+        create_connection,
+        get_user_by_email,
+        list_projects_for_user,
+    )
+
+    user = get_user_by_email(email)
+    project = list_projects_for_user(user["id"])[0]
+    create_connection(
+        connection_id=f"conn-{email}",
+        project_id=project["id"],
+        name="Tenant DB",
+        dsn_encrypted=crypto.encrypt_dsn(dsn),
+        schema_name=schema_name,
+        interval_minutes=15,
+        is_active=True,
+    )
+    return project
 
 
 def test_status_class_buckets():
@@ -224,6 +265,106 @@ def test_schema_page_renders_from_information_schema(client):
     assert "users" in body and "orders" in body
     assert "uuid" in body and "text" in body and "numeric" in body
     mock_col_nulls.assert_not_called()
+
+
+class _FakeTenantAdapter:
+    def __init__(self):
+        self.list_schema = None
+        self.schema_calls = []
+
+    def list_tables(self, schema):
+        self.list_schema = schema
+        return [{"table_name": "tenant_orders", "schema": schema}]
+
+    def table_schema(self, table_name, schema):
+        self.schema_calls.append((table_name, schema))
+        return [
+            {"name": "id", "type": "integer", "nullable": False},
+            {"name": "customer", "type": "text", "nullable": True},
+        ]
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.disposed = False
+
+    def dispose(self):
+        self.disposed = True
+
+
+def test_project_overview_uses_connection_dsn_not_global_database_url(client):
+    _login_with_project_connection(client)
+    adapter = _FakeTenantAdapter()
+    engine = _FakeEngine()
+
+    with patch(
+        "app.dashboard.db.list_tables",
+        side_effect=AssertionError("global DATABASE_URL list_tables leaked"),
+    ) as global_list, \
+         patch("app.dashboard.db.make_adapter_for_url", return_value=adapter) as make_adapter, \
+         patch("app.dashboard.create_engine", return_value=engine), \
+         patch("app.dashboard.get_latest_metric", return_value=None), \
+         patch("app.dashboard._ml_last_runs", return_value={}):
+        resp = client.get("/dashboard/")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "tenant_orders" in body
+    assert adapter.list_schema == "analytics"
+    assert engine.disposed is True
+    global_list.assert_not_called()
+    make_adapter.assert_called_once_with("postgresql://u:p@tenant-db:5432/app")
+
+
+def test_project_table_detail_uses_connection_schema_not_global_database_url(client):
+    _login_with_project_connection(client, email="detail@example.com")
+    adapter = _FakeTenantAdapter()
+
+    with patch(
+        "app.dashboard.db.list_tables",
+        side_effect=AssertionError("global DATABASE_URL list_tables leaked"),
+    ) as global_list, \
+         patch(
+             "app.dashboard.db.table_schema",
+             side_effect=AssertionError("global DATABASE_URL table_schema leaked"),
+         ) as global_schema, \
+         patch("app.dashboard.db.make_adapter_for_url", return_value=adapter), \
+         patch("app.dashboard.create_engine", return_value=_FakeEngine()), \
+         patch("app.dashboard.get_latest_metric", side_effect=_latest_factory({
+             ("tenant_orders", "row_count"): 10,
+         })), \
+         patch("app.dashboard.get_latest_null_counts", return_value={"customer": 1}):
+        resp = client.get("/dashboard/schema/tenant_orders")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "tenant_orders" in body
+    assert "customer" in body
+    assert adapter.schema_calls == [("tenant_orders", "analytics")]
+    global_list.assert_not_called()
+    global_schema.assert_not_called()
+
+
+def test_project_overview_bad_connection_does_not_fallback_to_global_database_url(client):
+    _login_with_project_connection(
+        client,
+        email="broken@example.com",
+        dsn="unknown://u:p@broken-host/db",
+    )
+
+    with patch(
+        "app.dashboard.db.list_tables",
+        side_effect=AssertionError("global DATABASE_URL list_tables leaked"),
+    ) as global_list, \
+         patch("app.dashboard.get_latest_metric", return_value=None), \
+         patch("app.dashboard._ml_last_runs", return_value={}):
+        resp = client.get("/dashboard/")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Нет таблиц для мониторинга" in body
+    assert "Нет подключений" not in body
+    global_list.assert_not_called()
 
 
 def test_healthz_still_works(client):


### PR DESCRIPTION
## Описание

После перехода на multi-tenant архитектуру (Sprint 3) `overview()`, `schema_view()` и `table_detail()` продолжали читать live-схему через глобальный `DATABASE_URL` из `.env`. Пользователь подключал свою БД, но видел таблицы dev-Postgres'а приложения.

### Что изменено

**`app/db.py`**
- `_connect_args(url)` → публичный `connect_args_for_url(url)` с docstring; `get_engine()` переведён на новое имя.

**`app/dashboard.py`**
- `_with_project_adapter(conn_row, fn)` — ядро фикса: расшифровывает DSN, создаёт временный `NullPool` engine, запускает callback через `db.using_engine(engine, adapter)`. На любой ошибке (невалидный ciphertext, недоступный хост, неизвестная схема URL) логирует WARNING и возвращает `[]` — **без фолбека на глобальный `DATABASE_URL`**. `finally: engine.dispose()` — нет утечки соединений. Iceberg: `engine=None` явно поддержан в `using_engine()`.
- `_list_tables_for_dashboard(project, connections)` и `_table_schema_for_dashboard(...)` — обёртки над helper'ом; при `project=None` сохраняют legacy-путь для анонимных пользователей.
- `_columns_with_nulls()` получила `schema_columns` keyword-аргумент — принимает готовые колонки от adapter'а вместо вызова `db.table_schema()`.
- `overview()`, `schema_view()`, `table_detail()` переведены на новые helpers.
- Поведение #137 сохранено: авторизованный пользователь без проекта/подключений не видит legacy-данные.

**`tests/test_dashboard.py`**
- `_fernet_key` autouse-фикстура — изолированный Fernet-ключ на каждый тест.
- `_login_with_project_connection()` helper — регистрирует пользователя с зашифрованным подключением.
- 3 регрессионных теста: `db.list_tables` / `db.table_schema` поднимают `AssertionError` если вызваны, гарантируя что глобальный `DATABASE_URL` не используется ни при рабочем подключении, ни при битом DSN.

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены (42 passed)
- [x] `pytest` проходит локально
- [x] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы

## Связанные issues

- Closes #147