### PR TITLE
feat(#154): wire per-project collector → notify per-tenant anomaly alerts

### DIFF
--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -139,6 +139,102 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
         project_id, connection_id, rows_saved, tables_seen, elapsed_ms,
     )
 
+    # #154 post-tick: per-project anomaly alerts. Only fires when (a) we
+    # actually wrote metrics this tick AND (b) the tenant has Telegram
+    # configured via /settings/notifications (#143). No global fallback —
+    # silence is the default. Schema-drift and change-point alerts still
+    # need their snapshot/event tables to grow a project_id column
+    # before they can run per-tenant; that's a separate ticket.
+    if rows_saved > 0:
+        _maybe_notify_anomalies(project_id, [t["table_name"] for t in tables])
+
+
+def _load_telegram_config(project_id: str) -> tuple[str, str, int] | None:
+    """Return ``(bot_token, chat_id, throttle_minutes)`` or None if the
+    project has not configured Telegram. Decryption failure is treated
+    as "not configured" with a loud warning — we never silently fall back."""
+    from app import crypto
+    from app.metrics_storage import get_project_notifications
+
+    cfg = get_project_notifications(project_id)
+    if cfg is None:
+        return None
+    token_encrypted = cfg.get("telegram_bot_token")
+    chat_id = cfg.get("telegram_chat_id")
+    if not token_encrypted or not chat_id:
+        return None
+    try:
+        bot_token = crypto.decrypt_token(token_encrypted)
+    except crypto.InvalidToken:
+        logger.warning(
+            "[project=%s] telegram_bot_token failed to decrypt — Fernet key "
+            "rotated without re-encrypt? Re-save the config in Settings.",
+            project_id,
+        )
+        return None
+    return bot_token, chat_id, int(cfg.get("throttle_minutes") or 30)
+
+
+def _maybe_notify_anomalies(project_id: str, table_names: list[str]) -> None:
+    """Score the last day of metrics for each table just collected, send a
+    Telegram alert for the most recent anomaly per table.
+
+    Mirrors the legacy ``collectors/scheduler.py::_score_recent_anomalies``
+    but scoped to the current tenant — both ``score_table`` and the
+    notification path take ``project_id`` explicitly. Anomaly model is
+    persisted per-(project_id, table); first tick after install trains
+    on the fly. ``InsufficientDataError`` is the "we don't have enough
+    history yet" signal, treated as silent skip.
+    """
+    cfg = _load_telegram_config(project_id)
+    if cfg is None:
+        logger.debug(
+            "[project=%s] no Telegram config — skipping anomaly notifications",
+            project_id,
+        )
+        return
+    bot_token, chat_id, throttle = cfg
+
+    # Late imports keep the cold-start cost out of `import collectors.per_project`
+    # — anomaly_detector pulls sklearn (heavy), and most ticks won't notify.
+    from app.metrics_storage import save_anomaly_scores
+    from app.notifications.telegram import notify_anomaly
+    from ml.anomaly_detector import InsufficientDataError, score_table
+
+    for name in table_names:
+        try:
+            scores = score_table(name, window_days=1, project_id=project_id)
+            if not scores:
+                continue
+            save_anomaly_scores(
+                [{**s, "table_name": name} for s in scores],
+                project_id,
+            )
+            anomalies = [s for s in scores if s["is_anomaly"]]
+            if not anomalies:
+                continue
+            latest = max(anomalies, key=lambda s: s["ts"])
+            try:
+                notify_anomaly(
+                    project_id, name, latest["ts"], latest["score"],
+                    bot_token=bot_token, chat_id=chat_id,
+                    throttle_minutes=throttle,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[project=%s][table=%s] anomaly notification failed: %s",
+                    project_id, name, exc,
+                )
+        except InsufficientDataError:
+            # Not enough history to train — first few ticks. Quiet skip;
+            # no metric or log noise, this is expected for fresh tables.
+            pass
+        except Exception as exc:
+            logger.warning(
+                "[project=%s][table=%s] anomaly scoring skipped: %s",
+                project_id, name, exc,
+            )
+
 
 # --- Scheduler hooks ------------------------------------------------------
 

--- a/tests/test_per_project.py
+++ b/tests/test_per_project.py
@@ -320,3 +320,186 @@ def test_user_owns_job_rejects_cross_tenant(storage):
     # Non-collect job id → False (the caller still needs to look it up
     # against the scheduler; user_owns_job is the tenant check only).
     assert user_owns_job(user_a, "collect_all_tables") is False
+
+
+# --- Per-project notifications wiring (#154) -------------------------------
+
+def _tg_token(bot_id: str = "0000000001") -> str:
+    """Synthetic Telegram bot token — format-valid for our validators
+    but obviously fake (leading zeros — real Telegram bot IDs don't have
+    those). Mirrors the constant in tests/test_project_notifications.py.
+    """
+    return bot_id + ":" + "A" * 35
+
+
+def _run_collect_with_anomaly_stub(storage, project_id, conn_id, table_name,
+                                   is_anomaly, monkeypatch):
+    """Drive collect_for_connection through one tick with a fake target +
+    a stubbed anomaly_detector.score_table that returns a single point."""
+    import unittest.mock as mock
+
+    import app.db as db_mod
+    from collectors import metrics_collector
+
+    fake_rows = [{
+        "ts": datetime.now(UTC), "table_name": table_name,
+        "metric_name": "row_count", "value": 42.0,
+    }]
+    def fake_list_tables(self, schema):
+        return [{"table_name": table_name, "schema": schema}]
+
+    fake_score = [{
+        "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+        "score": -0.22 if is_anomaly else 0.05,
+        "is_anomaly": 1 if is_anomaly else 0,
+    }]
+    monkeypatch.setattr(
+        "ml.anomaly_detector.score_table",
+        lambda table, window_days=14, project_id="legacy": fake_score,
+    )
+
+    with mock.patch.object(metrics_collector.MetricsCollector, "collect",
+                           return_value=fake_rows), \
+         mock.patch.object(db_mod.PostgresAdapter, "list_tables",
+                           autospec=True, side_effect=fake_list_tables):
+        collect_for_connection(project_id, conn_id)
+
+
+def test_collect_for_connection_notifies_when_configured(storage, monkeypatch):
+    """Tenant with valid Telegram config gets notify_anomaly called with
+    its OWN bot_token / chat_id on a confirmed anomaly."""
+    _user, project, conn = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@unreachable:5432/d",
+    )
+    storage.save_project_notifications(
+        project["id"],
+        telegram_bot_token=crypto.encrypt_token(_tg_token()),
+        telegram_chat_id="9001",
+        throttle_minutes=15,
+    )
+
+    captures = []
+    def fake_notify(pid, table, ts, score, *, bot_token, chat_id,
+                    throttle_minutes=None, metric="row_count"):
+        captures.append({
+            "pid": pid, "table": table, "score": score,
+            "bot_token": bot_token, "chat_id": chat_id,
+            "throttle": throttle_minutes,
+        })
+
+    monkeypatch.setattr(
+        "app.notifications.telegram.notify_anomaly", fake_notify,
+    )
+    _run_collect_with_anomaly_stub(
+        storage, project["id"], conn["id"], "users",
+        is_anomaly=True, monkeypatch=monkeypatch,
+    )
+
+    assert len(captures) == 1
+    c = captures[0]
+    assert c["pid"] == project["id"]
+    assert c["table"] == "users"
+    assert c["bot_token"] == _tg_token()
+    assert c["chat_id"] == "9001"
+    assert c["throttle"] == 15
+
+
+def test_collect_for_connection_skips_notify_when_not_configured(storage, monkeypatch):
+    """Tenant with no project_notifications row gets ZERO notify calls,
+    even on a confirmed anomaly. This is the "no global fallback" rule."""
+    _user, project, conn = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@unreachable:5432/d",
+    )
+
+    captures = []
+    monkeypatch.setattr(
+        "app.notifications.telegram.notify_anomaly",
+        lambda *args, **kwargs: captures.append((args, kwargs)),
+    )
+    _run_collect_with_anomaly_stub(
+        storage, project["id"], conn["id"], "users",
+        is_anomaly=True, monkeypatch=monkeypatch,
+    )
+    assert captures == []
+
+
+def test_collect_for_connection_skips_notify_when_no_anomaly(storage, monkeypatch):
+    """Configured tenant + healthy score → still no notification (only
+    real anomalies fire alerts; the throttle doesn't even get touched)."""
+    _user, project, conn = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@unreachable:5432/d",
+    )
+    storage.save_project_notifications(
+        project["id"],
+        telegram_bot_token=crypto.encrypt_token(_tg_token()),
+        telegram_chat_id="42",
+        throttle_minutes=30,
+    )
+
+    captures = []
+    monkeypatch.setattr(
+        "app.notifications.telegram.notify_anomaly",
+        lambda *args, **kwargs: captures.append(args),
+    )
+    _run_collect_with_anomaly_stub(
+        storage, project["id"], conn["id"], "orders",
+        is_anomaly=False, monkeypatch=monkeypatch,
+    )
+    assert captures == []
+
+
+def test_collect_for_connection_cross_tenant_notification_isolation(storage, monkeypatch):
+    """Two tenants, anomaly only in tenant A's tick → only A gets notified.
+    Pins the no-fallback / no-cross-leak invariant at the wiring layer."""
+    # Tenant A — Telegram configured.
+    _user_a, proj_a, conn_a = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@unreachable:5432/a",
+    )
+    storage.save_project_notifications(
+        proj_a["id"],
+        telegram_bot_token=crypto.encrypt_token(_tg_token("0000000001")),
+        telegram_chat_id="aaa",
+        throttle_minutes=20,
+    )
+    # Tenant B — also configured, different chat.
+    user_b = uuid.uuid4().hex
+    storage.create_user(user_id=user_b, email=f"b{user_b[:5]}@x.io",
+                        password_hash="x")
+    proj_b = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=user_b, name="B", slug="default-b",
+    )
+    conn_b = storage.create_connection(
+        connection_id=uuid.uuid4().hex, project_id=proj_b["id"],
+        name="b", dsn_encrypted=crypto.encrypt_dsn("postgresql://u:p@unreachable:5432/b"),
+        schema_name="public", interval_minutes=15, is_active=True,
+    )
+    storage.save_project_notifications(
+        proj_b["id"],
+        telegram_bot_token=crypto.encrypt_token(_tg_token("0000000002")),
+        telegram_chat_id="bbb",
+        throttle_minutes=20,
+    )
+
+    captures = []
+    def fake_notify(pid, table, ts, score, *, bot_token, chat_id,
+                    throttle_minutes=None, metric="row_count"):
+        captures.append({"pid": pid, "chat_id": chat_id})
+
+    monkeypatch.setattr(
+        "app.notifications.telegram.notify_anomaly", fake_notify,
+    )
+
+    # Tick A — anomaly fires; B is not invoked at all.
+    _run_collect_with_anomaly_stub(
+        storage, proj_a["id"], conn_a["id"], "orders",
+        is_anomaly=True, monkeypatch=monkeypatch,
+    )
+    # Tick B — healthy, no notification.
+    _run_collect_with_anomaly_stub(
+        storage, proj_b["id"], conn_b["id"], "orders",
+        is_anomaly=False, monkeypatch=monkeypatch,
+    )
+
+    assert len(captures) == 1
+    assert captures[0]["pid"] == proj_a["id"]
+    assert captures[0]["chat_id"] == "aaa"


### PR DESCRIPTION
Closes #154. Замыкает цикл #143: до этого PR настройка Telegram в `/settings/notifications` сохранялась, но реальные алерты не приходили — legacy global scheduler по дизайну #143 немой, а `collect_for_connection` не делал post-tick analysis вообще.

## Что меняется

### 1. `collect_for_connection` (per-tick)
После успешного `save_metrics` зовёт `_maybe_notify_anomalies(project_id, tables)`. Если коннект ничего не собрал (`rows_saved=0`) — анализ пропускается.

### 2. `_load_telegram_config(project_id)`
- Подтягивает `project_notifications` ряд
- Расшифровывает `bot_token` через `crypto.decrypt_token`
- Возвращает `(bot_token, chat_id, throttle_minutes)` или `None` если конфиг отсутствует / не до конца заполнен / не дешифруется
- `InvalidToken` логируется как warning (Fernet ключ повёрнут без re-encrypt?)
- **Никакого fallback на `settings.TELEGRAM_*`** — silence by default

### 3. `_maybe_notify_anomalies`
Итерирует таблицы **только этого коннекта** (не глобальный `list_tables()` как в legacy), для каждой:
- `score_table(name, project_id=...)` — уже per-tenant с #53
- `save_anomaly_scores` с правильным `project_id`
- latest anomaly → `notify_anomaly` с проектным `bot_token` / `chat_id` / `throttle`
- `InsufficientDataError` — quiet skip (свежие таблицы)

## Out of scope (отдельные тикеты)

- **Schema-drift per-tenant** — требует `project_id` на `schema_snapshots` / `schema_events`. Нужна миграция.
- **Changepoint per-tenant** — `detect_all` сейчас глобальный cron-job.
- **Демонтаж legacy scheduler-side `_notify_*`** — пусть остаётся silent shim для `legacy` bucket, удалить можно после переезда schema-drift / changepoint.

## Тесты (4 новых кейса в `test_per_project.py`)

1. `test_collect_for_connection_notifies_when_configured` — тенант с валидной конфигой получает `notify_anomaly` с **СВОИМИ** `bot_token` / `chat_id` на confirmed anomaly. Проверяется передача всех трёх полей (token, chat_id, throttle).

2. `test_collect_for_connection_skips_notify_when_not_configured` — тенант без `project_notifications` ряда → **0 notify calls** даже на anomaly. Защита от cross-tenant leak.

3. `test_collect_for_connection_skips_notify_when_no_anomaly` — healthy score → 0 notify (throttle даже не трогается).

4. `test_collect_for_connection_cross_tenant_notification_isolation` — два тенанта, anomaly только в A → только A получает alert с `chat_id=aaa`, B не вызывается. Пинит invariant на wiring-уровне.

## Verification

- 543 passed (4 новых + 539 существующих)
- `ruff check` clean

## Test plan

- [x] Юнит-тесты на configured / not-configured / no-anomaly / cross-tenant
- [x] No fallback verified explicitly (skip_notify_when_not_configured)
- [ ] Manual smoke после merge: реальный Telegram bot + два юзера + симуляция anomaly → проверить что только нужный чат получает сообщение