### PR TITLE
fix(#165): передать project_id в save_metrics/get_metrics в integration тестах

### DIFF
--- a/tests/integration/test_full_cycle.py
+++ b/tests/integration/test_full_cycle.py
@@ -71,7 +71,7 @@ def test_collector_to_api_full_cycle(pg_url, tmp_path):
         # 2. Persist into the SQLite metrics store.
         from app.metrics_storage import save_metrics
 
-        saved = save_metrics(rows)
+        saved = save_metrics(rows, "legacy")
         assert saved == len(rows)
 
         # 3. Read back via the public REST API using the Flask test client.

--- a/tests/integration/test_metrics_storage_timescale.py
+++ b/tests/integration/test_metrics_storage_timescale.py
@@ -88,8 +88,8 @@ def test_save_and_get_metrics_roundtrip(timescale_url):
              "metric_name": "row_count", "value": 120,
              "tags": {"column": "email"}},
         ]
-        assert save_metrics(rows) == 3
-        result = get_metrics("users", "row_count", window=timedelta(days=1))
+        assert save_metrics(rows, "legacy") == 3
+        result = get_metrics("users", "row_count", "legacy", window=timedelta(days=1))
 
     assert [r["value"] for r in result] == [100.0, 110.0, 120.0]
     # ts must be coerced to an ISO string on read, even though Timescale
@@ -110,8 +110,8 @@ def test_get_metrics_respects_window(timescale_url):
              "metric_name": "null_rate", "value": 0.06},
             {"ts": now, "table_name": "orders",
              "metric_name": "null_rate", "value": 0.07},
-        ])
-        result = get_metrics("orders", "null_rate", window=timedelta(days=7))
+        ], "legacy")
+        result = get_metrics("orders", "null_rate", "legacy", window=timedelta(days=7))
 
     assert [r["value"] for r in result] == [0.06, 0.07]
 
@@ -184,9 +184,9 @@ def test_purge_old_drops_timescale_chunks(timescale_url):
              "metric_name": "row_count", "value": 1},
             {"ts": now, "table_name": "users",
              "metric_name": "row_count", "value": 2},
-        ])
+        ], "legacy")
         purge_old(retention_days=90)
-        remaining = get_metrics("users", "row_count", window=timedelta(days=365))
+        remaining = get_metrics("users", "row_count", "legacy", window=timedelta(days=365))
 
     assert [r["value"] for r in remaining] == [2.0]
 


### PR DESCRIPTION
## Описание

После multi-tenant рефакторинга спринта 3 `save_metrics()` и `get_metrics()` стали требовать `project_id` как обязательный аргумент. Integration тесты не были обновлены и падали с `TypeError` на каждый push в master.

Closes #165

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [x] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы (не применимо)