### PR TITLE
fix(#145): удаление проекта теперь удаляет его метрики

### DIFF
--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -1906,6 +1906,10 @@ def delete_project(user_id: str, project_id: str) -> bool:
         deleted = (result.rowcount or 0) > 0
         if deleted:
             conn.execute(
+                text("DELETE FROM metrics WHERE project_id = :pid"),
+                {"pid": project_id},
+            )
+            conn.execute(
                 text("DELETE FROM notifications WHERE project_id = :pid"),
                 {"pid": project_id},
             )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -585,3 +585,35 @@ def test_delete_project_cascades_notifications(tmp_path, monkeypatch):
     messages = [n["message"] for n in remaining]
     assert "A_MSG" not in messages
     assert "B_MSG" in messages
+
+
+def test_delete_project_cascades_metrics(tmp_path, monkeypatch):
+    """delete_project() removes the project's metrics but not other projects'."""
+    import app.metrics_storage as storage
+    db_path = tmp_path / "cascade_metrics.db"
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    from datetime import UTC, datetime
+
+    from app.metrics_storage import (
+        create_project,
+        create_user,
+        delete_project,
+        get_metrics,
+        save_metrics,
+    )
+
+    user = create_user("user-metrics-cascade", "metrics-cascade@example.com", "hash")
+    proj_a = create_project("proj-metrics-a", user["id"], "A", "proj-metrics-a")
+    proj_b = create_project("proj-metrics-b", user["id"], "B", "proj-metrics-b")
+
+    ts = datetime.now(UTC)
+    save_metrics([{"ts": ts, "table_name": "orders", "metric_name": "row_count", "value": 100}], proj_a["id"])
+    save_metrics([{"ts": ts, "table_name": "orders", "metric_name": "row_count", "value": 200}], proj_b["id"])
+
+    delete_project(user["id"], proj_a["id"])
+
+    assert get_metrics("orders", "row_count", proj_a["id"]) == []
+    assert len(get_metrics("orders", "row_count", proj_b["id"])) == 1


### PR DESCRIPTION
## Описание

Строки в таблице `metrics` с `project_id` удалённого проекта оставались в БД навсегда — занимали место и никогда не показывались в UI.

Добавлен ручной каскад в `delete_project()` по паттерну уже существующего удаления `notifications`: `DELETE FROM metrics WHERE project_id = :pid` выполняется в той же транзакции что и `DELETE FROM projects`.

Closes #145

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены (`test_delete_project_cascades_metrics` — проверяет изоляцию между проектами)
- [x] `pytest` проходит локально (581 passed)
- [x] Если изменена схема БД — не применимо (схема не менялась)