### PR TITLE
feat(#103): Sentry integration — auto exception capture с двухслойным scrubbing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,18 @@ FLASK_ENV=development
 # Ставь ТОЛЬКО если приложение действительно за прокси — иначе атакующий
 # подделает X-Forwarded-For и обойдёт лимиты.
 #   TRUST_PROXY=1
+
+# --- Sentry error tracking (#103) -----------------------------------------
+#
+# Опционально. Пустой SENTRY_DSN → SDK не инициализируется, в проде
+# полная no-op (dev/CI ничего не отправляют). DSN берётся из Sentry →
+# Project Settings → Client Keys (DSN).
+#   SENTRY_DSN=https://abcdef0123456789@o12345.ingest.sentry.io/678910
+#
+# Optional environment tag (по умолчанию падает на FLASK_ENV):
+#   SENTRY_ENVIRONMENT=production
+#
+# Doll-sized sampling: 10% traces + 10% profiles — баланс между signal
+# и quota. Bump до 1.0 на staging, downsample до 0.01 на high-traffic prod.
+#   SENTRY_TRACES_SAMPLE_RATE=0.1
+#   SENTRY_PROFILES_SAMPLE_RATE=0.1

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pinned: false
 - [Поддерживаемые СУБД](#поддерживаемые-субд)
 - [Запуск в Docker](#запуск-в-docker)
 - [Переменные окружения](#переменные-окружения)
+- [Sentry (error tracking)](#sentry-error-tracking)
 - [Метрики (Prometheus)](#метрики-prometheus)
 - [Логи](#логи)
 - [Структура проекта](#структура-проекта)
@@ -450,6 +451,35 @@ DATABASE_URL=postgresql://postgres.<project>:<PASSWORD>@aws-0-<region>.pooler.su
 | `FLASK_DEBUG`        | —            | `1` (Docker — `0`)        | Включает дебаг и автоперезапуск Flask         |
 
 > ⚠️ Файл `.env` содержит секреты — не коммитить в git.
+
+---
+
+## Sentry (error tracking)
+
+Опционально. Заполни `SENTRY_DSN` в `.env` — приложение начнёт автоматически
+слать exceptions с request-контекстом, трассировкой и breadcrumb-ами.
+Пустой DSN = SDK не инициализируется (dev/CI ничего не шлют).
+
+```env
+SENTRY_DSN=https://abcdef@o12345.ingest.sentry.io/678910
+SENTRY_ENVIRONMENT=production         # опционально, по умолчанию = FLASK_ENV
+SENTRY_TRACES_SAMPLE_RATE=0.1         # 10% requests → performance traces
+SENTRY_PROFILES_SAMPLE_RATE=0.1
+```
+
+Перед отправкой каждого события `before_send` хук применяет два слоя
+скраббинга:
+
+1. **DSN-пароли в любых строках** (включая стек-трейс source-context лайны) —
+   regex-подстановка `user:***@host` через тот же `scrub_value` что уже
+   маскирует логи (#56)
+2. **Ключи `password` / `token` / `secret` / `api_key` / `authorization`**
+   в любых вложенных dict-ах → значение заменяется на `[REDACTED]`
+
+Тест `tests/test_sentry.py::test_dsn_password_is_scrubbed_in_captured_event`
+пинит инвариант: реальный `sentry_sdk.capture_exception` с DSN-паролем
+в сообщении исключения → паролем нет ни в одном поле итогового event-а
+(включая `pre_context` / `context_line` где раньше торчал источник).
 
 ---
 

--- a/app/app.py
+++ b/app/app.py
@@ -18,6 +18,7 @@ from .logging_setup import configure_logging
 from .projects import bp as projects_bp
 from .projects import load_current_project_into_g
 from .security import init_logging_filter
+from .sentry import init_sentry
 from .settings import bp as settings_bp
 
 _ISO_TS_RE = re.compile(
@@ -73,6 +74,9 @@ def create_app(config: dict | None = None):
     # actually use. _ensure_dsn_logging_filter is idempotent per process.
     configure_logging(settings.LOG_FORMAT, level=settings.LOG_LEVEL)
     _ensure_dsn_logging_filter()
+    # Sentry init (#103) — no-op when SENTRY_DSN is empty. Must run
+    # before Flask() so FlaskIntegration can patch the right symbols.
+    init_sentry()
     app = Flask(__name__)
     app.config["SECRET_KEY"] = settings.SECRET_KEY
     app.config["COLLECT_INTERVAL_MINUTES"] = settings.COLLECT_INTERVAL_MINUTES

--- a/app/config.py
+++ b/app/config.py
@@ -56,5 +56,14 @@ class Settings(BaseSettings):
     # wrong for user-facing links. Set this explicitly per environment.
     APP_BASE_URL: str = "http://localhost:5001"
 
+    # Sentry error tracking (#103). Optional — empty DSN means the SDK is
+    # never initialised, perfect for dev/CI where we don't want to spam
+    # the project quota. Traces + profiles are sampled at 10% to control
+    # cost; bump per environment if traffic is low.
+    SENTRY_DSN: str = ""
+    SENTRY_ENVIRONMENT: str = ""
+    SENTRY_TRACES_SAMPLE_RATE: float = 0.1
+    SENTRY_PROFILES_SAMPLE_RATE: float = 0.1
+
 
 settings = Settings()

--- a/app/security.py
+++ b/app/security.py
@@ -17,7 +17,7 @@ import logging
 import re
 from urllib.parse import urlparse, urlunparse
 
-__all__ = ["DSNFilter", "init_logging_filter", "mask_dsn"]
+__all__ = ["DSNFilter", "init_logging_filter", "mask_dsn", "scrub_value"]
 
 _PASSWORD_PLACEHOLDER = "***"
 
@@ -78,6 +78,12 @@ def mask_dsn(url: str) -> str:
     user, _ = userinfo.split(":", 1)
     masked_netloc = f"{user}:{_PASSWORD_PLACEHOLDER}@{host}"
     return urlunparse(parsed._replace(netloc=masked_netloc))
+
+
+def scrub_value(value):
+    """Public alias for ``_scrub`` — same recursive sanitiser, used by
+    code outside the logging path (Sentry ``before_send`` in #103)."""
+    return _scrub(value)
 
 
 def _scrub(value):

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,0 +1,135 @@
+"""Sentry initialisation + scrubbing (#103).
+
+Init is **gated on ``SENTRY_DSN``** — empty value means the SDK is never
+loaded, so dev/CI never spam the project quota. Production gets the
+FlaskIntegration (auto request/response context, breadcrumbs, exception
+capture).
+
+Two scrubbing layers stack with the existing #56 ``setLogRecordFactory``:
+
+1. ``scrub_value`` (from ``app.security``) walks the entire event dict
+   recursively, rewriting any PostgreSQL/MySQL/ClickHouse DSN found
+   inside strings AND any Telegram bot token from #143. Uses a regex
+   substitution (not ``urlparse``) so a DSN buried in a source-code
+   context line or an exception message is still caught.
+2. A keyword-based scrub flips any dict value whose key matches
+   ``password`` / ``token`` / ``api_key`` (case-insensitive) to a fixed
+   placeholder — protects ``extra={"api_key": "…"}`` patterns.
+
+Both run on every event in ``before_send``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.config import settings
+from app.security import scrub_value
+
+logger = logging.getLogger(__name__)
+
+# Substring match on dict keys. Anything containing these tokens (case-
+# insensitive) gets its value redacted. Conservative on purpose — false
+# positives are cheap (a tag with "tokenizer" in the name loses its value
+# in Sentry, but Sentry is for traces, not for ML pipeline tags).
+_SECRET_KEY_HINTS = ("password", "token", "secret", "api_key", "authorization")
+_REDACTED = "[REDACTED]"
+
+
+def _key_is_secret(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    lowered = key.lower()
+    return any(hint in lowered for hint in _SECRET_KEY_HINTS)
+
+
+def _scrub(value: Any) -> Any:
+    """Recursively rewrite DSNs and redact secret-named dict values.
+
+    Order matters: we redact suspicious keys BEFORE recursing into their
+    values, so a ``{"password": "<long DSN-shaped string>"}`` doesn't
+    leak the DSN even though ``scrub_value`` would also handle it.
+    For pure strings we delegate to ``security.scrub_value`` — its regex
+    finds DSNs inside larger blobs (source-code context lines, traceback
+    snippets) where ``urlparse``-based ``mask_dsn`` doesn't.
+    """
+    if isinstance(value, dict):
+        scrubbed = {}
+        for k, v in value.items():
+            if _key_is_secret(k):
+                scrubbed[k] = _REDACTED
+            else:
+                scrubbed[k] = _scrub(v)
+        return scrubbed
+    if isinstance(value, list):
+        return [_scrub(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub(v) for v in value)
+    # str / BaseException / anything else: defer to security.scrub_value
+    # which handles strings via regex AND stringifies exceptions safely.
+    return scrub_value(value)
+
+
+def before_send(event: dict, _hint: dict) -> dict | None:
+    """Sentry ``before_send`` hook — sanitises every outgoing event.
+
+    Never drops events (returns the scrubbed dict, not None) — operators
+    rely on the event count for monitoring. Returning None would silently
+    eat the error.
+    """
+    try:
+        return _scrub(event)
+    except Exception:  # pragma: no cover - defence in depth
+        # If scrubbing itself fails for some pathological event shape,
+        # we still want SOMETHING in Sentry — better a less-clean event
+        # than no signal at all.
+        logger.exception("Sentry before_send scrub failed; sending raw event")
+        return event
+
+
+def init_sentry() -> bool:
+    """Initialise the Sentry SDK if ``SENTRY_DSN`` is configured.
+
+    Returns True on initialisation, False when DSN is empty (intended
+    for dev / CI). Safe to call multiple times — ``sentry_sdk.init`` is
+    itself idempotent within a single process.
+    """
+    dsn = settings.SENTRY_DSN.strip()
+    if not dsn:
+        return False
+
+    # Late import: keep the cold-start cost of the auth/main modules low,
+    # and let environments without sentry-sdk installed run the rest of
+    # the app without crashing at import time.
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.flask import FlaskIntegration
+    except ImportError:  # pragma: no cover - dependency missing in slim builds
+        logger.warning(
+            "SENTRY_DSN set but sentry-sdk not installed; skipping init"
+        )
+        return False
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=settings.SENTRY_ENVIRONMENT or settings.FLASK_ENV,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        profiles_sample_rate=settings.SENTRY_PROFILES_SAMPLE_RATE,
+        integrations=[FlaskIntegration()],
+        before_send=before_send,
+        # Don't auto-attach the request body — bodies can contain DSN
+        # input from the connections form (#51) and our scrub runs only
+        # on event fields, not the raw body capture.
+        send_default_pii=False,
+        # Drop User-Agent / cookies / IP from request context. We can
+        # always opt back in per-event via sentry_sdk.set_user().
+        request_bodies="never",
+        max_breadcrumbs=50,
+    )
+    logger.info("Sentry initialised (environment=%s)",
+                settings.SENTRY_ENVIRONMENT or settings.FLASK_ENV)
+    return True
+
+
+__all__ = ["before_send", "init_sentry"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,8 @@ pyiceberg[pyarrow,glue]>=0.7.0,<1.0.0
 # standard text exposition format consumed by Grafana / VictoriaMetrics /
 # any Prometheus-compatible scraper.
 prometheus-client>=0.20,<1.0
+
+# Sentry error tracking (#103). [flask] extra wires the FlaskIntegration
+# automatically — request context, breadcrumbs, exception capture. Init
+# is gated on SENTRY_DSN env var; empty DSN → SDK is a no-op (dev/CI).
+sentry-sdk[flask]>=2.0,<3.0

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,209 @@
+"""Sentry init + scrubbing tests (#103).
+
+We don't talk to Sentry's network — ``sentry_sdk.init`` accepts a custom
+``transport`` callable, so we capture outgoing envelopes locally and
+assert on them. That covers the full path: init → exception captured →
+before_send scrub → transport.send.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.sentry import _scrub, before_send, init_sentry
+
+# ── before_send / _scrub unit tests ────────────────────────────────────────
+
+
+def test_scrub_masks_dsn_in_string():
+    """Top-level string with a DSN gets the password redacted."""
+    out = _scrub("postgresql://user:topsecret@host/db")
+    assert "topsecret" not in out
+    assert "user:***@host" in out
+
+
+def test_scrub_recurses_into_dict():
+    event = {
+        "extra": {"connection": "postgresql://u:hidden@h:5432/d"},
+    }
+    out = _scrub(event)
+    assert "hidden" not in str(out)
+
+
+def test_scrub_redacts_secret_keyed_dict_values():
+    """Keys containing password/token/secret/api_key/authorization
+    have their values wholesale replaced — even before recursing."""
+    event = {
+        "extra": {
+            "password": "Pa$$w0rd-1234",
+            "api_key": "sk-1234",
+            "bearer_token": "Bearer eyJ…",
+            "AUTHORIZATION": "Basic dXNlcjo=",
+            "username": "alice",  # NOT secret — preserved
+        },
+    }
+    out = _scrub(event)
+    assert out["extra"]["password"] == "[REDACTED]"
+    assert out["extra"]["api_key"] == "[REDACTED]"
+    assert out["extra"]["bearer_token"] == "[REDACTED]"
+    assert out["extra"]["AUTHORIZATION"] == "[REDACTED]"
+    assert out["extra"]["username"] == "alice"
+
+
+def test_scrub_handles_list_and_tuple():
+    event = {"breadcrumbs": [
+        "no secret here",
+        "postgresql://u:leaked@h/d",
+        ("nested", "postgresql://u:tupled@h/d"),
+    ]}
+    out = _scrub(event)
+    serialised = str(out)
+    assert "leaked" not in serialised
+    assert "tupled" not in serialised
+
+
+def test_before_send_returns_dict_not_none():
+    """We never drop events — scrub-or-pass-through, never silent drop."""
+    out = before_send({"extra": {"trace": "ok"}}, {})
+    assert out is not None
+    assert isinstance(out, dict)
+
+
+def test_before_send_swallows_scrub_errors(monkeypatch):
+    """Pathological event that breaks _scrub still ships SOMETHING."""
+    def boom(_):
+        raise RuntimeError("scrub broke")
+
+    monkeypatch.setattr("app.sentry._scrub", boom)
+    event = {"raw": "data"}
+    out = before_send(event, {})
+    # Falls back to the raw event — operator sees the error, just less clean.
+    assert out is event
+
+
+# ── init_sentry behaviour ──────────────────────────────────────────────────
+
+
+def test_init_sentry_noop_when_dsn_empty(monkeypatch):
+    """Empty SENTRY_DSN → don't even import sentry_sdk, return False."""
+    from app.config import settings
+    monkeypatch.setattr(settings, "SENTRY_DSN", "")
+    assert init_sentry() is False
+
+
+def test_init_sentry_initialises_when_dsn_present(monkeypatch):
+    """With a DSN configured we actually call sentry_sdk.init."""
+    from app.config import settings as cfg
+    monkeypatch.setattr(cfg, "SENTRY_DSN",
+                        "https://public@sentry.example.com/1")
+    monkeypatch.setattr(cfg, "SENTRY_ENVIRONMENT", "test-env")
+
+    captured = {}
+
+    def fake_init(**kwargs):
+        captured.update(kwargs)
+
+    import sentry_sdk
+    monkeypatch.setattr(sentry_sdk, "init", fake_init)
+
+    assert init_sentry() is True
+    assert captured["dsn"] == "https://public@sentry.example.com/1"
+    assert captured["environment"] == "test-env"
+    assert callable(captured["before_send"])
+    assert captured["send_default_pii"] is False
+
+
+# ── End-to-end with fake transport ─────────────────────────────────────────
+
+
+def _make_fake_transport(events: list):
+    """Build a Transport subclass that captures every envelope's event
+    JSON into ``events``. Sentry 2.x dropped the "transport callable"
+    shim, so we have to subclass ``sentry_sdk.transport.Transport``.
+    """
+    from sentry_sdk.transport import Transport
+
+    class _Captor(Transport):
+        def __init__(self, options=None):
+            super().__init__(options or {})
+
+        def capture_envelope(self, envelope):
+            for item in envelope.items:
+                payload = item.payload
+                # Item payloads can be raw bytes or a JsonPayload object
+                # depending on the item type — try both.
+                if hasattr(payload, "json"):
+                    events.append(payload.json)
+
+        def flush(self, *_a, **_kw):
+            pass
+
+        def kill(self, *_a, **_kw):
+            pass
+
+    return _Captor
+
+
+def test_dsn_password_is_scrubbed_in_captured_event():
+    """Exception with a DSN in the message → Sentry sees the masked form."""
+    import sentry_sdk
+
+    events: list[dict] = []
+    sentry_sdk.init(
+        dsn="https://public@sentry.example.com/1",
+        transport=_make_fake_transport(events),
+        before_send=before_send,
+        send_default_pii=False,
+        traces_sample_rate=0.0,
+        # Don't auto-attach the Flask integration — this test is about
+        # the scrub itself, not request context capture.
+        integrations=[],
+    )
+    try:
+        raise RuntimeError("connect failed: postgresql://u:topsecret@h:5432/d")
+    except RuntimeError:
+        sentry_sdk.capture_exception()
+
+    sentry_sdk.flush(timeout=2)
+
+    assert events, "expected at least one event captured"
+    blob = repr(events[-1])
+    assert "topsecret" not in blob
+    assert "u:***@h" in blob
+
+
+def test_password_key_in_extra_is_redacted_end_to_end():
+    """capture_message with secret-named scope extras → Sentry event
+    has REDACTED placeholders, not the raw values."""
+    import sentry_sdk
+
+    events: list[dict] = []
+    sentry_sdk.init(
+        dsn="https://public@sentry.example.com/1",
+        transport=_make_fake_transport(events),
+        before_send=before_send,
+        send_default_pii=False,
+        traces_sample_rate=0.0,
+        integrations=[],
+    )
+    with sentry_sdk.new_scope() as scope:
+        scope.set_extra("password", "Pa$$w0rd-1234")
+        scope.set_tag("api_key", "sk-secret")
+        sentry_sdk.capture_message("test event")
+
+    sentry_sdk.flush(timeout=2)
+
+    assert events
+    blob = repr(events[-1])
+    assert "Pa$$w0rd-1234" not in blob
+    assert "sk-secret" not in blob
+    assert "[REDACTED]" in blob
+
+
+# Suppress noisy ``app.sentry`` log lines from polluting unrelated test output.
+@pytest.fixture(autouse=True)
+def _quiet_sentry_logger():
+    logging.getLogger("app.sentry").setLevel(logging.ERROR)
+    yield


### PR DESCRIPTION
Closes #103. Sprint 4 production-readiness — последний слой observability-стека. Prometheus (#101) даёт агрегаты для алертов, JSON-логи (#102) — drill-down по request_id, Sentry — exception tracking с request-контекстом, трассировкой и breadcrumb-ами.

## Скоуп

### `sentry-sdk[flask]>=2.0`
Extra `[flask]` автоматически подцепляет `FlaskIntegration` — request/response контекст, breadcrumbs, exception capture на 500-ках. Гейт на `SENTRY_DSN`: пустой DSN → SDK не инициализируется (dev/CI quota не жрут).

### `app/sentry.py`

`init_sentry()` — late-import `sentry_sdk`, передаёт DSN + env + sample rates + наш `before_send` + `integrations=[FlaskIntegration()]`. `send_default_pii=False` и `request_bodies="never"` чтобы body коннект-формы (которая содержит plain DSN перед Fernet) НЕ попадал в события.

`before_send` — двухслойный scrubber:

1. **Dict-keys** (case-insensitive substring) matching `password` / `token` / `secret` / `api_key` / `authorization` → значение целиком заменяется на `[REDACTED]` ДО рекурсии. Защищает паттерн `{"password": "<long DSN-shaped string>"}` от частичного раскрытия.

2. **Strings, exceptions, lists, tuples** → recursive `security.scrub_value`: regex-substitution DSN-в-любой-строке (включая `pre_context` / `context_line` из стек-трейса) + Telegram bot tokens из #143.

### Promote `security._scrub` → `security.scrub_value`
Раньше private, использовался только из logging path. Теперь Sentry заимствует тот же scrubber вместо дублирования логики. Один источник истины для DSN/token masking.

### Init в `create_app` ПЕРЕД `Flask()`
FlaskIntegration патчит wsgi_app, должна видеть наш app сразу при создании.

## Тесты (10 кейсов)

Unit (5):
- scrub маскирует DSN в строке
- recurse в dict
- redact key-based для password/token/secret/api_key/authorization (включая case-mix), не трогает безопасные ключи
- list + tuple recurse
- before_send возвращает dict даже при exception в scrub (никогда не drop event)

init_sentry (2):
- empty DSN → False, sentry_sdk.init не вызывается
- DSN present → True, init вызван с правильными kwargs

End-to-end через fake `Transport` subclass (3):
- `capture_exception` с DSN в message → событие НЕ содержит plain password ни в одном поле (включая stacktrace pre_context), `u:***@h` присутствует
- `capture_message` со `scope.set_extra("password", ...)` и `set_tag("api_key", ...)` → `[REDACTED]` в событии, plain values отсутствуют

## Acceptance из тикета

- [x] Зависимость `sentry-sdk[flask]`
- [x] Инициализация в `app/app.py` под env `SENTRY_DSN` (пусто → выкл)
- [x] `traces_sample_rate=0.1` + `profiles_sample_rate=0.1`
- [x] `before_send` проходит через DSN-маскирование (#56)
- [x] PII scrubbing на `password` / `token` / `api_key` в `extra` / `tags`
- [x] Тест: фейк-transport — exception вызывает send, DSN маскируются
- [x] README: SENTRY_DSN в `.env.example` с комментарием «опционально»

## Verification

- **591 passed** (10 новых)
- ruff clean
- DSN-leak проверен явно: тест с реальным `sentry_sdk.capture_exception(...postgresql://u:topsecret@h/d...)` подтверждает, что "topsecret" не появляется в событии ни в `message`, ни в `pre_context`, ни в `context_line`

## Test plan

- [x] Юнит-тесты на scrub layers + init
- [x] End-to-end через fake transport
- [ ] Manual smoke после merge: настроить `SENTRY_DSN` на test-проект → `curl /api/throw` (если есть) или просто бросить exception → проверить в Sentry UI что событие пришло, в нём request-context, и нет ни одного plaintext-пароля