### PR TITLE
feat(#102): Структурированные JSON-логи + request_id корреляция

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pinned: false
 - [Поддерживаемые СУБД](#поддерживаемые-субд)
 - [Запуск в Docker](#запуск-в-docker)
 - [Переменные окружения](#переменные-окружения)
+- [Логи](#логи)
 - [Структура проекта](#структура-проекта)
 - [Функциональность](#функциональность)
 ---
@@ -441,12 +442,48 @@ DATABASE_URL=postgresql://postgres.<project>:<PASSWORD>@aws-0-<region>.pooler.su
 | `SECRET_KEY`         | ✅           | —                         | Секрет для Flask-сессий/CSRF                  |
 | `COLLECT_INTERVAL_MINUTES` | —      | `15`                      | Интервал коллектора метрик                    |
 | `LOG_LEVEL`          | —            | `INFO`                    | Уровень логирования                           |
+| `LOG_FORMAT`         | —            | `text`                    | `text` (dev) или `json` (Loki/ELK/Datadog) — см. [Логи](#логи) |
 | `FLASK_ENV`          | —            | `development`             | Режим Flask                                   |
 | `HOST`               | —            | `127.0.0.1`               | Bind-адрес (в Docker — `0.0.0.0`)             |
 | `PORT`               | —            | `5001`                    | Порт HTTP-сервера                             |
 | `FLASK_DEBUG`        | —            | `1` (Docker — `0`)        | Включает дебаг и автоперезапуск Flask         |
 
 > ⚠️ Файл `.env` содержит секреты — не коммитить в git.
+
+---
+
+## Логи
+
+По умолчанию приложение пишет логи свободным текстом в stdout — удобно
+для локальной разработки. Для прода поставь `LOG_FORMAT=json` —
+каждая строка станет одной JSON-записью, парсимой Loki / ELK / Datadog
+без ingest-side регулярок.
+
+```bash
+LOG_FORMAT=json python -m app.app | jq .
+```
+
+Обязательные поля в JSON-режиме: `timestamp` (ISO 8601 с миллисекундами,
+UTC), `level`, `logger`, `message`, `request_id`. Дополнительно:
+`exc_info` для перехваченных исключений, любые поля переданные в
+`logger.info(..., extra={...})`.
+
+### Корреляция запросов
+
+Каждый HTTP-запрос получает уникальный `request_id` (UUID4 hex). Если
+upstream-прокси прислал заголовок `X-Request-Id`, он используется без
+изменений — это позволяет проследить запрос через несколько сервисов.
+
+Сервер эхо-возвращает `X-Request-Id` в каждом ответе, так что клиент
+может попросить сапорт «найти лог по этому id». Pipe-friendly grep:
+
+```bash
+docker compose logs -f app | jq 'select(.request_id == "a1b2…")'
+```
+
+DSN-пароли продолжают маскироваться через `DSNFilter` (#56) до того
+как formatter увидит запись — `topsecret` в исходном `logger.warning`
+превращается в `u:***@host` и в text-, и в JSON-выводе.
 
 ---
 

--- a/app/app.py
+++ b/app/app.py
@@ -13,6 +13,7 @@ from .connections import bp as connections_bp
 from .dashboard import bp as dashboard_bp
 from .dashboard import status_class
 from .health import build_health_payload
+from .logging_setup import configure_logging
 from .projects import bp as projects_bp
 from .projects import load_current_project_into_g
 from .security import init_logging_filter
@@ -66,6 +67,10 @@ def _maybe_install_proxy_fix(app: Flask) -> None:
 
 
 def create_app(config: dict | None = None):
+    # Order matters: configure formatters/handlers BEFORE the DSN-scrub
+    # filter so the scrubber gets attached to the JSON/text handler we
+    # actually use. _ensure_dsn_logging_filter is idempotent per process.
+    configure_logging(settings.LOG_FORMAT, level=settings.LOG_LEVEL)
     _ensure_dsn_logging_filter()
     app = Flask(__name__)
     app.config["SECRET_KEY"] = settings.SECRET_KEY
@@ -146,6 +151,30 @@ def create_app(config: dict | None = None):
     # Runs *after* the login gate above (Flask runs before_request hooks in
     # registration order), so anonymous requests never hit the DB lookup.
     app.before_request(load_current_project_into_g)
+
+    # Request-id correlation (#102). Honour upstream X-Request-Id if a load
+    # balancer / proxy issued one; otherwise mint a fresh uuid4. The id is
+    # echoed back on the response so a caller can grep server logs after
+    # the fact. JsonFormatter pulls g.request_id into every log line.
+    @app.before_request
+    def _assign_request_id():
+        import uuid
+
+        from flask import g, request
+        upstream = request.headers.get("X-Request-Id", "").strip()
+        # Cap incoming header length so a hostile peer can't make logs
+        # disgusting; UUID hex is 32 chars, give a 4× buffer for upstream
+        # systems that prefix their own tracing IDs.
+        g.request_id = upstream[:128] if upstream else uuid.uuid4().hex
+
+    @app.after_request
+    def _echo_request_id(response):
+        from flask import g
+
+        rid = getattr(g, "request_id", None)
+        if rid:
+            response.headers["X-Request-Id"] = rid
+        return response
 
     @app.route("/")
     def index():

--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,10 @@ class Settings(BaseSettings):
     # Уровень логирования
     LOG_LEVEL: str = "INFO"
 
+    # Формат логов (#102): "text" (default — человеко-читаемо, dev) или
+    # "json" (одна JSON-строка на запись, парсится в Loki/ELK/Datadog).
+    LOG_FORMAT: str = "text"
+
     # Режим Flask
     FLASK_ENV: str = "development"
 

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -1,0 +1,119 @@
+"""Structured JSON logging (#102).
+
+Default mode is human-readable text — what local dev wants. Set
+``LOG_FORMAT=json`` in env and every emitted log line becomes a single
+JSON object, parsable by Loki / ELK / Datadog without ingest-side regex.
+
+Why a hand-rolled formatter instead of ``python-json-logger``?
+- One library file, ~50 lines, no new dependency.
+- We need to pull ``request_id`` from ``flask.g`` — small custom hook
+  is cleaner than configuring an external formatter to do the same.
+- ``setLogRecordFactory`` (installed in ``app.security``) already scrubs
+  DSN passwords before any formatter sees the record, so the JSON
+  output is automatically safe — no extra integration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+
+# Keys present on every ``LogRecord`` by default. We skip them when
+# harvesting "extra" fields supplied via logger.info(..., extra={...}),
+# otherwise the JSON payload would balloon with framework noise.
+_STANDARD_RECORD_ATTRS = {
+    "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+    "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+    "created", "msecs", "relativeCreated", "thread", "threadName",
+    "processName", "process", "taskName", "message", "asctime",
+}
+
+
+class JsonFormatter(logging.Formatter):
+    """One JSON object per line — keys are stable, values are scrubbed.
+
+    Required fields: ``timestamp``, ``level``, ``logger``, ``message``,
+    ``request_id``. Additional fields:
+    - ``exc_info`` (stringified traceback) when present
+    - any ``extra={...}`` dict keys passed to the log call
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        # ``record.getMessage`` applies %-formatting using already-scrubbed
+        # args (LogRecord factory in app.security runs first), so the
+        # rendered string can never resurrect a plaintext DSN here.
+        payload: dict = {
+            "timestamp": (
+                datetime.fromtimestamp(record.created, tz=UTC)
+                .isoformat(timespec="milliseconds")
+            ),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "request_id": _request_id_from_context(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+
+        # Honour anything passed via `extra=...`. Values that can't be
+        # JSON-serialised are str()-ed — better than dropping the call.
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_RECORD_ATTRS or key in payload:
+                continue
+            try:
+                json.dumps(value)
+            except TypeError:
+                value = str(value)
+            payload[key] = value
+
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def _request_id_from_context() -> str | None:
+    """Best-effort pull of ``g.request_id`` set by the Flask before_request
+    hook. Returns None outside an app context (background scheduler ticks,
+    CLI invocations) so the field stays present but null."""
+    try:
+        from flask import g, has_app_context
+    except ImportError:  # pragma: no cover - Flask is a hard dep
+        return None
+    if not has_app_context():
+        return None
+    return getattr(g, "request_id", None)
+
+
+def configure_logging(log_format: str, level: str = "INFO") -> None:
+    """Install the chosen formatter on the root handler.
+
+    Idempotent: re-installing replaces the previous handler so repeated
+    ``create_app()`` calls in tests don't stack StreamHandlers.
+
+    ``log_format``:
+      - ``"json"`` — JsonFormatter, stdout
+      - anything else — default human-readable text
+    """
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    # Drop our previously-installed handler (if any) so this function can
+    # be called more than once per process without accumulating handlers.
+    for h in list(root.handlers):
+        if getattr(h, "_dbmon_managed", False):
+            root.removeHandler(h)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler._dbmon_managed = True  # type: ignore[attr-defined]
+    if log_format.lower() == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s: %(message)s"
+        ))
+    root.addHandler(handler)
+
+
+__all__ = ["JsonFormatter", "configure_logging"]

--- a/tests/test_logging_json.py
+++ b/tests/test_logging_json.py
@@ -1,0 +1,245 @@
+"""JSON-log tests (#102).
+
+Cover the explicit acceptance criteria:
+- LOG_FORMAT=json → every log line is valid JSON with all required fields
+- request_id flows from g.request_id into every record within the request
+- DSN scrubbing from #56 stays effective (regression guard)
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import re
+
+import pytest
+
+from app.logging_setup import JsonFormatter, configure_logging
+
+
+def _capture_records_via(formatter: logging.Formatter, *,
+                         logger_name: str, msg: str, **extra) -> str:
+    """Render one log record through ``formatter`` and return the line.
+
+    A dedicated logger + handler stack keeps the test from depending on
+    whatever the global root handler currently is.
+    """
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(formatter)
+    logger = logging.getLogger(logger_name)
+    logger.handlers = [handler]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    try:
+        logger.info(msg, extra=extra) if extra else logger.info(msg)
+    finally:
+        logger.handlers = []
+    return buf.getvalue().strip()
+
+
+# ── JsonFormatter shape ────────────────────────────────────────────────────
+
+def test_json_formatter_required_fields():
+    """Every line includes timestamp, level, logger, message, request_id."""
+    line = _capture_records_via(
+        JsonFormatter(),
+        logger_name="test_required",
+        msg="hello",
+    )
+    record = json.loads(line)
+    for field in ("timestamp", "level", "logger", "message", "request_id"):
+        assert field in record
+    assert record["level"] == "INFO"
+    assert record["logger"] == "test_required"
+    assert record["message"] == "hello"
+    # No flask app context → request_id stays null but the field is present.
+    assert record["request_id"] is None
+
+
+def test_json_formatter_includes_iso_utc_timestamp():
+    line = _capture_records_via(
+        JsonFormatter(), logger_name="ts", msg="x",
+    )
+    record = json.loads(line)
+    # 2026-05-30T12:34:56.789+00:00 — millisecond precision, UTC offset.
+    assert re.match(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+00:00",
+        record["timestamp"],
+    )
+
+
+def test_json_formatter_includes_extra_fields():
+    """logger.info(..., extra={'k': v}) → JSON payload has 'k'."""
+    line = _capture_records_via(
+        JsonFormatter(), logger_name="ex", msg="x",
+        project_id="proj-A", connection_id="conn-X",
+    )
+    record = json.loads(line)
+    assert record["project_id"] == "proj-A"
+    assert record["connection_id"] == "conn-X"
+
+
+def test_json_formatter_includes_exc_info():
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(JsonFormatter())
+    logger = logging.getLogger("exc_test")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    try:
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            logger.exception("caught")
+    finally:
+        logger.handlers = []
+    record = json.loads(buf.getvalue().strip())
+    assert record["message"] == "caught"
+    assert "ValueError" in record["exc_info"]
+    assert "boom" in record["exc_info"]
+
+
+def test_json_formatter_handles_unserialisable_extra():
+    """An object that isn't JSON-serialisable must NOT crash the formatter.
+    We fall back to str(value)."""
+    class NotSerializable:
+        def __repr__(self):
+            return "<NotSerializable instance>"
+
+    line = _capture_records_via(
+        JsonFormatter(), logger_name="bad", msg="x",
+        widget=NotSerializable(),
+    )
+    record = json.loads(line)
+    assert record["widget"] == "<NotSerializable instance>"
+
+
+# ── configure_logging integration ──────────────────────────────────────────
+
+def test_configure_logging_idempotent_handler_count():
+    """Repeated configure_logging() must not stack handlers on root —
+    tests do create_app() dozens of times per session, would otherwise
+    leak into a 50-line log per record."""
+    root = logging.getLogger()
+    before = len([h for h in root.handlers if getattr(h, "_dbmon_managed", False)])
+    configure_logging("text")
+    configure_logging("json")
+    configure_logging("text")
+    after = len([h for h in root.handlers if getattr(h, "_dbmon_managed", False)])
+    # Exactly one managed handler regardless of how many times we called.
+    assert before in (0, 1)
+    assert after == 1
+
+
+def test_configure_logging_json_mode_attached(monkeypatch):
+    configure_logging("json")
+    root = logging.getLogger()
+    managed = [h for h in root.handlers if getattr(h, "_dbmon_managed", False)]
+    assert len(managed) == 1
+    assert isinstance(managed[0].formatter, JsonFormatter)
+
+
+# ── Flask request_id propagation ───────────────────────────────────────────
+
+@pytest.fixture
+def app_(tmp_path, monkeypatch):
+    import app.metrics_storage as storage
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "log.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+    monkeypatch.setattr(cfg, "LOG_FORMAT", "json")
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    return create_app({"TESTING": True})
+
+
+def test_request_id_is_set_and_echoed_back(app_):
+    """Each request gets a unique uuid4-shaped request_id, echoed on the
+    response header so clients can correlate."""
+    c = app_.test_client()
+    r1 = c.get("/healthz")
+    r2 = c.get("/healthz")
+    rid1 = r1.headers.get("X-Request-Id")
+    rid2 = r2.headers.get("X-Request-Id")
+    assert rid1 and rid2
+    assert rid1 != rid2
+    assert re.fullmatch(r"[0-9a-f]{32}", rid1)
+
+
+def test_request_id_honours_upstream_header(app_):
+    """A reverse proxy (or test harness) can pre-seed the id — we honour
+    it so a request can be traced through multiple services."""
+    c = app_.test_client()
+    rid = "trace-from-edge-1234567890abcdef"
+    r = c.get("/healthz", headers={"X-Request-Id": rid})
+    assert r.headers["X-Request-Id"] == rid
+
+
+def test_request_id_appears_in_json_logs_within_request(app_, caplog):
+    """JsonFormatter must observe g.request_id while inside a request."""
+    rid = "deterministic-test-rid"
+    # We don't intercept the actual JSON stream; instead we render a
+    # record manually inside a synthetic app context to confirm the
+    # JsonFormatter pulls g.request_id.
+    formatter = JsonFormatter()
+    with app_.test_request_context("/healthz",
+                                    headers={"X-Request-Id": rid}):
+        # Simulate the before_request hook (test_request_context doesn't
+        # auto-fire app-level hooks).
+        from flask import g
+        g.request_id = rid
+        rec = logging.makeLogRecord({
+            "name": "ctx", "msg": "hi", "levelname": "INFO",
+            "levelno": 20, "args": (), "created": 1700000000.123,
+        })
+        rec.message = "hi"
+        line = formatter.format(rec)
+    payload = json.loads(line)
+    assert payload["request_id"] == rid
+    # Suppress unused warning from caplog parameter.
+    assert caplog is not None
+    # Sanity: outside the context, request_id is None.
+    rec_out = logging.makeLogRecord({
+        "name": "ctx", "msg": "hi", "levelname": "INFO",
+        "levelno": 20, "args": (), "created": 1700000000.123,
+    })
+    rec_out.message = "hi"
+    assert json.loads(formatter.format(rec_out))["request_id"] is None
+
+
+# ── DSN scrubbing regression (from #56) ────────────────────────────────────
+
+def test_dsn_scrub_still_works_under_json_formatter():
+    """Logging a DSN-containing message must NOT include the password
+    in the JSON payload. The record factory in app.security scrubs at
+    LogRecord construction, so the formatter never sees the secret.
+    """
+    from app.security import install_log_record_scrubber
+
+    install_log_record_scrubber()  # idempotent
+    logger = logging.getLogger("scrub_under_json")
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(JsonFormatter())
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    try:
+        logger.warning("connect failed: %s",
+                       "postgresql://u:topsecret@h:5432/d")
+    finally:
+        logger.handlers = []
+
+    line = buf.getvalue().strip()
+    payload = json.loads(line)
+    assert "topsecret" not in payload["message"]
+    assert "u:***@h" in payload["message"]


### PR DESCRIPTION
Closes #102. Sprint 4 production-readiness: `LOG_FORMAT=json` выдаёт одну JSON-запись на строку, парсится Loki/ELK/Datadog без ingest-side регулярок. Каждая запись несёт `request_id` — UUID4 hex per HTTP-request (или upstream `X-Request-Id` если прокся прислала).

## Что внутри

### `app/logging_setup.py` — JsonFormatter (~50 строк, без зависимостей)
Кастомный formatter поверх stdlib `logging` — `python-json-logger` был бы лишним кодом ради 1 файла. Поля:

- **Обязательные**: `timestamp` (ISO 8601 ms UTC), `level`, `logger`, `message`, `request_id`
- `exc_info` / `stack_info` автоматически при их наличии
- `extra={...}` из `logger.info(..., extra=...)` попадает в payload поверх стандартных полей
- Несериализуемые объекты → str() fallback, formatter не крашится

`configure_logging(format, level)` идемпотентна — handler помечен `_dbmon_managed`, повторные вызовы заменяют его. Тесты делают `create_app()` десятки раз — иначе бы handlers стекались.

### `request_id` propagation (`app/app.py`)

- `@before_request`: `g.request_id = X-Request-Id header || uuid4().hex`. Cap 128 символов — враждебный peer не загадит логи мегабайтным header-ом.
- `@after_request`: echo `X-Request-Id` в ответе. Клиент знает id и может попросить сапорт «найдите по этому».
- JsonFormatter pulls `g.request_id` через `has_app_context` guard. Вне request (background scheduler, CLI) → `null`, но поле всегда присутствует — единый shape для всех source-ов.

### `settings.LOG_FORMAT` = `text` (default, dev) | `json` (prod)

`configure_logging` вызывается в `create_app` ПЕРЕД DSN-scrub фильтром — формат подменяется на JSON до того, как scrub устанавливается.

### DSN-scrub продолжает работать

`setLogRecordFactory` из #56 мутирует `record.msg` / `record.args` ДО того как formatter их видит. JSON-payload автоматически безопасный — никакой дополнительной интеграции. Регрессионный тест подтверждает: `topsecret` в DSN → не попадает в JSON-сообщение.

## Acceptance из тикета

- [x] Зависимость — собственный JsonFormatter ~50 строк (не `python-json-logger`)
- [x] `configure_logging()` устанавливает JsonFormatter на root handler при `LOG_FORMAT=json`
- [x] Обязательные поля: `timestamp`, `level`, `logger`, `message`, `request_id`
- [x] DSNFilter из #56 продолжает работать (regression test)
- [x] Каждая строка — валидный JSON со всеми обязательными полями
- [x] README: новый раздел «Логи» с примерами

## Тесты (11 кейсов, `tests/test_logging_json.py`)

JsonFormatter shape:
- все обязательные поля
- ISO timestamp с ms precision
- extra-поля попадают в payload
- exc_info с трейсбеком
- несериализуемые объекты → str fallback

configure_logging:
- idempotent (handler count не растёт)
- json mode — handler с JsonFormatter

Flask integration:
- request_id уникален между запросами
- echo в X-Request-Id response header
- upstream X-Request-Id honoured
- request_id propagates в JSON payload внутри context, null вне

DSN scrub regression:
- `topsecret` в DSN → JSON-message содержит `u:***@host`, не пароль

## Live smoke

```
$ LOG_FORMAT=json python -c "import logging; from app.logging_setup import configure_logging; configure_logging('json'); logging.getLogger('smoke').info('hello world', extra={'project_id': 'demo'})"
{"timestamp": "2026-05-30T10:26:36.084+00:00", "level": "INFO", "logger": "smoke", "message": "hello world", "request_id": null, "project_id": "demo"}
```

## Verification

- **568 passed** (11 новых + 557 существующих)
- ruff clean

## Test plan

- [x] Юнит-тесты на shape + integration + регрессию scrub
- [x] Live smoke на реальный запуск
- [ ] Manual smoke после merge: `LOG_FORMAT=json make server`, открыть pre-prod, grep по `request_id` через `docker compose logs | jq`