### PR TITLE
fix(#165): project_id в e2e conftest и is_throttled/update_throttle

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -78,7 +78,7 @@ def _seed_metrics(metrics_url: str) -> None:
         "ts": now, "table_name": "users",
         "metric_name": "size_bytes", "value": 65536,
     })
-    metrics_storage.save_metrics(rows)
+    metrics_storage.save_metrics(rows, "legacy")
 
 
 def _patch_db_module() -> dict:

--- a/tests/integration/test_metrics_storage_timescale.py
+++ b/tests/integration/test_metrics_storage_timescale.py
@@ -196,6 +196,6 @@ def test_throttle_roundtrip(timescale_url):
     with use_metrics_db(timescale_url):
         from app.metrics_storage import is_throttled, update_throttle
 
-        assert not is_throttled("users", "anomaly_row_count")
-        update_throttle("users", "anomaly_row_count")
-        assert is_throttled("users", "anomaly_row_count")
+        assert not is_throttled("legacy", "users", "anomaly_row_count")
+        update_throttle("legacy", "users", "anomaly_row_count")
+        assert is_throttled("legacy", "users", "anomaly_row_count")


### PR DESCRIPTION
## Описание

Продолжение фикса после PR #166. После мёржа выяснилось что ещё два места не были обновлены:

- `tests/e2e/conftest.py` — `save_metrics(rows)` → `save_metrics(rows, 'legacy')`
- `tests/integration/test_metrics_storage_timescale.py` — `is_throttled()` и `update_throttle()` получили обязательный `project_id` в спринте 3

Closes #165

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [x] Если изменена схема БД — не применимо