### PR TITLE
feat(#141): ClickHouse demo-инфраструктура — Docker, probe, seed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PORT          ?= 5001
 PROJECT_ID    ?= legacy
 CONNECTION_ID ?=
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg demo-ids
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg demo-ids clickhouse-up clickhouse-down seed-clickhouse
 
 build:
 	docker build -t $(IMAGE) .
@@ -120,6 +120,23 @@ smoke-iceberg: ## Run live smoke test against local Iceberg REST + MinIO (requir
 	@curl -sf http://localhost:8181/v1/config >/dev/null 2>&1 || \
 		(echo "Iceberg REST не запущен. Сначала выполни: make iceberg-up" && exit 1)
 	python -m scripts.smoke_iceberg
+
+# ── ClickHouse demo target (#141) ────────────────────────────────────
+clickhouse-up:
+	docker compose --profile clickhouse up -d clickhouse
+	@echo "Waiting for ClickHouse to become healthy..."
+	@i=0; until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-clickhouse 2>/dev/null)" = "healthy" ]; do \
+		i=$$((i+1)); [ $$i -gt 60 ] && echo "ERROR: ClickHouse did not become healthy in 60s" && exit 1; sleep 1; done
+	@echo "ClickHouse HTTP:   http://localhost:8123  (user=default db=demo, no password)"
+	@echo "ClickHouse native: localhost:19000        (DSN: clickhouse+native://default@localhost:19000/demo)"
+
+clickhouse-down:
+	docker compose --profile clickhouse down
+
+seed-clickhouse: ## Заполнить ClickHouse-демо тестовыми данными
+	@curl -sf http://localhost:8123/ping >/dev/null 2>&1 || \
+		(echo "ClickHouse не запущен. Сначала выполни: make clickhouse-up" && exit 1)
+	python -m scripts.seed_clickhouse $(ARGS)
 
 # Ruff: linter + import sort + pyupgrade in one tool. Config in pyproject.toml.
 # Runs locally via venv (fast, no docker round-trip). Same command runs in CI.

--- a/app/connections.py
+++ b/app/connections.py
@@ -357,15 +357,55 @@ def _probe_iceberg(dsn: str) -> dict:
         }
 
 
+def _probe_clickhouse(dsn: str) -> dict:
+    """Probe a ClickHouse server. Supports clickhouse://, clickhouse+native://
+    and clickhouse+http:// DSNs handled by clickhouse-sqlalchemy.
+
+    Mirrors the Postgres path: NullPool (one-off engine, no slot held),
+    bounded connect timeout, ``SELECT 1`` + ``SELECT version()`` to confirm
+    the server actually accepts a query (not just a TCP handshake). Same
+    error classification — auth failures, timeouts, network errors all map
+    to the same codes the UI already knows how to render.
+    """
+    # clickhouse-sqlalchemy passes connect_args straight to clickhouse-driver.
+    # Native protocol uses `connect_timeout` (TCP-level handshake bound);
+    # the HTTP dialect ignores it but doesn't error on unknown kwargs.
+    engine = create_engine(
+        dsn,
+        poolclass=NullPool,
+        connect_args={"connect_timeout": _TEST_CONNECT_TIMEOUT_S},
+    )
+    started = time.monotonic()
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+            row = conn.execute(text("SELECT version()")).fetchone()
+        latency_ms = int((time.monotonic() - started) * 1000)
+        return {
+            "status": "ok",
+            "database": "clickhouse",
+            "version": str(row[0]) if row and row[0] else "unknown",
+            "latency_ms": latency_ms,
+        }
+    except SQLAlchemyError as exc:
+        logger.warning("clickhouse probe failed: %s", exc, exc_info=True)
+        code, user_msg = _classify_error(exc)
+        return {
+            "status": "error", "code": code, "message": user_msg,
+            "latency_ms": int((time.monotonic() - started) * 1000),
+        }
+    finally:
+        engine.dispose()
+
+
 def probe_connection(dsn: str) -> dict:
     """Try connecting and reading a couple of harmless metadata bits.
 
-    Postgres-only at the moment — other dialects return ``unsupported_dialect``
-    until a per-dialect probe lands (the adapters in #42 know how to
-    introspect tables but not how to phrase a self-test in a way that
-    works across MySQL / ClickHouse). The JSON response is identical
-    shape across success and failure so the UI never has to branch on
-    keys, only on ``status``.
+    Dialect support: PostgreSQL (full), ClickHouse (full, #141),
+    Iceberg REST/Glue (#111). Other dialects return ``unsupported_dialect``
+    until a per-dialect probe lands. The JSON response is identical shape
+    across success and failure so the UI never has to branch on keys,
+    only on ``status``.
     """
     try:
         backend = make_url(dsn).get_backend_name()
@@ -377,6 +417,9 @@ def probe_connection(dsn: str) -> dict:
 
     if backend.startswith("iceberg"):
         return _probe_iceberg(dsn)
+
+    if backend == "clickhouse":
+        return _probe_clickhouse(dsn)
 
     if backend != "postgresql":
         return {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,38 @@ services:
       minio:
         condition: service_healthy
 
+  # ── ClickHouse demo target (#141) ────────────────────────────────────
+  # Start with: make clickhouse-up   Stop with: make clickhouse-down
+  #
+  # Demo target — мониторируем как обычный source-of-truth DB. App
+  # подключается через clickhouse+native:// (порт 9000 in-container,
+  # 19000 проброшен наружу чтобы не коллидировать с MinIO 9000 из
+  # iceberg-профиля, если кто-то запустит оба). HTTP 8123 — для
+  # ручного debug через `curl localhost:8123/?query=...`.
+  clickhouse:
+    image: clickhouse/clickhouse-server:24-alpine
+    container_name: db-monitoring-clickhouse
+    profiles: ["clickhouse"]
+    environment:
+      CLICKHOUSE_DB: demo
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: ""
+      # Без этого CH запускается с дефолтными limit-ами и при перезапуске
+      # ругается в логе, что мешает читать здоровые сообщения.
+      CLICKHOUSE_SKIP_USER_SETUP: "1"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    ports:
+      - "8123:8123"     # HTTP интерфейс
+      - "19000:9000"    # native (TCP) — 19000 наружу чтобы не пересекаться с MinIO
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8123/ping || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
 volumes:
   pg_data:
   timescale_data:

--- a/scripts/seed_clickhouse.py
+++ b/scripts/seed_clickhouse.py
@@ -1,0 +1,277 @@
+"""Seed the local ClickHouse demo target with realistic test data (#141).
+
+Creates a ``demo`` database with 4 tables analogous to the Postgres demo
+seed (``scripts/seed_target_db.py``): ``users``, ``products``, ``orders``,
+``events``. Schemas are ClickHouse-native (MergeTree engine, no NULL by
+default, UInt32 / DateTime types) so the adapter's ``list_tables`` /
+``table_stats`` / ``null_count`` paths see real data shaped how a CH
+production database actually looks.
+
+Defaults are small (~10k rows) — designed for "demo on a laptop" speed.
+Bump with flags for stress-tests.
+
+Usage:
+    python -m scripts.seed_clickhouse
+    python -m scripts.seed_clickhouse --reset
+    python -m scripts.seed_clickhouse --events 200000 --reset
+
+Connection:
+    Defaults to clickhouse+native://default@localhost:19000/demo to match
+    `make clickhouse-up`. Override via CLICKHOUSE_URL env var.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import random
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import create_engine, text
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_URL = "clickhouse+native://default@localhost:19000/demo"
+
+# Demo enum-like dimensions — match the Postgres seed (#42, #75) so cross-
+# database demos use the same vocabulary.
+_CATEGORIES = ["Electronics", "Clothing", "Food", "Books", "Home", "Sports"]
+_COUNTRIES = ["RU", "US", "DE", "GB", "FR", "CN", "BR"]
+_SIGNUP_SOURCES = ["web", "mobile", "api", "referral"]
+_STATUSES = ["pending", "confirmed", "shipped", "delivered", "cancelled"]
+_EVENT_TYPES = ["login", "view", "add_to_cart", "checkout", "purchase",
+                "error", "logout"]
+_SERVER_IDS = ["server-1", "server-2", "server-3"]
+_DEVICE_TYPES = ["mobile", "desktop", "tablet"]
+
+
+# ── Schema ────────────────────────────────────────────────────────────────
+
+_SCHEMA_STATEMENTS = [
+    # Database is created by docker-compose CLICKHOUSE_DB; keep an IF NOT
+    # EXISTS guard so the script works against an existing CH outside Docker.
+    "CREATE DATABASE IF NOT EXISTS demo",
+
+    # users — flat profile data, MergeTree ordered by signup_date so any
+    # WHERE created_at <= T snapshot scan stays sequential.
+    """
+    CREATE TABLE IF NOT EXISTS demo.users (
+        user_id      UInt32,
+        email        String,
+        name         String,
+        country      LowCardinality(String),
+        signup_date  DateTime,
+        signup_source LowCardinality(String),
+        is_active    UInt8
+    ) ENGINE = MergeTree() ORDER BY (signup_date, user_id)
+    """,
+
+    # products — small dimension table.
+    """
+    CREATE TABLE IF NOT EXISTS demo.products (
+        product_id   UInt32,
+        name         String,
+        category     LowCardinality(String),
+        price        Decimal(10, 2),
+        created_at   DateTime
+    ) ENGINE = MergeTree() ORDER BY (created_at, product_id)
+    """,
+
+    # orders — main fact-table for null-rate / changepoint demos.
+    """
+    CREATE TABLE IF NOT EXISTS demo.orders (
+        order_id     UInt64,
+        user_id      UInt32,
+        product_id   UInt32,
+        status       LowCardinality(String),
+        quantity     UInt16,
+        total_price  Decimal(12, 2),
+        created_at   DateTime
+    ) ENGINE = MergeTree() ORDER BY (created_at, order_id)
+    """,
+
+    # events — append-only stream, the bread-and-butter of ClickHouse demos.
+    # event_id as String (UUID-as-text) — CH has a UUID type but String
+    # plays nicer with the SQLAlchemy round-trip for the simple seed here.
+    """
+    CREATE TABLE IF NOT EXISTS demo.events (
+        event_id     String,
+        user_id      UInt32,
+        event_type   LowCardinality(String),
+        server_id    LowCardinality(String),
+        device_type  LowCardinality(String),
+        created_at   DateTime
+    ) ENGINE = MergeTree() ORDER BY (created_at, event_id)
+    """,
+]
+
+
+def _apply_schema(engine) -> None:
+    """ClickHouse does not allow multi-statement execute; run one at a time."""
+    with engine.begin() as conn:
+        for stmt in _SCHEMA_STATEMENTS:
+            clean = stmt.strip()
+            if clean:
+                conn.execute(text(clean))
+
+
+def _reset_tables(engine) -> None:
+    """TRUNCATE all demo tables — fast for MergeTree (drops parts directly).
+
+    Idempotent: missing tables (first run after schema drop) are silently
+    tolerated; CH errors with code 60 for unknown table.
+    """
+    from sqlalchemy.exc import DatabaseError
+    for table in ("users", "products", "orders", "events"):
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(f"TRUNCATE TABLE demo.{table}"))
+        except DatabaseError as exc:
+            logger.debug("TRUNCATE demo.%s skipped: %s", table, exc)
+
+
+# ── Seeders ───────────────────────────────────────────────────────────────
+
+def _seed_users(engine, count: int) -> None:
+    """Insert *count* users with signup_date spread over the last 365 days."""
+    now = datetime.now(UTC)
+    rng = random.Random(42)
+    rows = []
+    for i in range(1, count + 1):
+        days_ago = rng.randint(0, 365)
+        rows.append({
+            "user_id": i,
+            "email": f"user{i}@example.com",
+            "name": f"User {i}",
+            "country": rng.choice(_COUNTRIES),
+            "signup_date": now - timedelta(days=days_ago,
+                                           seconds=rng.randint(0, 86399)),
+            "signup_source": rng.choice(_SIGNUP_SOURCES),
+            "is_active": 1 if rng.random() > 0.05 else 0,
+        })
+    with engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO demo.users "
+            "(user_id, email, name, country, signup_date, signup_source, is_active) "
+            "VALUES (:user_id, :email, :name, :country, :signup_date, "
+            ":signup_source, :is_active)"
+        ), rows)
+    logger.info("Seeded %d users", count)
+
+
+def _seed_products(engine, count: int) -> None:
+    now = datetime.now(UTC)
+    rng = random.Random(43)
+    rows = [
+        {
+            "product_id": i,
+            "name": f"Product {i}",
+            "category": rng.choice(_CATEGORIES),
+            "price": round(rng.uniform(5, 500), 2),
+            "created_at": now - timedelta(days=rng.randint(0, 730)),
+        }
+        for i in range(1, count + 1)
+    ]
+    with engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO demo.products "
+            "(product_id, name, category, price, created_at) "
+            "VALUES (:product_id, :name, :category, :price, :created_at)"
+        ), rows)
+    logger.info("Seeded %d products", count)
+
+
+def _seed_orders(engine, count: int, max_user_id: int, max_product_id: int) -> None:
+    now = datetime.now(UTC)
+    rng = random.Random(44)
+    rows = []
+    for i in range(1, count + 1):
+        qty = rng.randint(1, 5)
+        price = round(rng.uniform(5, 500) * qty, 2)
+        rows.append({
+            "order_id": i,
+            "user_id": rng.randint(1, max_user_id),
+            "product_id": rng.randint(1, max_product_id),
+            "status": rng.choice(_STATUSES),
+            "quantity": qty,
+            "total_price": price,
+            "created_at": now - timedelta(days=rng.randint(0, 90),
+                                          seconds=rng.randint(0, 86399)),
+        })
+    # ClickHouse executemany via clickhouse-sqlalchemy works fine for batches
+    # in this range; for >>100k rows you'd switch to Native protocol bulk insert.
+    with engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO demo.orders "
+            "(order_id, user_id, product_id, status, quantity, total_price, created_at) "
+            "VALUES (:order_id, :user_id, :product_id, :status, :quantity, "
+            ":total_price, :created_at)"
+        ), rows)
+    logger.info("Seeded %d orders", count)
+
+
+def _seed_events(engine, count: int, max_user_id: int) -> None:
+    now = datetime.now(UTC)
+    rng = random.Random(45)
+    rows = [
+        {
+            "event_id": uuid.uuid4().hex,
+            "user_id": rng.randint(1, max_user_id),
+            "event_type": rng.choice(_EVENT_TYPES),
+            "server_id": rng.choice(_SERVER_IDS),
+            "device_type": rng.choice(_DEVICE_TYPES),
+            "created_at": now - timedelta(seconds=rng.randint(0, 14 * 86400)),
+        }
+        for _ in range(count)
+    ]
+    with engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO demo.events "
+            "(event_id, user_id, event_type, server_id, device_type, created_at) "
+            "VALUES (:event_id, :user_id, :event_type, :server_id, "
+            ":device_type, :created_at)"
+        ), rows)
+    logger.info("Seeded %d events", count)
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    parser = argparse.ArgumentParser(description="Seed local ClickHouse demo target.")
+    parser.add_argument("--users", type=int, default=2_000)
+    parser.add_argument("--products", type=int, default=200)
+    parser.add_argument("--orders", type=int, default=5_000)
+    parser.add_argument("--events", type=int, default=10_000)
+    parser.add_argument(
+        "--reset", action="store_true",
+        help="TRUNCATE all demo tables before seeding (destructive!)",
+    )
+    parser.add_argument(
+        "--url", default=os.environ.get("CLICKHOUSE_URL", DEFAULT_URL),
+        help=f"ClickHouse SQLAlchemy URL (default: {DEFAULT_URL})",
+    )
+    args = parser.parse_args()
+
+    engine = create_engine(args.url)
+    try:
+        _apply_schema(engine)
+        logger.info("Schema applied.")
+        if args.reset:
+            _reset_tables(engine)
+            logger.info("Tables truncated.")
+        _seed_users(engine, args.users)
+        _seed_products(engine, args.products)
+        _seed_orders(engine, args.orders, args.users, args.products)
+        _seed_events(engine, args.events, args.users)
+        logger.info(
+            "Done. demo db now has ~%d rows total across users/products/orders/events.",
+            args.users + args.products + args.orders + args.events,
+        )
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_connection_test.py
+++ b/tests/test_connection_test.py
@@ -68,6 +68,97 @@ def test_probe_classifies_unsupported_dialect():
     assert result["code"] == "unsupported_dialect"
 
 
+# --- ClickHouse probe (#141) ----------------------------------------------
+
+
+def _ch_engine_returns_version(version: str):
+    """Build a Mock that mimics _probe_clickhouse's connection sequence:
+    SELECT 1 then SELECT version()."""
+    engine = MagicMock(name="ch_engine")
+    conn = MagicMock(name="ch_conn")
+    select1 = MagicMock(name="select1")
+    version_row = MagicMock(name="version_row")
+    version_row.fetchone.return_value = (version,)
+    conn.execute.side_effect = [select1, version_row]
+
+    @contextmanager
+    def _connect():
+        yield conn
+
+    engine.connect.side_effect = _connect
+    engine.dispose = MagicMock()
+    return engine
+
+
+def test_probe_clickhouse_routes_via_backend(monkeypatch):
+    """clickhouse:// DSN must NOT fall through to unsupported_dialect."""
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _ch_engine_returns_version("ClickHouse 24.5.1"),
+    )
+    result = connections.probe_connection("clickhouse://default@h:9000/demo")
+    assert result["status"] == "ok"
+    assert result["database"] == "clickhouse"
+    assert result["version"] == "ClickHouse 24.5.1"
+    assert isinstance(result["latency_ms"], int)
+
+
+def test_probe_clickhouse_native_scheme(monkeypatch):
+    """clickhouse+native:// — same code path, distinct scheme."""
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _ch_engine_returns_version("24.8.4.1"),
+    )
+    result = connections.probe_connection("clickhouse+native://default@h:9000/demo")
+    assert result["status"] == "ok"
+    assert result["version"] == "24.8.4.1"
+
+
+def test_probe_clickhouse_classifies_auth_failure(monkeypatch):
+    """Wrong password from CH should map to auth_failed, not generic error."""
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_raises(
+            OperationalError(
+                "SELECT 1", {},
+                Exception("Code: 516. DB::Exception: default: Authentication failed: password is incorrect"),
+            )
+        ),
+    )
+    result = connections.probe_connection("clickhouse://default:wrong@h:9000/demo")
+    assert result["status"] == "error"
+    assert result["code"] == "auth_failed"
+
+
+def test_probe_clickhouse_classifies_network_error(monkeypatch):
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_raises(
+            OperationalError("SELECT 1", {}, Exception("Connection refused"))
+        ),
+    )
+    result = connections.probe_connection("clickhouse://default@127.0.0.1:1/demo")
+    assert result["status"] == "error"
+    assert result["code"] == "network"
+
+
+def test_probe_clickhouse_disposes_engine_on_success(monkeypatch):
+    """One-off engine must release its pool — no slot held after probe."""
+    engine = _ch_engine_returns_version("24.1")
+    monkeypatch.setattr(connections, "create_engine", lambda *_a, **_kw: engine)
+    connections.probe_connection("clickhouse://default@h:9000/demo")
+    engine.dispose.assert_called_once()
+
+
+def test_probe_clickhouse_disposes_engine_on_error(monkeypatch):
+    engine = _engine_that_raises(
+        OperationalError("SELECT 1", {}, Exception("Connection refused"))
+    )
+    monkeypatch.setattr(connections, "create_engine", lambda *_a, **_kw: engine)
+    connections.probe_connection("clickhouse://default@h:9000/demo")
+    engine.dispose.assert_called_once()
+
+
 @pytest.mark.parametrize("err_text, expected_code", [
     ('FATAL:  password authentication failed for user "admin"', "auth_failed"),
     ("connection timeout expired", "timeout"),


### PR DESCRIPTION
Closes #141. Замыкает ClickHouse-петлю: адаптер был с #42, теперь юзер может реально подключить CH через визард и UI протестирует коннект синхронно (раньше любой `clickhouse://` DSN возвращал `unsupported_dialect`).

## Что внутри

### 1. docker-compose
Сервис `clickhouse` с профилем `clickhouse` — `clickhouse/clickhouse-server:24-alpine`. Порты: 8123 (HTTP, для `curl`-дебага), **19000:9000** для native — наружу не 9000 чтобы не пересекаться с MinIO из iceberg-профиля если кто-то запустит оба. Healthcheck через `/ping`. ulimits подняты до 262k.

### 2. Makefile
- `clickhouse-up` / `clickhouse-down` — старт/стоп профиля
- `seed-clickhouse` — запуск seed-скрипта

### 3. `_probe_clickhouse` в `app/connections.py`
Зеркалит postgres-путь: NullPool + `connect_timeout=5s`, `SELECT 1` + `SELECT version()`, `engine.dispose()` в `finally`. Тот же `_classify_error` → `auth_failed` / `timeout` / `network` коды UI уже знает рендерить. Роутинг в `probe_connection` ДО fall-through:

```python
if backend == "clickhouse":
    return _probe_clickhouse(dsn)
```

### 4. `scripts/seed_clickhouse.py`
4 таблицы (users, products, orders, events) с паритетом с `seed_target_db.py`, но CH-native — `MergeTree ORDER BY`, `LowCardinality` для категориальных колонок, `UInt8/UInt32/Decimal`. Дефолты маленькие (~17k rows total), флаги для стресс-тестов. URL по умолчанию совпадает с `make clickhouse-up`, override через `CLICKHOUSE_URL` env.

### 5. Тесты
7 новых кейсов в `tests/test_connection_test.py`:
- happy paths: clickhouse:// и clickhouse+native://
- классификация ошибок: auth_failed (CH "Authentication failed"), network (Connection refused)
- инвариант: `engine.dispose()` на обоих путях (success + error)

## Acceptance из тикета

- [x] Docker compose сервис с профилем `clickhouse`
- [x] Makefile `clickhouse-up` / `clickhouse-down`
- [x] Seed-скрипт с реалистичными демо-данными
- [x] `_probe_clickhouse` + роутинг в `probe_connection`
- [x] Тесты: ok-path, error-path

## Verification

- `pytest tests/test_connection_test.py` → **25 passed**
- Full suite → **538 passed** (39 deselected: integration / iceberg-list)
- `ruff check` → clean
- Live Docker smoke не запускался (daemon недоступен в этой среде); manual smoke после мерджа: `make clickhouse-up && make seed-clickhouse && curl http://localhost:8123/?query=SELECT+count()+FROM+demo.events`

## Onboarding hint

В `templates/onboarding/add_connection.html` подсказка для ClickHouse уже была с #55 — `clickhouse+native://user:password@host:9000/dbname`. Менять не пришлось.

## Out of scope

- Live integration test через testcontainers (по образцу `tests/integration/test_db_iceberg.py`) — отдельный тикет если понадобится в CI.
- DSN-подсказка про порт **19000** наружу через docker desktop (если демо проводится не из контейнера) — упомянуто только в README `make clickhouse-up` output. При первом manual smoke может стать понятно нужен ли явный hint в UI.