### PR TITLE
fix(#162): ANALYZE после seed чтобы row_count не был 0 на первом тике

### DIFF
--- a/scripts/seed_target_db.py
+++ b/scripts/seed_target_db.py
@@ -221,6 +221,13 @@ def main(
     print(f"Seeding {n_events:,} events  (growing ip_address NULL-rate in last 7 days)...")
     _seed_events(engine, fake, user_ids, n_events)
 
+    # n_live_tup in pg_stat_user_tables stays 0 after bulk INSERT until ANALYZE
+    # or autovacuum runs — the metrics collector would show row_count=0 on the
+    # first tick. Run ANALYZE immediately so the dashboard is correct right away.
+    with engine.connect() as conn:
+        conn.execute(text("ANALYZE"))
+        conn.commit()
+
     print("\nDone! Seeded target DB:")
     print(f"  users    — {n_users:,} rows  (~5% email NULL)")
     print(f"  products — {n_products:,} rows")


### PR DESCRIPTION
## Описание

После `make seed` дашборд показывал «Строк: 0» для всех таблиц из-за того, что `n_live_tup` в `pg_stat_user_tables` остаётся 0 после bulk INSERT до первого `ANALYZE` или автовакуума.

Добавлен `ANALYZE` в конец `scripts/seed_target_db.py` — обновляет статистику сразу после вставки, дашборд показывает корректные цифры с первого тика коллектора.

Closes #162

## Тип изменения

- [x] Bug fix

## Чеклист

- [ ] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [x] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы (не применимо, схема не менялась)