### PR TITLE
fix(#146): anomaly_scores / changepoints / drift_reports скоупированы по project_id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ reset-metrics:
 	$(MAKE) warmup-ml
 
 warmup-ml:
-	docker compose run --rm --build app python -m scripts.warmup_ml
+	docker compose run --rm --build app python -m scripts.warmup_ml \
+		--project-id $(PROJECT_ID)
 
 # ── Локальный Postgres для разработки ────────────────────────────────
 db-up:

--- a/app/api.py
+++ b/app/api.py
@@ -135,7 +135,7 @@ def drift(table_name: str):
     """
     from app.metrics_storage import get_drift_report
 
-    return jsonify(get_drift_report(table_name))
+    return jsonify(get_drift_report(table_name, _current_project_id()))
 
 
 @api.route("/changepoints/<table_name>")
@@ -152,7 +152,12 @@ def changepoints(table_name: str):
         return jsonify({"error": f"metric must be one of {sorted(_VALID_METRICS)}"}), 400
     if range_str not in _RANGES:
         return jsonify({"error": f"range must be one of {sorted(_RANGES)}"}), 400
-    rows = get_changepoints(table_name, metric_name=metric, window=_RANGES[range_str])
+    rows = get_changepoints(
+        table_name,
+        project_id=_current_project_id(),
+        metric_name=metric,
+        window=_RANGES[range_str],
+    )
     return jsonify(rows)
 
 
@@ -183,14 +188,15 @@ def anomalies(table_name: str):
     if range_str not in _RANGES:
         return jsonify({"error": f"range must be one of {sorted(_RANGES)}"}), 400
     window = _RANGES[range_str]
-    scores = get_anomaly_scores(table_name, window=window)
+    project_id = _current_project_id()
+    scores = get_anomaly_scores(table_name, project_id=project_id, window=window)
     if any(s["is_anomaly"] for s in scores):
         # Attach per-feature values + z-scores so the UI can show which of
         # the 4 dimensions (row_count / null_rate / Δrow_count / Δnull_rate)
         # actually drove each anomaly. Computed lazily (no DB migration).
         from ml.anomaly_detector import feature_breakdown
 
-        details = feature_breakdown(table_name, window=window)
+        details = feature_breakdown(table_name, window=window, project_id=project_id)
         for s in scores:
             if s["is_anomaly"] and s["ts"] in details:
                 s["features"] = details[s["ts"]]
@@ -227,7 +233,7 @@ def explain():
     if table not in known_tables:
         return jsonify({"error": "table not found"}), 404
 
-    result = explain_anomaly(table, metric, ts)
+    result = explain_anomaly(table, metric, ts, project_id=_current_project_id())
     save_explanation(
         table=table,
         metric=metric,

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -195,13 +195,14 @@ def overview():
         "overview.html",
         tables=tables,
         summary=summary,
-        ml_last_runs={} if (needs_first_project or needs_first_connection) else _ml_last_runs(),
+        ml_last_runs={} if (needs_first_project or needs_first_connection)
+        else _ml_last_runs(_current_project_id()),
         needs_first_project=needs_first_project,
         needs_first_connection=needs_first_connection,
     )
 
 
-def _ml_last_runs() -> dict[str, str | None]:
+def _ml_last_runs(project_id: str) -> dict[str, str | None]:
     """Last-run timestamp (UTC, "YYYY-MM-DD HH:MM") per ML model."""
     from sqlalchemy import text
 
@@ -215,9 +216,26 @@ def _ml_last_runs() -> dict[str, str | None]:
         "drift": None,
     }
     with get_engine().connect() as conn:
-        out["isolation_forest"] = conn.execute(text("SELECT MAX(ts) FROM anomaly_scores")).scalar()
-        out["pelt"] = conn.execute(text("SELECT MAX(detected_at) FROM changepoints")).scalar()
-        out["drift"] = conn.execute(text("SELECT MAX(computed_at) FROM drift_reports")).scalar()
+        out["isolation_forest"] = conn.execute(
+            text("SELECT MAX(ts) FROM anomaly_scores WHERE project_id = :project_id"),
+            {"project_id": project_id},
+        ).scalar()
+        out["pelt"] = conn.execute(
+            text("""
+                SELECT MAX(detected_at)
+                FROM changepoints
+                WHERE project_id = :project_id
+            """),
+            {"project_id": project_id},
+        ).scalar()
+        out["drift"] = conn.execute(
+            text("""
+                SELECT MAX(computed_at)
+                FROM drift_reports
+                WHERE project_id = :project_id
+            """),
+            {"project_id": project_id},
+        ).scalar()
     # Prophet не пишет в БД — обученные модели лежат в models/*.joblib,
     # mtime самого свежего файла = время последнего ночного переобучения.
     if MODELS_DIR.exists():
@@ -262,7 +280,10 @@ def schema_view():
                 name, entry["schema"], snapshot["row_count"],
                 schema_columns=schema_cols,
             )
-            drift_by_col = {d["column"]: d for d in get_drift_report(name)}
+            drift_by_col = {
+                d["column"]: d
+                for d in get_drift_report(name, _current_project_id())
+            }
             for c in cols:
                 d = drift_by_col.get(c["name"])
                 c["drift"] = d
@@ -377,7 +398,10 @@ def table_detail(table_name: str):
     columns = _columns_with_nulls(
         table_name, schema, snapshot["row_count"], schema_columns=schema_cols
     )
-    drift_by_col = {d["column"]: d for d in get_drift_report(table_name)}
+    drift_by_col = {
+        d["column"]: d
+        for d in get_drift_report(table_name, _current_project_id())
+    }
     for c in columns:
         c["drift"] = drift_by_col.get(c["name"])
     schema_events = get_schema_events(table_name, window=timedelta(days=30))

--- a/app/llm.py
+++ b/app/llm.py
@@ -33,7 +33,9 @@ def _context_window(ts: str) -> timedelta:
         return timedelta(hours=48)
 
 
-def _build_prompt(table: str, metric: str, ts: str) -> str:
+def _build_prompt(
+    table: str, metric: str, ts: str, project_id: str = "legacy"
+) -> str:
     schema = get_schema_snapshot(table) or []
     schema_text = ", ".join(
         f"{c['name']} {c['type']}{'?' if c.get('nullable') else ''}"
@@ -41,11 +43,12 @@ def _build_prompt(table: str, metric: str, ts: str) -> str:
     ) or "unknown"
 
     window = _context_window(ts)
-    # #53: LLM context reads 'legacy' tenant; per-project anomaly explain in #54.
-    recent_rc = get_metrics(table, "row_count", "legacy", window=window)
-    recent_nr = get_metrics(table, "null_rate", "legacy", window=window)
-    changepoints = get_changepoints(table, window=max(timedelta(days=14), window))
-    anomaly_scores = get_anomaly_scores(table, window=window)
+    recent_rc = get_metrics(table, "row_count", project_id, window=window)
+    recent_nr = get_metrics(table, "null_rate", project_id, window=window)
+    changepoints = get_changepoints(
+        table, window=max(timedelta(days=14), window), project_id=project_id
+    )
+    anomaly_scores = get_anomaly_scores(table, project_id=project_id, window=window)
 
     # Limit context to rows at or before ts so the LLM sees the state
     # at the moment of the anomaly, not current state.
@@ -236,7 +239,9 @@ def _rule_based_explain(table: str, metric: str, ts: str) -> dict:
     }
 
 
-def explain_anomaly(table: str, metric: str, ts: str) -> dict:
+def explain_anomaly(
+    table: str, metric: str, ts: str, project_id: str = "legacy"
+) -> dict:
     """Orchestrate LLM explanation with cache bypass (cache handled in the API layer).
 
     Returns {explanation, suggested_fix, confidence}.
@@ -246,7 +251,7 @@ def explain_anomaly(table: str, metric: str, ts: str) -> dict:
         return _rule_based_explain(table, metric, ts)
 
     try:
-        prompt = _build_prompt(table, metric, ts)
+        prompt = _build_prompt(table, metric, ts, project_id=project_id)
         raw = _call_nim(prompt)
         parsed = _parse_nim_response(raw)
         if parsed:

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -133,6 +133,192 @@ def _table_exists(engine: Engine, table: str) -> bool:
     return row is not None
 
 
+_PROJECT_SCOPED_ML_TABLES = {
+    "anomaly_scores": {
+        "columns": [
+            "project_id", "ts", "table_name", "score", "is_anomaly",
+        ],
+        "select": (
+            "'legacy' AS project_id, ts, table_name, score, is_anomaly"
+        ),
+        "sqlite_ddl": """
+            CREATE TABLE anomaly_scores__new (
+                project_id  TEXT NOT NULL DEFAULT 'legacy',
+                ts          TEXT NOT NULL,
+                table_name  TEXT NOT NULL,
+                score       REAL NOT NULL,
+                is_anomaly  INTEGER NOT NULL,
+                PRIMARY KEY (project_id, ts, table_name)
+            )
+        """,
+        "postgres_pk": ["project_id", "ts", "table_name"],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_anomaly_scores_table_ts "
+            "ON anomaly_scores (table_name, ts)",
+            "CREATE INDEX IF NOT EXISTS idx_anomaly_scores_project_ts "
+            "ON anomaly_scores (project_id, ts DESC)",
+        ],
+    },
+    "changepoints": {
+        "columns": [
+            "project_id", "ts", "table_name", "metric_name", "score",
+            "value_before", "value_after", "detected_at",
+        ],
+        "select": (
+            "'legacy' AS project_id, ts, table_name, metric_name, score, "
+            "value_before, value_after, detected_at"
+        ),
+        "sqlite_ddl": """
+            CREATE TABLE changepoints__new (
+                project_id    TEXT NOT NULL DEFAULT 'legacy',
+                ts            TEXT NOT NULL,
+                table_name    TEXT NOT NULL,
+                metric_name   TEXT NOT NULL,
+                score         REAL NOT NULL,
+                value_before  REAL NOT NULL,
+                value_after   REAL NOT NULL,
+                detected_at   TEXT NOT NULL,
+                PRIMARY KEY (project_id, ts, table_name, metric_name)
+            )
+        """,
+        "postgres_pk": ["project_id", "ts", "table_name", "metric_name"],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_changepoints_table_metric_ts "
+            "ON changepoints (table_name, metric_name, ts)",
+            "CREATE INDEX IF NOT EXISTS idx_changepoints_project_ts "
+            "ON changepoints (project_id, detected_at DESC)",
+        ],
+    },
+    "drift_reports": {
+        "columns": [
+            "project_id", "table_name", "column_name", "data_type", "psi",
+            "ks_pvalue", "is_drift", "severity", "computed_at",
+        ],
+        "select": (
+            "'legacy' AS project_id, table_name, column_name, data_type, psi, "
+            "ks_pvalue, is_drift, severity, computed_at"
+        ),
+        "sqlite_ddl": """
+            CREATE TABLE drift_reports__new (
+                project_id  TEXT NOT NULL DEFAULT 'legacy',
+                table_name  TEXT NOT NULL,
+                column_name TEXT NOT NULL,
+                data_type   TEXT,
+                psi         REAL,
+                ks_pvalue   REAL,
+                is_drift    INTEGER NOT NULL,
+                severity    TEXT NOT NULL,
+                computed_at TEXT NOT NULL,
+                PRIMARY KEY (project_id, table_name, column_name)
+            )
+        """,
+        "postgres_pk": ["project_id", "table_name", "column_name"],
+        "indexes": [
+            "CREATE INDEX IF NOT EXISTS idx_drift_reports_table "
+            "ON drift_reports (table_name)",
+            "CREATE INDEX IF NOT EXISTS idx_drift_reports_project_ts "
+            "ON drift_reports (project_id, computed_at DESC)",
+        ],
+    },
+}
+
+
+def _sqlite_pk_columns(engine: Engine, table: str) -> list[str]:
+    with engine.connect() as conn:
+        rows = conn.execute(text(f"PRAGMA table_info({table})")).fetchall()
+    return [r[1] for r in sorted((r for r in rows if r[5]), key=lambda r: r[5])]
+
+
+def _postgres_pk_columns(engine: Engine, table: str) -> list[str]:
+    with engine.connect() as conn:
+        rows = conn.execute(text("""
+            SELECT a.attname
+            FROM pg_index i
+            JOIN pg_attribute a
+              ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+            WHERE i.indrelid = CAST(:table_name AS regclass)
+              AND i.indisprimary
+            ORDER BY array_position(i.indkey, a.attnum)
+        """), {"table_name": table}).fetchall()
+    return [r[0] for r in rows]
+
+
+def _postgres_pk_constraint(engine: Engine, table: str) -> str | None:
+    with engine.connect() as conn:
+        row = conn.execute(text("""
+            SELECT conname
+            FROM pg_constraint
+            WHERE conrelid = CAST(:table_name AS regclass)
+              AND contype = 'p'
+        """), {"table_name": table}).fetchone()
+    return row[0] if row else None
+
+
+def _migrate_sqlite_project_scoped_ml_table(
+    engine: Engine, table: str, spec: dict
+) -> None:
+    desired_pk = spec["postgres_pk"]
+    if (
+        "project_id" in _existing_columns(engine, table)
+        and _sqlite_pk_columns(engine, table) == desired_pk
+    ):
+        return
+    columns = ", ".join(spec["columns"])
+    has_project_id = "project_id" in _existing_columns(engine, table)
+    with engine.begin() as conn:
+        conn.execute(text(f"DROP TABLE IF EXISTS {table}__new"))
+        conn.execute(text(spec["sqlite_ddl"]))
+        if has_project_id:
+            select_cols = columns
+        else:
+            select_cols = spec["select"]
+        conn.execute(text(
+            f"INSERT INTO {table}__new ({columns}) "
+            f"SELECT {select_cols} FROM {table}"
+        ))
+        conn.execute(text(f"DROP TABLE {table}"))
+        conn.execute(text(f"ALTER TABLE {table}__new RENAME TO {table}"))
+        for index_sql in spec["indexes"]:
+            conn.execute(text(index_sql))
+    logger.info("%s migrated to project-scoped primary key", table)
+
+
+def _migrate_postgres_project_scoped_ml_table(
+    engine: Engine, table: str, spec: dict
+) -> None:
+    desired_pk = spec["postgres_pk"]
+    columns = _existing_columns(engine, table)
+    pk_columns = _postgres_pk_columns(engine, table)
+    if "project_id" in columns and pk_columns == desired_pk:
+        return
+    constraint = _postgres_pk_constraint(engine, table)
+
+    with engine.begin() as conn:
+        if "project_id" not in columns:
+            conn.execute(text(
+                f"ALTER TABLE {table} ADD COLUMN project_id TEXT NOT NULL "
+                "DEFAULT 'legacy'"
+            ))
+        if constraint:
+            conn.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT {constraint}"))
+        conn.execute(text(
+            f"ALTER TABLE {table} ADD PRIMARY KEY ({', '.join(desired_pk)})"
+        ))
+        for index_sql in spec["indexes"]:
+            conn.execute(text(index_sql))
+    logger.info("%s migrated to project-scoped primary key", table)
+
+
+def _migrate_project_scoped_ml_tables(engine: Engine) -> None:
+    for table, spec in _PROJECT_SCOPED_ML_TABLES.items():
+        if not _table_exists(engine, table):
+            continue
+        if _is_postgres():
+            _migrate_postgres_project_scoped_ml_table(engine, table, spec)
+        else:
+            _migrate_sqlite_project_scoped_ml_table(engine, table, spec)
+
+
 def _migrate_existing_schema(engine: Engine) -> None:
     """ALTER pre-#53/#137 tables to match the current schema file.
 
@@ -182,6 +368,8 @@ def _migrate_existing_schema(engine: Engine) -> None:
             "telegram_throttle dropped for multi-tenant migration "
             "(throttle cache reset; recreated below with project_id in PK)"
         )
+
+    _migrate_project_scoped_ml_tables(engine)
 
 
 def _is_optional_timescale_stmt(stmt: str) -> bool:
@@ -369,7 +557,7 @@ def get_latest_null_counts(
 _CLUSTER_WINDOW_HOURS = 72
 
 
-def save_changepoints(rows: Iterable[dict]) -> int:
+def save_changepoints(rows: Iterable[dict], project_id: str = "legacy") -> int:
     """Persist detected change-points with cross-run cluster deduplication.
 
     Within a ±72 h window, at most one record is kept per
@@ -382,6 +570,7 @@ def save_changepoints(rows: Iterable[dict]) -> int:
     detected_at = _iso(datetime.now(UTC))
     for r in rows:
         payload.append({
+            "project_id": project_id,
             "ts": _iso(r["ts"]),
             "table_name": r["table_name"],
             "metric_name": r["metric_name"],
@@ -395,21 +584,25 @@ def save_changepoints(rows: Iterable[dict]) -> int:
 
     insert_stmt = text(_upsert_sql(
         "changepoints",
-        ["ts", "table_name", "metric_name", "score",
+        ["project_id", "ts", "table_name", "metric_name", "score",
          "value_before", "value_after", "detected_at"],
-        conflict_columns=["ts", "table_name", "metric_name"],
+        conflict_columns=["project_id", "ts", "table_name", "metric_name"],
     ))
     # Dialect-specific time delta: julianday is SQLite-only. On Postgres the
     # ts column is TIMESTAMPTZ and we compute hours via EXTRACT(EPOCH).
     # Delete by the changepoints PK — identical on both dialects.
     delete_stmt = text("""
         DELETE FROM changepoints
-        WHERE ts = :ts AND table_name = :t AND metric_name = :m
+        WHERE project_id = :project_id
+          AND ts = :ts
+          AND table_name = :t
+          AND metric_name = :m
     """)
     if _is_postgres():
         cluster_query = text("""
             SELECT ts, score FROM changepoints
-            WHERE table_name = :t
+            WHERE project_id = :project_id
+              AND table_name = :t
               AND metric_name = :m
               AND ABS(EXTRACT(EPOCH FROM (ts - CAST(:ts AS TIMESTAMPTZ))) / 3600) <= :w
               AND (CASE WHEN value_after > value_before THEN 1 ELSE 0 END) = :dir
@@ -417,7 +610,8 @@ def save_changepoints(rows: Iterable[dict]) -> int:
     else:
         cluster_query = text("""
             SELECT ts, score FROM changepoints
-            WHERE table_name = :t
+            WHERE project_id = :project_id
+              AND table_name = :t
               AND metric_name = :m
               AND ABS(julianday(ts) - julianday(:ts)) * 24 <= :w
               AND (CASE WHEN value_after > value_before THEN 1 ELSE 0 END) = :dir
@@ -428,6 +622,7 @@ def save_changepoints(rows: Iterable[dict]) -> int:
         for row in payload:
             direction = 1 if row["value_after"] > row["value_before"] else 0
             existing = conn.execute(cluster_query, {
+                "project_id": project_id,
                 "t": row["table_name"],
                 "m": row["metric_name"],
                 "ts": row["ts"],
@@ -442,7 +637,12 @@ def save_changepoints(rows: Iterable[dict]) -> int:
                 for old in existing:
                     conn.execute(
                         delete_stmt,
-                        {"ts": old.ts, "t": row["table_name"], "m": row["metric_name"]},
+                        {
+                            "project_id": project_id,
+                            "ts": old.ts,
+                            "t": row["table_name"],
+                            "m": row["metric_name"],
+                        },
                     )
                 conn.execute(insert_stmt, row)
                 saved += 1
@@ -454,6 +654,7 @@ def get_changepoints(
     table_name: str,
     metric_name: str | None = None,
     window: timedelta = timedelta(days=14),
+    project_id: str = "legacy",
 ) -> list[dict]:
     """Return change-points for a table, oldest first. `metric_name=None`
     returns all metrics; otherwise filters."""
@@ -461,9 +662,15 @@ def get_changepoints(
     base = """
         SELECT ts, table_name, metric_name, score, value_before, value_after
         FROM changepoints
-        WHERE table_name = :table_name AND ts >= :since
+        WHERE project_id = :project_id
+          AND table_name = :table_name
+          AND ts >= :since
     """
-    params: dict[str, Any] = {"table_name": table_name, "since": since}
+    params: dict[str, Any] = {
+        "project_id": project_id,
+        "table_name": table_name,
+        "since": since,
+    }
     if metric_name is not None:
         base += " AND metric_name = :metric_name"
         params["metric_name"] = metric_name
@@ -556,11 +763,12 @@ def get_schema_events(
     ]
 
 
-def save_anomaly_scores(rows: Iterable[dict]) -> int:
+def save_anomaly_scores(rows: Iterable[dict], project_id: str = "legacy") -> int:
     """Upsert anomaly scores. Each row: {ts, table_name, score, is_anomaly}."""
     payload = []
     for r in rows:
         payload.append({
+            "project_id": project_id,
             "ts": _iso(r["ts"]),
             "table_name": r["table_name"],
             "score": float(r["score"]),
@@ -570,8 +778,8 @@ def save_anomaly_scores(rows: Iterable[dict]) -> int:
         return 0
     stmt = text(_upsert_sql(
         "anomaly_scores",
-        ["ts", "table_name", "score", "is_anomaly"],
-        conflict_columns=["ts", "table_name"],
+        ["project_id", "ts", "table_name", "score", "is_anomaly"],
+        conflict_columns=["project_id", "ts", "table_name"],
     ))
     with get_engine().begin() as conn:
         conn.execute(stmt, payload)
@@ -579,25 +787,34 @@ def save_anomaly_scores(rows: Iterable[dict]) -> int:
 
 
 def get_anomaly_scores(
-    table_name: str, window: timedelta = timedelta(days=7)
+    table_name: str,
+    project_id: str = "legacy",
+    window: timedelta = timedelta(days=7),
 ) -> list[dict]:
     """Return anomaly scores for a table within *window*, oldest first."""
     since = _iso(datetime.now(UTC) - window)
     stmt = text("""
         SELECT ts, score, is_anomaly
         FROM anomaly_scores
-        WHERE table_name = :t AND ts >= :since
+        WHERE project_id = :project_id
+          AND table_name = :t
+          AND ts >= :since
         ORDER BY ts
     """)
     with get_engine().connect() as conn:
-        rows = conn.execute(stmt, {"t": table_name, "since": since}).fetchall()
+        rows = conn.execute(
+            stmt,
+            {"project_id": project_id, "t": table_name, "since": since},
+        ).fetchall()
     return [
         {"ts": _normalize_ts(r[0]), "score": r[1], "is_anomaly": r[2]}
         for r in rows
     ]
 
 
-def save_drift_reports(table_name: str, rows: Iterable[dict]) -> int:
+def save_drift_reports(
+    table_name: str, rows: Iterable[dict], project_id: str = "legacy"
+) -> int:
     """Полностью переписать кеш drift для одной таблицы.
 
     Рассчитанный снапшот PSI/KS — слайд по 7-дневному окну, поэтому хранить
@@ -607,6 +824,7 @@ def save_drift_reports(table_name: str, rows: Iterable[dict]) -> int:
     computed_at = _iso(datetime.now(UTC))
     for r in rows:
         payload.append({
+            "project_id": project_id,
             "table_name": table_name,
             "column_name": r["column"],
             "data_type": r.get("data_type"),
@@ -618,16 +836,19 @@ def save_drift_reports(table_name: str, rows: Iterable[dict]) -> int:
         })
     with get_engine().begin() as conn:
         conn.execute(
-            text("DELETE FROM drift_reports WHERE table_name = :t"),
-            {"t": table_name},
+            text("""
+                DELETE FROM drift_reports
+                WHERE project_id = :project_id AND table_name = :t
+            """),
+            {"project_id": project_id, "t": table_name},
         )
         if payload:
             conn.execute(
                 text("""
                     INSERT INTO drift_reports
-                        (table_name, column_name, data_type, psi, ks_pvalue,
+                        (project_id, table_name, column_name, data_type, psi, ks_pvalue,
                          is_drift, severity, computed_at)
-                    VALUES (:table_name, :column_name, :data_type, :psi,
+                    VALUES (:project_id, :table_name, :column_name, :data_type, :psi,
                             :ks_pvalue, :is_drift, :severity, :computed_at)
                 """),
                 payload,
@@ -635,16 +856,19 @@ def save_drift_reports(table_name: str, rows: Iterable[dict]) -> int:
     return len(payload)
 
 
-def get_drift_report(table_name: str) -> list[dict]:
+def get_drift_report(table_name: str, project_id: str = "legacy") -> list[dict]:
     """Кешированный drift по таблице, отсортированный по убыванию PSI."""
     stmt = text("""
         SELECT column_name, data_type, psi, ks_pvalue, is_drift, severity
         FROM drift_reports
-        WHERE table_name = :t
+        WHERE project_id = :project_id
+          AND table_name = :t
         ORDER BY COALESCE(psi, 0) DESC
     """)
     with get_engine().connect() as conn:
-        rows = conn.execute(stmt, {"t": table_name}).fetchall()
+        rows = conn.execute(
+            stmt, {"project_id": project_id, "t": table_name}
+        ).fetchall()
     return [
         {
             "column": r[0],
@@ -788,10 +1012,12 @@ def _fetch_history_metric_rows(
     ]
 
 
-def _fetch_anomalies_by_ts(window: timedelta | None = timedelta(days=30)) -> dict[str, int]:
+def _fetch_anomalies_by_ts(
+    project_id: str, window: timedelta | None = timedelta(days=30)
+) -> dict[str, int]:
     """Count IF anomalies per collector tick within the window."""
-    params: dict[str, Any] = {}
-    where = "WHERE is_anomaly = 1"
+    params: dict[str, Any] = {"project_id": project_id}
+    where = "WHERE project_id = :project_id AND is_anomaly = 1"
     if window is not None:
         params["since"] = (datetime.now(UTC) - window).isoformat()
         where += " AND ts >= :since"
@@ -813,10 +1039,9 @@ def _history_aggregate(
     Null spikes: null_rate jump by >= 5 pp compared with the previous run
     for the same table/column metric. Rule-based heuristic on raw NULL rate.
     Anomalies: IF model verdicts from anomaly_scores keyed by the same ts.
-    NB: anomaly_scores still global (not scoped) — separate ticket.
     """
     rows = _fetch_history_metric_rows(project_id=project_id, window=window)
-    anomalies_by_ts = _fetch_anomalies_by_ts(window=window)
+    anomalies_by_ts = _fetch_anomalies_by_ts(project_id=project_id, window=window)
 
     tables_by_ts: dict[str, set[str]] = {}
     problems_by_ts: dict[str, int] = {}
@@ -1722,4 +1947,3 @@ def purge_old_failed_logins(retention: timedelta = timedelta(days=30)) -> int:
     with get_engine().begin() as conn:
         result = conn.execute(stmt, {"cutoff": cutoff})
     return result.rowcount or 0
-

--- a/ml/anomaly_detector.py
+++ b/ml/anomaly_detector.py
@@ -20,6 +20,7 @@ shifts with every request.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -66,7 +67,7 @@ FEATURE_NAMES = ("row_count", "null_rate", "d_row_count", "d_null_rate")
 
 
 def _load_features(
-    table: str, window: timedelta
+    table: str, window: timedelta, project_id: str = "legacy"
 ) -> tuple[list[datetime], np.ndarray]:
     """Load (timestamps, feature_matrix) for *table* over *window*.
 
@@ -78,9 +79,8 @@ def _load_features(
     if not _HAS_SKLEARN:
         raise ImportError("scikit-learn is required for anomaly detection")
 
-    # #53: ML jobs are global today (legacy tenant); #54 will scope per project.
-    rc_rows = get_metrics(table, "row_count", "legacy", window=window)
-    nr_rows = get_metrics(table, "null_rate", "legacy", window=window)
+    rc_rows = get_metrics(table, "row_count", project_id, window=window)
+    nr_rows = get_metrics(table, "null_rate", project_id, window=window)
 
     rc_map = {r["ts"]: float(r["value"]) for r in rc_rows}
     nr_map = {r["ts"]: float(r["value"]) for r in nr_rows}
@@ -107,18 +107,23 @@ def _load_features(
     return timestamps, X
 
 
-def _model_path(table: str) -> Path:
+def _model_path(table: str, project_id: str = "legacy") -> Path:
     safe = table.replace("/", "_").replace(" ", "_")
-    return MODELS_DIR / f"{safe}__anomaly.joblib"
+    if project_id == "legacy":
+        return MODELS_DIR / f"{safe}__anomaly.joblib"
+    safe_project = project_id.replace("/", "_").replace(" ", "_")
+    return MODELS_DIR / f"{safe_project}__{safe}__anomaly.joblib"
 
 
-def train(table: str) -> dict[str, Any]:
+def train(table: str, project_id: str = "legacy") -> dict[str, Any]:
     """Fit and persist an anomaly-detection model for *table*.
 
     Returns metadata dict: {n_points, trained_at}.
     Raises InsufficientDataError when history is too short.
     """
-    timestamps, X = _load_features(table, window=timedelta(days=TRAIN_WINDOW_DAYS))
+    timestamps, X = _load_features(
+        table, window=timedelta(days=TRAIN_WINDOW_DAYS), project_id=project_id
+    )
     if len(timestamps) < MIN_POINTS:
         raise InsufficientDataError(
             f"need at least {MIN_POINTS} points for {table}, got {len(timestamps)}"
@@ -146,17 +151,17 @@ def train(table: str) -> dict[str, Any]:
     }
     if _HAS_JOBLIB:
         try:
-            _joblib.dump(payload, _model_path(table))
+            _joblib.dump(payload, _model_path(table, project_id))
         except Exception as exc:
             logger.warning("Failed to persist anomaly model for %s: %s", table, exc)
 
     return {"n_points": len(timestamps), "trained_at": payload["trained_at"]}
 
 
-def _load_model(table: str) -> dict | None:
+def _load_model(table: str, project_id: str = "legacy") -> dict | None:
     if not _HAS_JOBLIB:
         return None
-    path = _model_path(table)
+    path = _model_path(table, project_id)
     if not path.exists():
         return None
     try:
@@ -169,6 +174,7 @@ def _load_model(table: str) -> dict | None:
 def score_table(
     table: str,
     window_days: int = 14,
+    project_id: str = "legacy",
 ) -> list[dict]:
     """Score every tick in *window_days* using the persisted model.
 
@@ -178,17 +184,19 @@ def score_table(
     If no persisted model exists, attempts an on-demand train. Raises
     InsufficientDataError when there is not enough data for training.
     """
-    persisted = _load_model(table)
+    persisted = _load_model(table, project_id)
     if persisted is None:
-        train(table)
-        persisted = _load_model(table)
+        train(table, project_id=project_id)
+        persisted = _load_model(table, project_id)
     if persisted is None:
         raise RuntimeError(
             f"anomaly model for {table} was trained but could not be loaded — "
             f"check write permissions on {MODELS_DIR}"
         )
 
-    timestamps, X = _load_features(table, window=timedelta(days=window_days))
+    timestamps, X = _load_features(
+        table, window=timedelta(days=window_days), project_id=project_id
+    )
     if len(timestamps) == 0:
         return []
 
@@ -209,7 +217,9 @@ def score_table(
     ]
 
 
-def feature_breakdown(table: str, window: timedelta) -> dict[str, dict]:
+def feature_breakdown(
+    table: str, window: timedelta, project_id: str = "legacy"
+) -> dict[str, dict]:
     """Return per-tick feature values and z-scores for *table* over *window*.
 
     Maps ts (ISO str) → {values, z_scores, top_feature}. The z-scores come
@@ -221,11 +231,11 @@ def feature_breakdown(table: str, window: timedelta) -> dict[str, dict]:
     Returns {} when the model is missing or there is too little data to
     compute deltas. Never raises.
     """
-    persisted = _load_model(table)
+    persisted = _load_model(table, project_id)
     if persisted is None:
         return {}
     try:
-        timestamps, X = _load_features(table, window=window)
+        timestamps, X = _load_features(table, window=window, project_id=project_id)
     except (InsufficientDataError, ImportError):
         return {}
     if len(timestamps) == 0:
@@ -251,15 +261,21 @@ def feature_breakdown(table: str, window: timedelta) -> dict[str, dict]:
     return out
 
 
-def retrain_all() -> dict[str, int]:
+def retrain_all(
+    project_id: str = "legacy", tables: Iterable[str] | None = None
+) -> dict[str, int]:
     """Retrain anomaly models for every monitored table. Used by the nightly job."""
-    from app.db import list_tables
+    if tables is None:
+        from app.db import list_tables
+
+        table_names = [t["table_name"] for t in list_tables()]
+    else:
+        table_names = list(tables)
 
     counts: dict[str, int] = {"trained": 0, "skipped": 0, "errors": 0}
-    for t in list_tables():
-        name = t["table_name"]
+    for name in table_names:
         try:
-            train(name)
+            train(name, project_id=project_id)
             counts["trained"] += 1
         except InsufficientDataError:
             counts["skipped"] += 1

--- a/ml/changepoint.py
+++ b/ml/changepoint.py
@@ -137,6 +137,7 @@ def detect_changepoints(
     table: str,
     metric: str,
     window_days: int = DEFAULT_WINDOW_DAYS,
+    project_id: str = "legacy",
 ) -> list[dict]:
     """Return change-point events for a single (table, metric) series.
 
@@ -144,8 +145,7 @@ def detect_changepoints(
     Scores below ``MIN_SCORE`` are suppressed — they fall into noise and
     polluting the chart with weak annotations is worse than missing them.
     """
-    # #53: global ML jobs read 'legacy'. Per-project change-point detection in #54.
-    rows = get_metrics(table, metric, "legacy", window=timedelta(days=window_days))
+    rows = get_metrics(table, metric, project_id, window=timedelta(days=window_days))
     if len(rows) < MIN_POINTS:
         return []
     timestamps = [_parse_ts(r["ts"]) for r in rows]
@@ -221,27 +221,35 @@ def _dedupe(events: list[dict]) -> list[dict]:
 def detect_all(
     metrics: Iterable[str] = ("row_count", "null_rate"),
     window_days: int = DEFAULT_WINDOW_DAYS,
+    project_id: str = "legacy",
+    tables: Iterable[str] | None = None,
 ) -> dict:
     """Run detection across every monitored (table, metric) and persist hits.
 
     Returns counts dict plus ``events`` list so callers can act on newly
     detected change-points without an extra DB round-trip.
     """
-    from app.db import list_tables  # local import — avoids app import cycle
+    if tables is None:
+        from app.db import list_tables  # local import — avoids app import cycle
+
+        table_names = [t["table_name"] for t in list_tables()]
+    else:
+        table_names = list(tables)
 
     counts: dict = {"detected": 0, "tables": 0, "errors": 0, "events": []}
-    for t in list_tables():
+    for name in table_names:
         counts["tables"] += 1
-        name = t["table_name"]
         for m in metrics:
             try:
-                events = detect_changepoints(name, m, window_days=window_days)
+                events = detect_changepoints(
+                    name, m, window_days=window_days, project_id=project_id
+                )
             except Exception as e:  # pragma: no cover - defensive
                 logger.exception("changepoint detection failed for %s/%s: %s", name, m, e)
                 counts["errors"] += 1
                 continue
             if events:
-                save_changepoints(events)
+                save_changepoints(events, project_id=project_id)
                 counts["detected"] += len(events)
                 counts["events"].extend(events)
     logger.info("Change-point sweep complete: %s", {k: v for k, v in counts.items() if k != "events"})

--- a/ml/drift.py
+++ b/ml/drift.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import math
+from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import text
@@ -110,12 +111,13 @@ def _severity(psi_value: float) -> str:
     return "ok"
 
 
-def _load_distributions(table_name: str, since: datetime) -> list[dict]:
+def _load_distributions(
+    table_name: str, since: datetime, project_id: str = "legacy"
+) -> list[dict]:
     """Pull every column_distribution snapshot for a table since `since`.
 
     Decodes JSON tags eagerly so callers can iterate without re-parsing.
     """
-    # #53: drift jobs are global today → 'legacy' tenant. Per-project drift in #54.
     stmt = text("""
         SELECT ts, tags
         FROM metrics
@@ -127,7 +129,7 @@ def _load_distributions(table_name: str, since: datetime) -> list[dict]:
     """)
     with get_engine().connect() as conn:
         rows = conn.execute(stmt, {
-            "project_id": "legacy",
+            "project_id": project_id,
             "table_name": table_name,
             "since": since.isoformat(timespec="seconds"),
         }).fetchall()
@@ -177,7 +179,9 @@ def _numeric_pairs(buckets: list[dict]) -> list[tuple[float, int]]:
 
 
 def compute_drift(
-    table_name: str, baseline_days: int = BASELINE_DAYS
+    table_name: str,
+    baseline_days: int = BASELINE_DAYS,
+    project_id: str = "legacy",
 ) -> list[dict]:
     """Return per-column drift report for `table_name`.
 
@@ -187,7 +191,7 @@ def compute_drift(
     "insufficient_data" and is_drift is False.
     """
     since = datetime.now(UTC) - timedelta(days=baseline_days)
-    snapshots = _load_distributions(table_name, since)
+    snapshots = _load_distributions(table_name, since, project_id=project_id)
     if not snapshots:
         return []
     baseline, current = _split_baseline_current(snapshots)
@@ -231,20 +235,26 @@ def compute_drift(
     return out
 
 
-def compute_and_store_drift_all() -> dict[str, int]:
+def compute_and_store_drift_all(
+    project_id: str = "legacy", tables: Iterable[str] | None = None
+) -> dict[str, int]:
     """Пересчитать drift по всем таблицам и сложить в кеш `drift_reports`.
 
     Вызывается из warmup_ml после сидинга и из тика коллектора.
     Идемпотентно: каждая таблица перезаписывается целиком.
     """
-    from app.db import list_tables  # локальный импорт — обходим app↔ml цикл
+    if tables is None:
+        from app.db import list_tables  # локальный импорт — обходим app↔ml цикл
+
+        table_names = [t["table_name"] for t in list_tables()]
+    else:
+        table_names = list(tables)
     from app.metrics_storage import save_drift_reports
 
     counts = {"tables": 0, "rows": 0}
-    for t in list_tables():
-        name = t["table_name"]
-        report = compute_drift(name)
-        save_drift_reports(name, report)
+    for name in table_names:
+        report = compute_drift(name, project_id=project_id)
+        save_drift_reports(name, report, project_id=project_id)
         counts["tables"] += 1
         counts["rows"] += len(report)
     return counts

--- a/scripts/live_demo.py
+++ b/scripts/live_demo.py
@@ -129,12 +129,12 @@ def _run_collector_tick(project_id: str, connection_id: str | None) -> int:
     return int(latest["value"]) if latest else 0
 
 
-def _run_changepoint_pass() -> dict:
+def _run_changepoint_pass(project_id: str) -> dict:
     """Optional: detect change-points after collection so the UI's red
     dashed lines update during the demo (the scheduled job runs hourly —
     too slow for a live walk-through)."""
     from ml.changepoint import detect_all
-    return detect_all()
+    return detect_all(project_id=project_id)
 
 
 def _setup_logging(verbose: bool) -> None:
@@ -231,7 +231,7 @@ def main() -> None:
         stored_row_count = _run_collector_tick(args.project_id, args.connection_id)
         cp_summary = ""
         if args.changepoints:
-            cp = _run_changepoint_pass()
+            cp = _run_changepoint_pass(args.project_id)
             cp_summary = f"  cp={cp.get('detected', 0)}"
 
         flag = "  ★ INCIDENT" if is_incident else ""

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -17,6 +17,7 @@ CREATE INDEX IF NOT EXISTS idx_metrics_project_table_metric_ts
 
 -- Detected change-points (PELT/RBF) — written by the hourly detection job.
 CREATE TABLE IF NOT EXISTS changepoints (
+    project_id    TEXT NOT NULL DEFAULT 'legacy',
     ts            TEXT NOT NULL,   -- ISO 8601 UTC of the detected breakpoint
     table_name    TEXT NOT NULL,
     metric_name   TEXT NOT NULL,
@@ -24,11 +25,13 @@ CREATE TABLE IF NOT EXISTS changepoints (
     value_before  REAL NOT NULL,
     value_after   REAL NOT NULL,
     detected_at   TEXT NOT NULL,
-    PRIMARY KEY (ts, table_name, metric_name)
+    PRIMARY KEY (project_id, ts, table_name, metric_name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_changepoints_table_metric_ts
     ON changepoints (table_name, metric_name, ts);
+CREATE INDEX IF NOT EXISTS idx_changepoints_project_ts
+    ON changepoints (project_id, detected_at DESC);
 
 -- Latest known column-list per table — written by the schema collector
 -- after every successful snapshot. Stored as JSON so we don't have to
@@ -58,20 +61,24 @@ CREATE INDEX IF NOT EXISTS idx_schema_events_table_ts
 -- Anomaly scores from Isolation Forest — written by the collect tick and
 -- the nightly retrain job. One row per (ts, table); upsert on re-run.
 CREATE TABLE IF NOT EXISTS anomaly_scores (
+    project_id  TEXT NOT NULL DEFAULT 'legacy',
     ts          TEXT NOT NULL,
     table_name  TEXT NOT NULL,
     score       REAL NOT NULL,   -- raw decision_function value; < 0 means anomaly
     is_anomaly  INTEGER NOT NULL, -- 1 if anomaly, 0 otherwise
-    PRIMARY KEY (ts, table_name)
+    PRIMARY KEY (project_id, ts, table_name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_anomaly_scores_table_ts
     ON anomaly_scores (table_name, ts);
+CREATE INDEX IF NOT EXISTS idx_anomaly_scores_project_ts
+    ON anomaly_scores (project_id, ts DESC);
 
 -- Кешированный отчёт drift по каждой (таблица, колонка). Перезаписывается
 -- целиком при пересчёте — на странице /schema читаем отсюда, а не считаем
 -- заново на каждый запрос. Обновляется warmup_ml + sweep'ом коллектора.
 CREATE TABLE IF NOT EXISTS drift_reports (
+    project_id  TEXT NOT NULL DEFAULT 'legacy',
     table_name  TEXT NOT NULL,
     column_name TEXT NOT NULL,
     data_type   TEXT,
@@ -80,11 +87,13 @@ CREATE TABLE IF NOT EXISTS drift_reports (
     is_drift    INTEGER NOT NULL,
     severity    TEXT NOT NULL,
     computed_at TEXT NOT NULL,
-    PRIMARY KEY (table_name, column_name)
+    PRIMARY KEY (project_id, table_name, column_name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_drift_reports_table
     ON drift_reports (table_name);
+CREATE INDEX IF NOT EXISTS idx_drift_reports_project_ts
+    ON drift_reports (project_id, computed_at DESC);
 
 -- LLM-generated root-cause explanations — cached to avoid repeated NIM calls.
 -- TTL is 24 h, checked at read time via created_at.

--- a/scripts/seed_metrics_db.py
+++ b/scripts/seed_metrics_db.py
@@ -290,7 +290,7 @@ def _backfill_offset(
     При fraction=0 эффект отключён."""
     if fraction <= 0 or progress >= BACKFILL_PROGRESS:
         return 0
-    return -int(round(current * fraction))
+    return -round(current * fraction)
 
 
 def _anomaly_multiplier(
@@ -325,7 +325,7 @@ def _step_scale(current: int, steps: tuple) -> float:
 def _step_contribution(progress: float, steps: tuple, scale: float) -> int:
     if not steps:
         return 0
-    return int(round(scale * sum(c for p, c in steps if progress >= p)))
+    return round(scale * sum(c for p, c in steps if progress >= p))
 
 
 def _row_count_at(
@@ -337,7 +337,7 @@ def _row_count_at(
     anomaly_mult: float = 1.0,
 ) -> int:
     scale = _step_scale(current, profile.growth_steps)
-    total_steps = int(round(scale * sum(c for _, c in profile.growth_steps)))
+    total_steps = round(scale * sum(c for _, c in profile.growth_steps))
     # Ramp заканчивается в (current - total_steps), чтобы вместе со ступеньками
     # дать ≈ current на progress=1.
     ramp_target = max(0, current - total_steps)
@@ -350,7 +350,7 @@ def _row_count_at(
     base *= anomaly_mult
     if profile.noise_amplitude > 0:
         base *= 1 + rng.uniform(-profile.noise_amplitude, profile.noise_amplitude)
-    return max(0, int(round(base)))
+    return max(0, round(base))
 
 
 def _null_rate_at(
@@ -406,7 +406,7 @@ def _generate_metric_rows(
             rate = _null_rate_at(progress, current_rate, regression_progress_start)
             if is_spike_tick:
                 rate = min(1.0, rate + NULL_SPIKE_DELTA)
-            null_count = int(round(rc * rate))
+            null_count = round(rc * rate)
             rows.append({
                 "ts": ts, "table_name": snapshot.table_name,
                 "metric_name": "null_count", "value": null_count,
@@ -450,7 +450,7 @@ def _categorical_buckets(progress: float, drift_amount: float) -> list[dict]:
     ]
     total = sum(weights) or 1.0
     return [
-        {"value": v, "count": int(round(w / total * 1000))}
+        {"value": v, "count": round(w / total * 1000)}
         for v, w in zip(CATEGORICAL_BUCKETS, weights, strict=False)
     ]
 
@@ -462,7 +462,7 @@ def _numeric_buckets(progress: float, drift_amount: float) -> list[dict]:
     for i in range(NUMERIC_BUCKETS):
         x = float(i) * 10.0
         w = math.exp(-((x - mean) ** 2) / (2 * NUMERIC_SIGMA ** 2))
-        out.append({"value": x, "count": int(round(w * 1000))})
+        out.append({"value": x, "count": round(w * 1000)})
     return out
 
 
@@ -686,13 +686,14 @@ def _generate_schema_events(
 def _purge_existing(project_id: str = "legacy") -> int:
     """Очистить metrics и производные таблицы перед ресидом.
 
-    При project_id != "legacy" таблицы с project_id-колонкой (metrics,
-    notifications) чистятся scoped; остальные (anomaly_scores, changepoints,
-    drift_reports, schema_events, schema_snapshots) — глобально, потому что
-    project_id-скоупинга в них ещё нет (#146).
+    При project_id != "legacy" таблицы с project_id-колонкой чистятся scoped.
+    Schema tables пока остаются глобальными: schema_snapshots/schema_events ещё
+    не имеют project_id и будут вынесены в отдельную задачу.
     """
-    # Таблицы с project_id — scoped при non-legacy reset.
-    _SCOPED = {"metrics", "notifications"}
+    _SCOPED = {
+        "metrics", "notifications", "anomaly_scores", "changepoints",
+        "drift_reports",
+    }
     # Таблицы без project_id — всегда глобальный DELETE.
     _GLOBAL = [t for t in _PURGE_TABLES if t not in _SCOPED]
 
@@ -708,7 +709,7 @@ def _purge_existing(project_id: str = "legacy") -> int:
             if _GLOBAL:
                 logger.warning(
                     "--reset с project_id=%s: таблицы %s очищены глобально — "
-                    "project_id-скоупинг для них будет в отдельной задаче (#146)",
+                    "project_id-скоупинг для них будет в отдельной задаче",
                     project_id, ", ".join(_GLOBAL),
                 )
             for table_name in _GLOBAL:

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -31,6 +31,7 @@ CREATE INDEX IF NOT EXISTS idx_metrics_project_table_metric_ts
     ON metrics (project_id, table_name, metric_name, ts);
 
 CREATE TABLE IF NOT EXISTS changepoints (
+    project_id    TEXT NOT NULL DEFAULT 'legacy',
     ts            TIMESTAMPTZ NOT NULL,
     table_name    TEXT NOT NULL,
     metric_name   TEXT NOT NULL,
@@ -38,11 +39,13 @@ CREATE TABLE IF NOT EXISTS changepoints (
     value_before  DOUBLE PRECISION NOT NULL,
     value_after   DOUBLE PRECISION NOT NULL,
     detected_at   TIMESTAMPTZ NOT NULL,
-    PRIMARY KEY (ts, table_name, metric_name)
+    PRIMARY KEY (project_id, ts, table_name, metric_name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_changepoints_table_metric_ts
     ON changepoints (table_name, metric_name, ts);
+CREATE INDEX IF NOT EXISTS idx_changepoints_project_ts
+    ON changepoints (project_id, detected_at DESC);
 
 CREATE TABLE IF NOT EXISTS schema_snapshots (
     table_name  TEXT NOT NULL PRIMARY KEY,
@@ -62,17 +65,21 @@ CREATE INDEX IF NOT EXISTS idx_schema_events_table_ts
     ON schema_events (table_name, ts);
 
 CREATE TABLE IF NOT EXISTS anomaly_scores (
+    project_id  TEXT NOT NULL DEFAULT 'legacy',
     ts          TIMESTAMPTZ NOT NULL,
     table_name  TEXT NOT NULL,
     score       DOUBLE PRECISION NOT NULL,
     is_anomaly  INTEGER NOT NULL,
-    PRIMARY KEY (ts, table_name)
+    PRIMARY KEY (project_id, ts, table_name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_anomaly_scores_table_ts
     ON anomaly_scores (table_name, ts);
+CREATE INDEX IF NOT EXISTS idx_anomaly_scores_project_ts
+    ON anomaly_scores (project_id, ts DESC);
 
 CREATE TABLE IF NOT EXISTS drift_reports (
+    project_id  TEXT NOT NULL DEFAULT 'legacy',
     table_name  TEXT NOT NULL,
     column_name TEXT NOT NULL,
     data_type   TEXT,
@@ -81,11 +88,13 @@ CREATE TABLE IF NOT EXISTS drift_reports (
     is_drift    INTEGER NOT NULL,
     severity    TEXT NOT NULL,
     computed_at TIMESTAMPTZ NOT NULL,
-    PRIMARY KEY (table_name, column_name)
+    PRIMARY KEY (project_id, table_name, column_name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_drift_reports_table
     ON drift_reports (table_name);
+CREATE INDEX IF NOT EXISTS idx_drift_reports_project_ts
+    ON drift_reports (project_id, computed_at DESC);
 
 CREATE TABLE IF NOT EXISTS llm_explanations (
     table_name    TEXT NOT NULL,

--- a/scripts/warmup_ml.py
+++ b/scripts/warmup_ml.py
@@ -14,25 +14,40 @@
 """
 from __future__ import annotations
 
+import argparse
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-def warmup_changepoints() -> dict:
+def _tables_from_metrics(project_id: str) -> list[str]:
+    from sqlalchemy import text
+
+    from app.metrics_storage import get_engine
+
+    with get_engine().connect() as conn:
+        rows = conn.execute(text("""
+            SELECT DISTINCT table_name
+            FROM metrics
+            WHERE project_id = :project_id
+            ORDER BY table_name
+        """), {"project_id": project_id}).fetchall()
+    return [r[0] for r in rows]
+
+
+def warmup_changepoints(project_id: str = "legacy", tables: list[str] | None = None) -> dict:
     """Прогон PELT/CUSUM по всем (таблица × метрика) и запись в changepoints."""
     from ml.changepoint import detect_all
-    return detect_all()
+    return detect_all(project_id=project_id, tables=tables)
 
 
-def warmup_anomalies() -> dict:
+def warmup_anomalies(project_id: str = "legacy", tables: list[str] | None = None) -> dict:
     """Тренируем IsolationForest на каждой таблице и сразу скорим 14-дневное окно.
 
     Ценим обе вещи: persisted-модель, чтобы тики коллектора могли скорить
     дальше (`_score_recent_anomalies`), и таблицу `anomaly_scores`, чтобы
     дашборд показал маркеры сразу после сидинга.
     """
-    from app.db import list_tables
     from app.metrics_storage import save_anomaly_scores
     from ml.anomaly_detector import (
         InsufficientDataError,
@@ -40,20 +55,28 @@ def warmup_anomalies() -> dict:
         score_table,
     )
 
-    train_counts = retrain_all()
+    if tables is None:
+        from app.db import list_tables
 
+        table_names = [t["table_name"] for t in list_tables()]
+    else:
+        table_names = tables
+
+    train_counts = retrain_all(project_id=project_id, tables=table_names)
     scored = 0
-    for t in list_tables():
-        name = t["table_name"]
+    for name in table_names:
         try:
-            scores = score_table(name, window_days=14)
+            scores = score_table(name, window_days=14, project_id=project_id)
         except InsufficientDataError:
             continue
         except Exception as exc:  # pragma: no cover — defensive
             logger.warning("Anomaly scoring failed for %s: %s", name, exc)
             continue
         if scores:
-            save_anomaly_scores([{**s, "table_name": name} for s in scores])
+            save_anomaly_scores(
+                [{**s, "table_name": name} for s in scores],
+                project_id=project_id,
+            )
             scored += len(scores)
     return {**train_counts, "scored": scored}
 
@@ -64,21 +87,23 @@ def warmup_forecasts() -> dict:
     return retrain_all()
 
 
-def warmup_drift() -> dict:
+def warmup_drift(project_id: str = "legacy", tables: list[str] | None = None) -> dict:
     """Считаем PSI/KS на column_distribution и пишем в кеш drift_reports."""
     from ml.drift import compute_and_store_drift_all
-    return compute_and_store_drift_all()
+    return compute_and_store_drift_all(project_id=project_id, tables=tables)
 
 
-def main() -> dict:
+def main(project_id: str = "legacy") -> dict:
     logging.basicConfig(level=logging.INFO)
+    tables = _tables_from_metrics(project_id)
+    table_scope = tables or (None if project_id == "legacy" else [])
 
     print("[1/4] change-point sweep...")
-    cps = warmup_changepoints()
+    cps = warmup_changepoints(project_id=project_id, tables=table_scope)
     print(f"       {cps}")
 
     print("[2/4] anomaly retrain + scoring...")
-    an = warmup_anomalies()
+    an = warmup_anomalies(project_id=project_id, tables=table_scope)
     print(f"       {an}")
 
     print("[3/4] forecast retrain...")
@@ -86,7 +111,7 @@ def main() -> dict:
     print(f"       {fc}")
 
     print("[4/4] drift cache refresh...")
-    dr = warmup_drift()
+    dr = warmup_drift(project_id=project_id, tables=table_scope)
     print(f"       {dr}")
 
     print("\nML warmup complete.")
@@ -94,4 +119,7 @@ def main() -> dict:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project-id", default="legacy")
+    args = parser.parse_args()
+    main(project_id=args.project_id)

--- a/tests/test_changepoint.py
+++ b/tests/test_changepoint.py
@@ -144,6 +144,44 @@ def test_save_changepoints_preserves_opposite_directions(clean_metrics):
     assert len(rows) == 2, "rise and fall are separate events and must both be kept"
 
 
+def test_changepoints_are_scoped_by_project(clean_metrics):
+    ts = (datetime.now(UTC) - timedelta(hours=1)).isoformat(timespec="seconds")
+    e = {
+        "ts": ts,
+        "table_name": "orders",
+        "metric_name": "null_rate",
+        "score": 5.0,
+        "value_before": 0.02,
+        "value_after": 0.20,
+    }
+
+    save_changepoints([e], project_id="proj-a")
+    save_changepoints([{**e, "score": 9.0}], project_id="proj-b")
+
+    assert get_changepoints("orders", project_id="proj-a")[0]["score"] == 5.0
+    assert get_changepoints("orders", project_id="proj-b")[0]["score"] == 9.0
+
+
+def test_changepoint_dedupe_does_not_cross_project(clean_metrics):
+    base = datetime.now(UTC) - timedelta(hours=10)
+
+    def _e(offset_hours: float, score: float) -> dict:
+        return {
+            "ts": (base + timedelta(hours=offset_hours)).isoformat(timespec="seconds"),
+            "table_name": "orders",
+            "metric_name": "row_count",
+            "score": score,
+            "value_before": 1000.0,
+            "value_after": 5000.0,
+        }
+
+    save_changepoints([_e(0, 20.0)], project_id="proj-a")
+    save_changepoints([_e(1, 30.0)], project_id="proj-b")
+
+    assert len(get_changepoints("orders", project_id="proj-a")) == 1
+    assert len(get_changepoints("orders", project_id="proj-b")) == 1
+
+
 # ---------------------------------------------------------------------------
 # /api/changepoints/<table>
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics_storage.py
+++ b/tests/test_metrics_storage.py
@@ -199,3 +199,118 @@ def test_save_drift_reports_handles_numeric_ks(storage):
     ])
     result = storage.get_drift_report("events")
     assert result[0]["ks_pvalue"] == pytest.approx(0.003)
+
+
+def test_drift_reports_are_scoped_by_project(storage):
+    storage.save_drift_reports("orders", [
+        {"column": "country", "data_type": "varchar", "psi": 0.42,
+         "ks_pvalue": None, "is_drift": True, "severity": "critical"},
+    ], project_id="proj-a")
+    storage.save_drift_reports("orders", [
+        {"column": "status", "data_type": "varchar", "psi": 0.01,
+         "ks_pvalue": None, "is_drift": False, "severity": "ok"},
+    ], project_id="proj-b")
+
+    assert [r["column"] for r in storage.get_drift_report("orders", "proj-a")] == ["country"]
+    assert [r["column"] for r in storage.get_drift_report("orders", "proj-b")] == ["status"]
+
+
+def test_anomaly_scores_are_scoped_by_project(storage):
+    now = datetime.now(UTC)
+    row = {"ts": now, "table_name": "orders", "score": -0.1, "is_anomaly": 1}
+    storage.save_anomaly_scores([row], project_id="proj-a")
+    storage.save_anomaly_scores([{**row, "score": 0.2, "is_anomaly": 0}], project_id="proj-b")
+
+    a_scores = storage.get_anomaly_scores("orders", project_id="proj-a")
+    b_scores = storage.get_anomaly_scores("orders", project_id="proj-b")
+
+    assert a_scores[0]["score"] == -0.1
+    assert a_scores[0]["is_anomaly"] == 1
+    assert b_scores[0]["score"] == 0.2
+    assert b_scores[0]["is_anomaly"] == 0
+
+
+def test_history_anomalies_are_scoped_by_project(storage):
+    now = datetime.now(UTC)
+    storage.save_metrics([
+        {"ts": now, "table_name": "orders", "metric_name": "row_count", "value": 10},
+        {"ts": now, "table_name": "orders", "metric_name": "null_rate", "value": 0.01},
+    ], "proj-a")
+    storage.save_anomaly_scores([
+        {"ts": now, "table_name": "orders", "score": -0.2, "is_anomaly": 1},
+    ], project_id="proj-b")
+
+    agg = storage.build_history_aggregate("proj-a")
+
+    assert agg["anomalies_by_ts"] == {}
+
+
+def test_migrates_legacy_ml_tables_to_project_scoped_pk(tmp_path, monkeypatch):
+    import sqlite3
+
+    db_path = tmp_path / "legacy.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript("""
+            CREATE TABLE anomaly_scores (
+                ts TEXT NOT NULL,
+                table_name TEXT NOT NULL,
+                score REAL NOT NULL,
+                is_anomaly INTEGER NOT NULL,
+                PRIMARY KEY (ts, table_name)
+            );
+            CREATE TABLE changepoints (
+                ts TEXT NOT NULL,
+                table_name TEXT NOT NULL,
+                metric_name TEXT NOT NULL,
+                score REAL NOT NULL,
+                value_before REAL NOT NULL,
+                value_after REAL NOT NULL,
+                detected_at TEXT NOT NULL,
+                PRIMARY KEY (ts, table_name, metric_name)
+            );
+            CREATE TABLE drift_reports (
+                table_name TEXT NOT NULL,
+                column_name TEXT NOT NULL,
+                data_type TEXT,
+                psi REAL,
+                ks_pvalue REAL,
+                is_drift INTEGER NOT NULL,
+                severity TEXT NOT NULL,
+                computed_at TEXT NOT NULL,
+                PRIMARY KEY (table_name, column_name)
+            );
+            INSERT INTO anomaly_scores VALUES ('2026-01-01T00:00:00+00:00', 'orders', -0.1, 1);
+            INSERT INTO changepoints VALUES (
+                '2026-01-01T00:00:00+00:00', 'orders', 'row_count',
+                3.0, 10.0, 20.0, '2026-01-01T00:01:00+00:00'
+            );
+            INSERT INTO drift_reports VALUES (
+                'orders', 'country', 'varchar', 0.3, NULL, 1,
+                'critical', '2026-01-01T00:02:00+00:00'
+            );
+        """)
+
+    import app.metrics_storage as storage_mod
+
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    engine = storage_mod.get_engine()
+
+    assert "project_id" in storage_mod._existing_columns(engine, "anomaly_scores")
+    assert storage_mod._sqlite_pk_columns(engine, "anomaly_scores") == [
+        "project_id", "ts", "table_name",
+    ]
+    assert storage_mod._sqlite_pk_columns(engine, "changepoints") == [
+        "project_id", "ts", "table_name", "metric_name",
+    ]
+    assert storage_mod._sqlite_pk_columns(engine, "drift_reports") == [
+        "project_id", "table_name", "column_name",
+    ]
+    assert storage_mod.get_anomaly_scores(
+        "orders", project_id="legacy", window=timedelta(days=3650)
+    )
+    assert storage_mod.get_changepoints(
+        "orders", project_id="legacy", window=timedelta(days=3650)
+    )
+    assert storage_mod.get_drift_report("orders", project_id="legacy")

--- a/tests/test_per_project.py
+++ b/tests/test_per_project.py
@@ -214,7 +214,7 @@ def test_collect_for_connection_writes_metrics_with_project_id(storage, tmp_path
     # We need a Postgres-compatible target for the adapter path.
     # Workaround: skip the adapter and test the job's persistence logic
     # via a monkeypatch.
-    user_id, project, conn = _seed_user_with_active_connection(
+    _user_id, project, conn = _seed_user_with_active_connection(
         storage, dsn="postgresql://u:p@unreachable:5432/d",
     )
     from collectors import metrics_collector
@@ -252,7 +252,7 @@ def test_collect_for_connection_skips_inactive(storage):
     connection is deactivated between job-fire scheduling and the actual
     callback.
     """
-    user_id, project, conn = _seed_user_with_active_connection(
+    _user_id, project, conn = _seed_user_with_active_connection(
         storage, dsn="postgresql://u:p@h/d",
     )
     storage.set_connection_active(project["id"], conn["id"], is_active=False)

--- a/tests/test_seed_metrics_db.py
+++ b/tests/test_seed_metrics_db.py
@@ -186,7 +186,7 @@ def test_drift_factor_monotonic_after_onset():
 def test_categorical_buckets_baseline_when_no_drift():
     out = _categorical_buckets(progress=1.0, drift_amount=0.0)
     weights = [b["count"] for b in out]
-    expected_total = sum(int(round(w / sum(CATEGORICAL_BASELINE_WEIGHTS) * 1000))
+    expected_total = sum(round(w / sum(CATEGORICAL_BASELINE_WEIGHTS) * 1000)
                          for w in CATEGORICAL_BASELINE_WEIGHTS)
     assert sum(weights) == expected_total
     # Бакеты соответствуют именам.


### PR DESCRIPTION
## Описание

Три ML-таблицы не содержали `project_id` — история аномалий, change-point'ов и drift-отчётов была глобальной. Дашборд пользователя A показывал ML-данные пользователя B. Старые PRIMARY KEY перетирали строки разных проектов при upsert.

### Схема

`anomaly_scores`, `changepoints`, `drift_reports` получили `project_id TEXT NOT NULL DEFAULT 'legacy'` и новые составные PK с `project_id` на первой позиции. Добавлены индексы `(project_id, ts DESC)`.

### Миграция (`app/metrics_storage.py`)

`_migrate_project_scoped_ml_tables()` мигрирует существующие БД при старте:
- **SQLite**: CREATE TABLE `__new` → INSERT SELECT с backfill `'legacy'` → DROP → RENAME (в одной транзакции, идемпотентно).
- **Postgres**: ALTER TABLE ADD COLUMN → DROP CONSTRAINT → ADD PRIMARY KEY.

### Storage API

Все функции чтения/записи получили `project_id="legacy"`. Dedupe-кластеризация changepoints (±72 ч) теперь фильтрует по `project_id` — cross-project вытеснение невозможно.

### ML-модули (`ml/`)

`anomaly_detector`, `changepoint`, `drift` — все функции от `_load_features` до `retrain_all` / `detect_all` / `compute_and_store_drift_all` принимают `project_id` и `tables`. Anomaly-модели: non-legacy сохраняется как `models/{project_id}__{table}__anomaly.joblib`.

### Dashboard / API / LLM

`_ml_last_runs`, `schema_view`, `table_detail`, все `/api/` endpoints, `explain_anomaly` — везде `_current_project_id()`.

### warmup_ml + Makefile

`--project-id` CLI arg. `_tables_from_metrics(project_id)` читает список таблиц из `metrics` без live-connection. `warmup-ml` в Makefile передаёт `$(PROJECT_ID)`.

### Seeder

`_purge_existing` теперь делает scoped DELETE для `anomaly_scores`, `changepoints`, `drift_reports`.

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены (359 passed)
- [x] `pytest` проходит локально
- [x] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы

## Связанные issues

- Closes #146
- Prophet-модели (`warmup_forecasts`) без project_id — отдельный тикет