### PR TITLE
fix(#153): изолировать Prophet-модели по project_id

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -118,7 +118,7 @@ def forecast_endpoint(table_name: str):
         return jsonify({"error": f"horizon must be one of {sorted(_HORIZONS)}"}), 400
 
     try:
-        points = run_forecast(table_name, metric, horizon_days=_HORIZONS[horizon])
+        points = run_forecast(table_name, metric, horizon_days=_HORIZONS[horizon], project_id=_current_project_id())
     except InsufficientDataError as e:
         return jsonify({"error": "insufficient_data", "message": str(e)}), 422
     return jsonify(points)

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -226,7 +226,7 @@ def retrain_forecasts() -> None:
     from ml.forecast import retrain_all
 
     logger.info("Job %s started", FORECAST_JOB_ID)
-    counts = retrain_all()
+    counts = retrain_all(project_id="legacy")
     logger.info("Job %s finished: %s", FORECAST_JOB_ID, counts)
 
 

--- a/ml/forecast.py
+++ b/ml/forecast.py
@@ -176,7 +176,7 @@ def train(
     table: str, metric: str = "row_count", project_id: str = "legacy"
 ) -> dict[str, Any]:
     """Fit a forecast model for (table, metric, project_id), persist it, return metadata."""
-    cps = get_changepoints(table, metric, window=timedelta(days=60))
+    cps = get_changepoints(table, metric, window=timedelta(days=60), project_id=project_id)
     last_cp_ts: str | None = cps[-1]["ts"] if cps else None
 
     if last_cp_ts is not None:
@@ -268,7 +268,7 @@ def forecast(
         )
     last_ts = points[-1][0]
 
-    cps = get_changepoints(table, metric, window=timedelta(days=60))
+    cps = get_changepoints(table, metric, window=timedelta(days=60), project_id=project_id)
     last_cp_ts = cps[-1]["ts"] if cps else None
 
     persisted = _load_persisted(table, metric, project_id)

--- a/ml/forecast.py
+++ b/ml/forecast.py
@@ -71,10 +71,10 @@ def _parse_ts(value: str | datetime) -> datetime:
     return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
 
 
-def _load_history(table: str, metric: str, days: int = 60) -> list[tuple[datetime, float]]:
-    # #53: global ML jobs read the 'legacy' tenant bucket. Per-project ML
-    # (#54) will plumb a real project_id through to this helper.
-    rows = get_metrics(table, metric, "legacy", window=timedelta(days=days))
+def _load_history(
+    table: str, metric: str, days: int = 60, project_id: str = "legacy"
+) -> list[tuple[datetime, float]]:
+    rows = get_metrics(table, metric, project_id, window=timedelta(days=days))
     return [(_parse_ts(r["ts"]), float(r["value"])) for r in rows]
 
 
@@ -164,13 +164,18 @@ def _predict_linear(
     return _anchor_shift(out, last_value)
 
 
-def _model_path(table: str, metric: str) -> Path:
+def _model_path(table: str, metric: str, project_id: str = "legacy") -> Path:
     safe = f"{table}__{metric}".replace("/", "_")
-    return MODELS_DIR / f"{safe}.joblib"
+    if project_id == "legacy":
+        return MODELS_DIR / f"{safe}.joblib"
+    safe_project = project_id.replace("/", "_").replace(" ", "_")
+    return MODELS_DIR / f"{safe_project}__{safe}.joblib"
 
 
-def train(table: str, metric: str = "row_count") -> dict[str, Any]:
-    """Fit a forecast model for (table, metric), persist it, return metadata."""
+def train(
+    table: str, metric: str = "row_count", project_id: str = "legacy"
+) -> dict[str, Any]:
+    """Fit a forecast model for (table, metric, project_id), persist it, return metadata."""
     cps = get_changepoints(table, metric, window=timedelta(days=60))
     last_cp_ts: str | None = cps[-1]["ts"] if cps else None
 
@@ -185,11 +190,11 @@ def train(table: str, metric: str = "row_count") -> dict[str, Any]:
             # ticks in, hence the explicit `p[0] >= since` filter.
             days_since = int(cp_age_days) + 2
             points = [
-                p for p in _load_history(table, metric, days=days_since)
+                p for p in _load_history(table, metric, days=days_since, project_id=project_id)
                 if p[0] >= since
             ]
             if len(points) < MIN_POINTS:
-                points = _load_history(table, metric)
+                points = _load_history(table, metric, project_id=project_id)
         else:
             # Recent changepoint — fitting on post-cp alone leaves only a
             # short flat plateau (e.g. ~10 ticks for a cp 10h ago), so the
@@ -199,9 +204,9 @@ def train(table: str, metric: str = "row_count") -> dict[str, Any]:
             # piecewise trend handles step shifts natively, and the linear
             # fallback at least carries the long-term slope rather than
             # extrapolating a single regime jump as a runaway trend.
-            points = _load_history(table, metric)
+            points = _load_history(table, metric, project_id=project_id)
     else:
-        points = _load_history(table, metric)
+        points = _load_history(table, metric, project_id=project_id)
 
     if len(points) < MIN_POINTS:
         raise InsufficientDataError(
@@ -225,16 +230,16 @@ def train(table: str, metric: str = "row_count") -> dict[str, Any]:
     }
     if _HAS_JOBLIB:
         try:
-            joblib.dump(payload, _model_path(table, metric))
+            joblib.dump(payload, _model_path(table, metric, project_id))
         except Exception as e:  # pragma: no cover
             logger.warning("Failed to persist model for %s/%s: %s", table, metric, e)
     return {"kind": kind, "points": len(points), "span_days": span_days}
 
 
-def _load_persisted(table: str, metric: str) -> dict | None:
+def _load_persisted(table: str, metric: str, project_id: str = "legacy") -> dict | None:
     if not _HAS_JOBLIB:
         return None
-    path = _model_path(table, metric)
+    path = _model_path(table, metric, project_id)
     if not path.exists():
         return None
     try:
@@ -248,6 +253,7 @@ def forecast(
     table: str,
     metric: str = "row_count",
     horizon_days: int = 7,
+    project_id: str = "legacy",
 ) -> list[dict]:
     """Return forecast points for the next ``horizon_days`` days.
 
@@ -255,7 +261,7 @@ def forecast(
     otherwise refits on demand. Raises InsufficientDataError when there isn't
     enough data even for the linear fallback.
     """
-    points = _load_history(table, metric)
+    points = _load_history(table, metric, project_id=project_id)
     if len(points) < MIN_POINTS:
         raise InsufficientDataError(
             f"need at least {MIN_POINTS} points for {table}/{metric}, got {len(points)}"
@@ -265,15 +271,15 @@ def forecast(
     cps = get_changepoints(table, metric, window=timedelta(days=60))
     last_cp_ts = cps[-1]["ts"] if cps else None
 
-    persisted = _load_persisted(table, metric)
+    persisted = _load_persisted(table, metric, project_id)
     fresh = (
         persisted is not None
         and _parse_ts(persisted["last_ts"]) >= last_ts - timedelta(hours=1)
         and persisted.get("last_changepoint_ts") == last_cp_ts
     )
     if not fresh:
-        train(table, metric)
-        persisted = _load_persisted(table, metric) or {
+        train(table, metric, project_id)
+        persisted = _load_persisted(table, metric, project_id) or {
             "kind": "linear",
             "model": _fit_linear(points),
         }
@@ -284,16 +290,21 @@ def forecast(
     return _predict_linear(persisted["model"], last_ts, horizon_days, last_value=last_value)
 
 
-def retrain_all(metrics: tuple[str, ...] = ("row_count",)) -> dict[str, int]:
+def retrain_all(
+    metrics: tuple[str, ...] = ("row_count",),
+    project_id: str = "legacy",
+    tables: list[str] | None = None,
+) -> dict[str, int]:
     """Retrain forecasts for every monitored table. Used by the nightly cron."""
-    from app.db import list_tables  # local import to avoid app cycles
+    if tables is None:
+        from app.db import list_tables  # local import to avoid app cycles
+        tables = [t["table_name"] for t in list_tables()]
 
     counts = {"trained": 0, "skipped": 0, "errors": 0}
-    for t in list_tables():
-        name = t["table_name"]
+    for name in tables:
         for m in metrics:
             try:
-                train(name, m)
+                train(name, m, project_id)
                 counts["trained"] += 1
             except InsufficientDataError:
                 counts["skipped"] += 1

--- a/scripts/warmup_ml.py
+++ b/scripts/warmup_ml.py
@@ -81,10 +81,10 @@ def warmup_anomalies(project_id: str = "legacy", tables: list[str] | None = None
     return {**train_counts, "scored": scored}
 
 
-def warmup_forecasts() -> dict:
+def warmup_forecasts(project_id: str = "legacy", tables: list[str] | None = None) -> dict:
     """Тренируем Prophet/linear по row_count для всех таблиц, кладём в models/."""
     from ml.forecast import retrain_all
-    return retrain_all()
+    return retrain_all(project_id=project_id, tables=tables)
 
 
 def warmup_drift(project_id: str = "legacy", tables: list[str] | None = None) -> dict:
@@ -107,7 +107,7 @@ def main(project_id: str = "legacy") -> dict:
     print(f"       {an}")
 
     print("[3/4] forecast retrain...")
-    fc = warmup_forecasts()
+    fc = warmup_forecasts(project_id=project_id, tables=table_scope)
     print(f"       {fc}")
 
     print("[4/4] drift cache refresh...")

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -196,9 +196,9 @@ def test_forecast_invalidates_cache_on_new_changepoint(tmp_path, monkeypatch):
     train_calls = []
 
     original_train = fc_mod.train
-    def spy_train(table, metric="row_count"):
+    def spy_train(table, metric="row_count", project_id="legacy"):
         train_calls.append((table, metric))
-        return original_train(table, metric)
+        return original_train(table, metric, project_id)
 
     with patch.object(fc_mod, "get_metrics", return_value=rows), \
          patch.object(fc_mod, "get_changepoints", return_value=new_cp), \
@@ -206,3 +206,34 @@ def test_forecast_invalidates_cache_on_new_changepoint(tmp_path, monkeypatch):
         fc_mod.forecast("t", "row_count", horizon_days=1)
 
     assert len(train_calls) == 1, "forecast() must retrain when changepoint is new"
+
+
+def test_model_path_isolated_per_project(tmp_path, monkeypatch):
+    """Two projects with the same table must not share a model file."""
+    monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
+
+    path_a = fc_mod._model_path("orders", "row_count", project_id="project-a")
+    path_b = fc_mod._model_path("orders", "row_count", project_id="project-b")
+    path_legacy = fc_mod._model_path("orders", "row_count", project_id="legacy")
+
+    assert path_a != path_b, "different projects must get different model paths"
+    assert path_a != path_legacy, "non-legacy project must not share path with legacy"
+    assert "project-a" in path_a.name
+    assert "project-b" in path_b.name
+    assert "project" not in path_legacy.name  # legacy keeps old filename format
+
+
+def test_train_writes_to_project_scoped_path(tmp_path, monkeypatch):
+    """train() with a real project_id must write to the project-scoped file."""
+    monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(fc_mod, "_HAS_PROPHET", False)
+    rows = _series(10, step_hours=1, slope=5.0, start=100.0)
+
+    with patch.object(fc_mod, "get_metrics", return_value=rows), \
+         patch.object(fc_mod, "get_changepoints", return_value=[]):
+        fc_mod.train("orders", "row_count", project_id="tenant-x")
+
+    expected = fc_mod._model_path("orders", "row_count", project_id="tenant-x")
+    legacy = fc_mod._model_path("orders", "row_count", project_id="legacy")
+    assert expected.exists(), "project-scoped model file must be created"
+    assert not legacy.exists(), "legacy model file must NOT be created for non-legacy project"


### PR DESCRIPTION
## Описание

До этого прогнозы писались в `models/{table}__{metric}.joblib` без tenant-префикса. Два проекта с таблицей одного имени делили одну модель и читали чужие данные.

Паттерн изоляции взят из `ml/anomaly_detector.py` (там уже реализовано через `{project_id}__{table}__anomaly.joblib`).

**Что изменено:**
- `ml/forecast.py` — `_model_path()`, `_load_history()`, `train()`, `forecast()`, `_load_persisted()`, `retrain_all()` принимают `project_id="legacy"`; legacy-путь без префикса сохранён для обратной совместимости
- `app/api.py` — `forecast_endpoint` передаёт `_current_project_id()` в `forecast()` (ключевое место — без этого пользователь видел чужую модель)
- `collectors/scheduler.py` — `retrain_forecasts()` явно передаёт `project_id="legacy"`
- `scripts/warmup_ml.py` — `warmup_forecasts()` принимает `project_id` и `tables`

Closes #153

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены (2 новых теста: изоляция путей + запись в правильный файл)
- [x] `pytest` проходит локально (34 passed)
- [x] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы (схема не менялась)