### PR TITLE
fix(#141): живые правки после первого реального запуска ClickHouse

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,10 @@ services:
       - "8123:8123"     # HTTP интерфейс
       - "19000:9000"    # native (TCP) — 19000 наружу чтобы не пересекаться с MinIO
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:8123/ping || exit 1"]
+      # ``localhost`` inside Alpine resolves to ::1 first; ClickHouse binds
+      # only to 0.0.0.0 by default, so the IPv6 attempt fails and the
+      # check never goes healthy. Force IPv4 with an explicit 127.0.0.1.
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:8123/ping || exit 1"]
       interval: 3s
       timeout: 5s
       retries: 20

--- a/scripts/seed_clickhouse.py
+++ b/scripts/seed_clickhouse.py
@@ -150,13 +150,12 @@ def _seed_users(engine, count: int) -> None:
             "signup_source": rng.choice(_SIGNUP_SOURCES),
             "is_active": 1 if rng.random() > 0.05 else 0,
         })
-    with engine.begin() as conn:
-        conn.execute(text(
-            "INSERT INTO demo.users "
-            "(user_id, email, name, country, signup_date, signup_source, is_active) "
-            "VALUES (:user_id, :email, :name, :country, :signup_date, "
-            ":signup_source, :is_active)"
-        ), rows)
+    _bulk_insert(
+        engine,
+        "INSERT INTO demo.users (user_id, email, name, country, signup_date, "
+        "signup_source, is_active) VALUES",
+        rows,
+    )
     logger.info("Seeded %d users", count)
 
 
@@ -173,12 +172,12 @@ def _seed_products(engine, count: int) -> None:
         }
         for i in range(1, count + 1)
     ]
-    with engine.begin() as conn:
-        conn.execute(text(
-            "INSERT INTO demo.products "
-            "(product_id, name, category, price, created_at) "
-            "VALUES (:product_id, :name, :category, :price, :created_at)"
-        ), rows)
+    _bulk_insert(
+        engine,
+        "INSERT INTO demo.products (product_id, name, category, price, "
+        "created_at) VALUES",
+        rows,
+    )
     logger.info("Seeded %d products", count)
 
 
@@ -199,15 +198,12 @@ def _seed_orders(engine, count: int, max_user_id: int, max_product_id: int) -> N
             "created_at": now - timedelta(days=rng.randint(0, 90),
                                           seconds=rng.randint(0, 86399)),
         })
-    # ClickHouse executemany via clickhouse-sqlalchemy works fine for batches
-    # in this range; for >>100k rows you'd switch to Native protocol bulk insert.
-    with engine.begin() as conn:
-        conn.execute(text(
-            "INSERT INTO demo.orders "
-            "(order_id, user_id, product_id, status, quantity, total_price, created_at) "
-            "VALUES (:order_id, :user_id, :product_id, :status, :quantity, "
-            ":total_price, :created_at)"
-        ), rows)
+    _bulk_insert(
+        engine,
+        "INSERT INTO demo.orders (order_id, user_id, product_id, status, "
+        "quantity, total_price, created_at) VALUES",
+        rows,
+    )
     logger.info("Seeded %d orders", count)
 
 
@@ -225,14 +221,41 @@ def _seed_events(engine, count: int, max_user_id: int) -> None:
         }
         for _ in range(count)
     ]
-    with engine.begin() as conn:
-        conn.execute(text(
-            "INSERT INTO demo.events "
-            "(event_id, user_id, event_type, server_id, device_type, created_at) "
-            "VALUES (:event_id, :user_id, :event_type, :server_id, "
-            ":device_type, :created_at)"
-        ), rows)
+    _bulk_insert(
+        engine,
+        "INSERT INTO demo.events (event_id, user_id, event_type, server_id, "
+        "device_type, created_at) VALUES",
+        rows,
+    )
     logger.info("Seeded %d events", count)
+
+
+def _bulk_insert(engine, sql: str, rows: list[dict]) -> None:
+    """ClickHouse-friendly bulk insert via the native driver.
+
+    We deliberately bypass SQLAlchemy's executemany here. The
+    ``clickhouse-sqlalchemy`` wrapper mangles dict-shaped params in bulk
+    INSERT mode (KeyError on first column name); the underlying
+    ``clickhouse_driver.Client.execute(SQL, [dict, ...])`` handles dicts
+    cleanly. Schema/DDL still goes through SQLAlchemy — only data load
+    drops into the raw client.
+    """
+    if not rows:
+        return
+    from clickhouse_driver import Client
+
+    url = engine.url
+    client = Client(
+        host=url.host or "localhost",
+        port=url.port or 9000,
+        user=url.username or "default",
+        password=url.password or "",
+        database=url.database or "default",
+    )
+    try:
+        client.execute(sql, rows)
+    finally:
+        client.disconnect()
 
 
 # ── CLI ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
После мерджа #156 (#141) запустил `make clickhouse-up && make seed-clickhouse` на macOS Docker Desktop. Поймал две конкретные проблемы — обе чинятся одной строкой каждая, но без них фича сломана в реальной среде.

## Проблема 1: Healthcheck вечно unhealthy

`docker-compose.yml` использовал `localhost` в healthcheck wget. В Alpine `localhost` резолвится в IPv6 `::1` **первым**. ClickHouse биндит только `0.0.0.0:8123`, не `::1` → `wget` падает с "Connection refused" → контейнер вечно unhealthy → `make clickhouse-up` ждёт 60с и фейлится.

Подтверждение:
```
$ docker exec ... netstat -tlnp
tcp 0 0 0.0.0.0:8123  LISTEN
$ docker exec ... wget http://localhost:8123/ping     # → Connection refused
$ docker exec ... wget http://127.0.0.1:8123/ping      # → OK
```

**Fix:** explicit `127.0.0.1` в healthcheck.

## Проблема 2: seed_clickhouse падает с KeyError

Скрипт использовал `SQLAlchemy text('INSERT ... VALUES')` с dict-параметрами — стандартный паттерн который работает с Postgres. С `clickhouse-sqlalchemy` wrapper-ом это ломается в bulk-INSERT режиме: клиент-сайд драйвер получает мангнутый row без ожидаемых ключей и падает с `KeyError` на первой колонке.

Воспроизведено минимальным кейсом:
- SQLAlchemy + dicts → `KeyError: 'user_id'`
- `clickhouse_driver.Client.execute(sql, [dict, ...])` напрямую → ок

**Fix:** bulk inserts идут через `clickhouse_driver.Client` напрямую (DSN-парсинг через `engine.url`). Schema/DDL остаётся через SQLAlchemy — для `CREATE TABLE` wrapper работает корректно. Чистая граница: SQLAlchemy для schema, native client для данных.

## Verification (end-to-end на реальном Docker)

- `make clickhouse-up` → healthy за 6 сек (вместо ∞)
- `make seed-clickhouse` → 2k users + 200 products + 5k orders + 10k events за <100ms
- `probe_connection('clickhouse+native://default@localhost:19000/demo')` →

```json
{"status": "ok", "database": "clickhouse", "version": "24.10.2.80", "latency_ms": 16}
```

- Все 25 юнит-тестов `test_connection_test.py` зелёные.

## Урок

Юнит-тесты с моком engine ловят логику ветвления, но не ловят dual-stack DNS или ловушки конкретного драйвера. Это сюда же где #139 supabase classifier — реальный запуск > синтетика.

## Test plan

- [x] Manual smoke на macOS Docker Desktop end-to-end
- [x] Unit-тесты не задеты
- [x] Ruff clean