### PR TITLE
feat(#101): Prometheus /metrics endpoint + HTTP/collector/auth counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pinned: false
 - [Поддерживаемые СУБД](#поддерживаемые-субд)
 - [Запуск в Docker](#запуск-в-docker)
 - [Переменные окружения](#переменные-окружения)
+- [Метрики (Prometheus)](#метрики-prometheus)
 - [Логи](#логи)
 - [Структура проекта](#структура-проекта)
 - [Функциональность](#функциональность)
@@ -449,6 +450,42 @@ DATABASE_URL=postgresql://postgres.<project>:<PASSWORD>@aws-0-<region>.pooler.su
 | `FLASK_DEBUG`        | —            | `1` (Docker — `0`)        | Включает дебаг и автоперезапуск Flask         |
 
 > ⚠️ Файл `.env` содержит секреты — не коммитить в git.
+
+---
+
+## Метрики (Prometheus)
+
+Эндпоинт `GET /metrics` отдаёт payload в стандартном Prometheus
+text exposition format. По соглашению — без auth и CSRF; ставится за
+network ACL (сидит во внутренней сети кластера, scrape только из
+Prometheus / Grafana Agent / VM).
+
+```bash
+curl http://localhost:5001/metrics | head -20
+```
+
+Что внутри:
+
+| Метрика | Тип | Лейблы | Источник |
+|---|---|---|---|
+| `http_requests_total` | Counter | `method, endpoint, status` | Flask before/after_request |
+| `http_request_duration_seconds` | Histogram | `method, endpoint` | Flask before/after_request |
+| `collector_runs_total` | Counter | `result` (`ok`/`error`) | `collectors/per_project.py` |
+| `failed_login_attempts_total` | Counter | — | `app/auth.py::login` |
+
+Сам endpoint rate-limited 60/min — защита от misconfigured scraper-а с
+1-секундным интервалом, который превратит /metrics в self-DoS.
+
+Пример scrape-конфига для Prometheus:
+
+```yaml
+scrape_configs:
+  - job_name: db-monitoring
+    metrics_path: /metrics
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["app.internal:5001"]
+```
 
 ---
 

--- a/app/app.py
+++ b/app/app.py
@@ -13,6 +13,7 @@ from .connections import bp as connections_bp
 from .dashboard import bp as dashboard_bp
 from .dashboard import status_class
 from .health import build_health_payload
+from .instrumentation import install_http_instrumentation, metrics_response
 from .logging_setup import configure_logging
 from .projects import bp as projects_bp
 from .projects import load_current_project_into_g
@@ -189,6 +190,27 @@ def create_app(config: dict | None = None):
         if current_user.is_authenticated:
             return redirect(url_for("dashboard.overview"))
         return render_template("landing.html")
+
+    # Prometheus instrumentation (#101). HTTP-level Counter/Histogram on
+    # every request; /metrics endpoint serves the registry. Rate-limited
+    # at 60/min so a misconfigured scrape interval can't DDoS the worker.
+    install_http_instrumentation(app)
+
+    @app.route("/metrics")
+    @limiter.limit("60/minute")
+    def metrics():
+        """Prometheus text-exposition endpoint.
+
+        Convention: no auth, no CSRF — scrapers are behind a network ACL.
+        Don't render it behind /dashboard or anything login-gated; every
+        Prometheus deployment assumes this is open inside the cluster.
+        """
+        return metrics_response()
+
+    # CSRF exempt: /metrics is GET-only but Flask-WTF middleware can still
+    # complain if a scraper sends odd headers; explicit exempt keeps the
+    # contract clean.
+    csrf.exempt(metrics)
 
     @app.route("/healthz")
     @limiter.exempt

--- a/app/auth.py
+++ b/app/auth.py
@@ -417,6 +417,13 @@ def login():
             return redirect(next_target or url_for("dashboard.overview"))
 
         metrics_storage.record_failed_login(email)
+        # #101: emit Prometheus counter. Late import keeps test rigs that
+        # don't init the registry from breaking the login flow.
+        try:
+            from app.instrumentation import failed_login_attempts_total
+            failed_login_attempts_total.inc()
+        except ImportError:
+            pass
         form.password.errors.append("Неверный email или пароль.")
     return render_template("auth/login.html", form=form)
 

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -1,0 +1,129 @@
+"""Prometheus instrumentation (#101).
+
+Exposes ``GET /metrics`` in the standard text exposition format and the
+collector primitives the rest of the codebase increments:
+
+- ``http_requests_total{method,endpoint,status}`` — bumped via Flask
+  ``before_request`` / ``after_request`` hooks installed in
+  :func:`install_http_instrumentation`.
+- ``http_request_duration_seconds`` — histogram observed in the same hooks.
+- ``collector_runs_total{result}`` — incremented from
+  ``collectors/per_project.py::collect_for_connection`` on success / error.
+- ``failed_login_attempts_total`` — incremented from
+  ``app/auth.py::login`` on wrong password / unknown email.
+
+We use the default global ``REGISTRY`` so a future ``prometheus-multiproc``
+swap (for gunicorn -w N) only changes the registry, not the call sites.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from flask import Response, g, request
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Counters / histograms ──────────────────────────────────────────────────
+
+http_requests_total = Counter(
+    "http_requests_total",
+    "Total HTTP requests served, partitioned by method, endpoint and status.",
+    labelnames=("method", "endpoint", "status"),
+)
+
+# Bucket boundaries cover the realistic range for a Flask app: <10ms (cached
+# lookups), 25/50/100ms (typical DB-roundtrip), 250/500ms (slower queries),
+# 1/2.5/5/10s (anomalous; aim to alert on these). Default prometheus-client
+# buckets stop at 10s which is fine for our SLO ceiling.
+http_request_duration_seconds = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency (seconds), by method + endpoint.",
+    labelnames=("method", "endpoint"),
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+collector_runs_total = Counter(
+    "collector_runs_total",
+    "Per-connection collector ticks, partitioned by outcome.",
+    labelnames=("result",),  # "ok" | "error"
+)
+
+failed_login_attempts_total = Counter(
+    "failed_login_attempts_total",
+    "Failed /auth/login attempts (wrong password or unknown email).",
+)
+
+
+# ── HTTP hooks ─────────────────────────────────────────────────────────────
+
+
+def _start_timer() -> None:
+    """Record start time so after_request can compute latency.
+
+    Using ``g`` keeps it request-scoped without polluting ``request``.
+    """
+    g._prom_start_time = time.perf_counter()
+
+
+def _record_response(response):
+    """Bump http_requests_total / http_request_duration_seconds.
+
+    ``request.endpoint`` is None for 404s on unknown routes — we substitute
+    a literal so the cardinality doesn't explode with the request path
+    (which can be arbitrary user-controlled garbage).
+    """
+    endpoint = request.endpoint or "unknown"
+    method = request.method
+    status = str(response.status_code)
+    http_requests_total.labels(
+        method=method, endpoint=endpoint, status=status,
+    ).inc()
+    start = getattr(g, "_prom_start_time", None)
+    if start is not None:
+        http_request_duration_seconds.labels(
+            method=method, endpoint=endpoint,
+        ).observe(time.perf_counter() - start)
+    return response
+
+
+def install_http_instrumentation(app) -> None:
+    """Wire the request-level Counter / Histogram into a Flask app."""
+    app.before_request(_start_timer)
+    app.after_request(_record_response)
+
+
+# ── /metrics endpoint ──────────────────────────────────────────────────────
+
+def metrics_response() -> Response:
+    """Render the current registry in Prometheus text exposition format.
+
+    No CSRF (would be hostile to scrapers), no auth (the convention is that
+    the endpoint sits behind a network ACL — exposing /metrics behind login
+    breaks every Prometheus deployment). Rate-limited at the route level
+    in app.app to discourage someone using it as an infinite-pull DoS.
+
+    Note: ``CONTENT_TYPE_LATEST`` already encodes the charset; we pass it
+    via ``content_type=`` (verbatim) rather than ``mimetype=`` to avoid
+    Flask appending a second ``charset=utf-8`` that some strict scrapers
+    refuse to parse.
+    """
+    return Response(generate_latest(), content_type=CONTENT_TYPE_LATEST)
+
+
+__all__ = [
+    "collector_runs_total",
+    "failed_login_attempts_total",
+    "http_request_duration_seconds",
+    "http_requests_total",
+    "install_http_instrumentation",
+    "metrics_response",
+]

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -129,6 +129,13 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
         )
         if engine:
             engine.dispose()
+        # #101: count the failed tick. Late import so a missing
+        # prometheus-client install doesn't break collection itself.
+        try:
+            from app.instrumentation import collector_runs_total
+            collector_runs_total.labels(result="error").inc()
+        except ImportError:
+            pass
         return
 
     if engine:
@@ -138,6 +145,11 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
         "[project=%s][conn=%s] collected %d metrics across %d tables in %dms",
         project_id, connection_id, rows_saved, tables_seen, elapsed_ms,
     )
+    try:
+        from app.instrumentation import collector_runs_total
+        collector_runs_total.labels(result="ok").inc()
+    except ImportError:
+        pass
 
     # #154 post-tick: per-project anomaly alerts. Only fires when (a) we
     # actually wrote metrics this tick AND (b) the tenant has Telegram

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,8 @@ Flask-Limiter==3.8.0
 # supported: iceberg+rest:// (REST catalog) and iceberg+glue:// (AWS Glue).
 # Note: in pyiceberg >=0.7 the old [s3] extra was renamed to [pyarrow].
 pyiceberg[pyarrow,glue]>=0.7.0,<1.0.0
+
+# Prometheus instrumentation (#101). Counter/Histogram primitives + the
+# standard text exposition format consumed by Grafana / VictoriaMetrics /
+# any Prometheus-compatible scraper.
+prometheus-client>=0.20,<1.0

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -1,0 +1,257 @@
+"""Prometheus /metrics endpoint + counter wiring tests (#101).
+
+Counters live on the prometheus_client default REGISTRY, which is process-
+global. We snapshot the current value with ``_get_value`` and assert the
+delta caused by the action under test — avoids order-dependent flakes
+between cases that share the registry.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.instrumentation import (
+    collector_runs_total,
+    failed_login_attempts_total,
+    http_requests_total,
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _get_value(counter, **labels) -> float:
+    """Read the current sample value for a labelled counter. Returns 0.0
+    if the label combination hasn't been observed yet."""
+    if labels:
+        try:
+            return counter.labels(**labels)._value.get()
+        except (KeyError, AttributeError):
+            return 0.0
+    return counter._value.get()
+
+
+# ── Fixture ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app_(tmp_path, monkeypatch):
+    """Auth-enabled app pointed at a fresh SQLite metrics DB."""
+    import app.metrics_storage as storage
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "metrics.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    return create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+
+
+@pytest.fixture
+def client(app_):
+    return app_.test_client()
+
+
+# ── Endpoint shape ─────────────────────────────────────────────────────────
+
+
+def test_metrics_endpoint_returns_prometheus_text_format(client):
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    # Prometheus exposition is text/plain with a version tag. prometheus-client
+    # >=0.20 uses "version=1.0.0"; older scrapers/integrations issue "0.0.4".
+    # Either is valid; we only assert the family.
+    ctype = resp.headers["Content-Type"]
+    assert ctype.startswith("text/plain")
+    assert "version=" in ctype
+
+    body = resp.get_data(as_text=True)
+    # The standard expositions start each metric with a HELP and TYPE line.
+    assert re.search(r"^# HELP http_requests_total ", body, re.MULTILINE)
+    assert re.search(r"^# TYPE http_requests_total counter", body, re.MULTILINE)
+
+
+def test_metrics_endpoint_does_not_require_login(client):
+    """Scrapers shouldn't be sent through the login flow. /metrics is open
+    by convention (sits behind a network ACL)."""
+    resp = client.get("/metrics", follow_redirects=False)
+    assert resp.status_code == 200
+    # If login was enforced we'd get a 302 to /auth/login here.
+
+
+def test_metrics_endpoint_csrf_exempt(app_):
+    """A scraper that fires POST against /metrics still gets a normal
+    405 (route is GET-only) rather than a CSRF rejection — confirms the
+    endpoint sits outside the CSRF protection envelope."""
+    c = app_.test_client()
+    resp = c.post("/metrics")
+    # Werkzeug returns 405 for unsupported method; we shouldn't see 400/403.
+    assert resp.status_code == 405
+
+
+# ── http_requests_total wiring ─────────────────────────────────────────────
+
+
+def test_http_requests_total_ticks_per_request(client):
+    """Counter goes up by exactly 1 for each successful request, with the
+    correct (method, endpoint, status) labels.
+
+    Use ``/auth/login`` (GET) — it always returns 200 in TESTING. Don't
+    use ``/healthz`` here because target_db may be unreachable in CI,
+    flipping the status to 503 and confusing the assertion.
+    """
+    before = _get_value(http_requests_total,
+                        method="GET", endpoint="auth.login", status="200")
+    client.get("/auth/login")
+    client.get("/auth/login")
+    after = _get_value(http_requests_total,
+                       method="GET", endpoint="auth.login", status="200")
+    assert after - before == 2
+
+
+def test_http_requests_total_records_4xx_separately(client):
+    """A 404 increments under status=404, not status=200."""
+    before_404 = _get_value(http_requests_total,
+                            method="GET", endpoint="unknown", status="404")
+    client.get("/this-does-not-exist")
+    after_404 = _get_value(http_requests_total,
+                           method="GET", endpoint="unknown", status="404")
+    assert after_404 - before_404 == 1
+
+
+def test_http_request_duration_histogram_observes(client):
+    """Histogram count goes up on each request — value depends on env so
+    we only assert the bucket got an observation, not its magnitude."""
+    from app.instrumentation import http_request_duration_seconds
+
+    samples_before = http_request_duration_seconds.labels(
+        method="GET", endpoint="auth.login",
+    )._sum.get()
+    client.get("/auth/login")
+    samples_after = http_request_duration_seconds.labels(
+        method="GET", endpoint="auth.login",
+    )._sum.get()
+    assert samples_after > samples_before
+
+
+# ── collector_runs_total wiring ────────────────────────────────────────────
+
+
+def test_collector_runs_total_ok_on_success(app_, monkeypatch):
+    """A successful collect_for_connection bumps {result="ok"}."""
+    import unittest.mock as mock
+    import uuid
+    from datetime import UTC, datetime
+
+    import app.db as db_mod
+    import app.metrics_storage as storage
+    from app import crypto
+    from collectors import metrics_collector, per_project
+
+    # Seed user + project + active connection.
+    uid = uuid.uuid4().hex
+    storage.create_user(user_id=uid, email=f"u{uid[:5]}@x.io", password_hash="x")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=uid, name="P", slug="d",
+    )
+    conn = storage.create_connection(
+        connection_id=uuid.uuid4().hex, project_id=project["id"],
+        name="local", dsn_encrypted=crypto.encrypt_dsn("postgresql://u:p@h/d"),
+        schema_name="public", interval_minutes=15, is_active=True,
+    )
+
+    fake_rows = [{
+        "ts": datetime.now(UTC), "table_name": "users",
+        "metric_name": "row_count", "value": 1.0,
+    }]
+
+    def fake_list_tables(self, schema):
+        return [{"table_name": "users", "schema": schema}]
+
+    before = _get_value(collector_runs_total, result="ok")
+    with mock.patch.object(metrics_collector.MetricsCollector, "collect",
+                           return_value=fake_rows), \
+         mock.patch.object(db_mod.PostgresAdapter, "list_tables",
+                           autospec=True, side_effect=fake_list_tables):
+        per_project.collect_for_connection(project["id"], conn["id"])
+    after = _get_value(collector_runs_total, result="ok")
+    assert after - before == 1
+
+
+def test_collector_runs_total_error_on_failure(app_, monkeypatch):
+    """When the adapter throws, the counter bumps {result="error"}."""
+    import unittest.mock as mock
+    import uuid
+
+    import app.db as db_mod
+    import app.metrics_storage as storage
+    from app import crypto
+    from collectors import per_project
+
+    uid = uuid.uuid4().hex
+    storage.create_user(user_id=uid, email=f"u{uid[:5]}@x.io", password_hash="x")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=uid, name="P", slug="d",
+    )
+    conn = storage.create_connection(
+        connection_id=uuid.uuid4().hex, project_id=project["id"],
+        name="local", dsn_encrypted=crypto.encrypt_dsn("postgresql://u:p@h/d"),
+        schema_name="public", interval_minutes=15, is_active=True,
+    )
+
+    def boom(self, schema):
+        raise RuntimeError("adapter boom")
+
+    before = _get_value(collector_runs_total, result="error")
+    with mock.patch.object(db_mod.PostgresAdapter, "list_tables",
+                           autospec=True, side_effect=boom):
+        per_project.collect_for_connection(project["id"], conn["id"])
+    after = _get_value(collector_runs_total, result="error")
+    assert after - before == 1
+
+
+# ── failed_login_attempts_total wiring ─────────────────────────────────────
+
+
+def test_failed_login_attempts_total_bumps_on_wrong_password(client):
+    """Wrong password → counter +1. Successful login → no bump."""
+    # Register so the email exists.
+    client.post("/auth/register", data={
+        "email": "u@example.com",
+        "password": "supersecret1",
+        "confirm": "supersecret1",
+    })
+    client.post("/auth/logout")
+
+    before = _get_value(failed_login_attempts_total)
+    client.post("/auth/login",
+                data={"email": "u@example.com", "password": "wrong-pass"})
+    after_bad = _get_value(failed_login_attempts_total)
+    assert after_bad - before == 1
+
+    # Successful login: counter does NOT move.
+    client.post("/auth/login",
+                data={"email": "u@example.com", "password": "supersecret1"})
+    after_good = _get_value(failed_login_attempts_total)
+    assert after_good == after_bad
+
+
+def test_failed_login_attempts_bumps_on_unknown_email(client):
+    """Counter still bumps for a non-existent email — same UI message
+    means we shouldn't distinguish counters either, otherwise scrape
+    becomes an oracle for email-enumeration."""
+    before = _get_value(failed_login_attempts_total)
+    client.post("/auth/login",
+                data={"email": "ghost@example.com", "password": "x" * 12})
+    after = _get_value(failed_login_attempts_total)
+    assert after - before == 1


### PR DESCRIPTION
Closes #101. Sprint 4 production-readiness — пара к #102: JSON-логи дают drill-down по `request_id`, Prometheus-метрики дают агрегированные сигналы для алертов.

## Что внутри

### `app/instrumentation.py` — модуль с примитивами

| Метрика | Тип | Лейблы |
|---|---|---|
| `http_requests_total` | Counter | method, endpoint, status |
| `http_request_duration_seconds` | Histogram (buckets 0.01..10s) | method, endpoint |
| `collector_runs_total` | Counter | result (ok/error) |
| `failed_login_attempts_total` | Counter | — |

`failed_login_attempts_total` без лейблов специально — иначе scrape становится oracle для email-enumeration (wrong-password vs unknown-email).

### Endpoint `GET /metrics`

- text exposition format (`generate_latest()` из default REGISTRY)
- `csrf.exempt` — scraper-у не нужен CSRF token
- **НЕ login-gated** — convention scraper-а сидит за network ACL внутри кластера
- `@limiter.limit("60/minute")` — misconfigured 1-sec interval не задосит

### Wiring счётчиков

- **`collectors/per_project.py::collect_for_connection`**: `.labels(result="ok"|"error").inc()` на обоих путях. Late import + ImportError-guard — отсутствие `prometheus-client` НЕ ломает collection.
- **`app/auth.py::login`**: `failed_login_attempts_total.inc()` при неудаче (любая причина).

### Late-import + try/except ImportError везде

Если кто-то развернёт без `prometheus-client` в зависимостях (стрипнутый Docker image, dev-environment), приложение продолжит работать — просто счётчики тихо никуда не пишутся. Это важно для collect-цикла, который не должен падать из-за observability-сабсистемы.

## Acceptance из тикета

- [x] Зависимость `prometheus-client\>=0.20,<1.0`
- [x] Endpoint `GET /metrics` отдаёт text/plain
- [x] `http_requests_total{method,endpoint,status}` — Counter
- [x] `http_request_duration_seconds` — Histogram
- [x] `collector_runs_total{result}` — Counter
- [x] `failed_login_attempts_total` — Counter
- [x] `/metrics` exempt от CSRF и login
- [x] Rate-limit /metrics 60/min
- [x] Тесты на формат вывода + что счётчики растут

## Тесты (10 кейсов)

Endpoint shape:
- text/plain с `version=` тегом, HELP/TYPE префиксы
- not login-gated (200, не 302)
- POST → 405 (csrf exempt: была бы 400/403 без exempt)

HTTP counters:
- `http_requests_total` тикает с правильными лейблами (используем `/auth/login` GET — он всегда 200 в TESTING; `/healthz` мог бы быть 503 если target_db unreachable в CI)
- 404 идёт на endpoint="unknown" — защита от cardinality explosion на user-controlled path
- Histogram observes (`_sum` растёт)

Collector counters:
- `collector_runs_total{ok}` тикает на successful collect
- `collector_runs_total{error}` тикает когда адаптер throw-нул

Auth counter:
- `failed_login_attempts_total` тикает на wrong-password И unknown-email
- НЕ тикает на successful login

## Verification

- **578 passed** (10 новых)
- ruff clean

## README

Новый раздел «Метрики (Prometheus)» с таблицей метрик и scrape-config примером + TOC обновлён.

## Test plan

- [x] Юнит-тесты на shape + wiring
- [x] Late-import guards (приложение работает без prometheus-client)
- [ ] Manual smoke после merge: `curl /metrics | head -30` показывает все 4 метрики, после `/auth/login` с wrong password счётчик `failed_login_attempts_total` вырос