### PR TITLE
fix(#103): sentry-sdk 2.x option rename request_bodies → max_request_body_size

### DIFF
--- a/app/sentry.py
+++ b/app/sentry.py
@@ -120,11 +120,12 @@ def init_sentry() -> bool:
         before_send=before_send,
         # Don't auto-attach the request body — bodies can contain DSN
         # input from the connections form (#51) and our scrub runs only
-        # on event fields, not the raw body capture.
+        # on event fields, not the raw body capture. send_default_pii
+        # also drops User-Agent / cookies / IP from request context.
         send_default_pii=False,
-        # Drop User-Agent / cookies / IP from request context. We can
-        # always opt back in per-event via sentry_sdk.set_user().
-        request_bodies="never",
+        # Sentry SDK 2.x renamed request_bodies → max_request_body_size.
+        # "never" — don't capture POST bodies at all.
+        max_request_body_size="never",
         max_breadcrumbs=50,
     )
     logger.info("Sentry initialised (environment=%s)",

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -115,6 +115,23 @@ def test_init_sentry_initialises_when_dsn_present(monkeypatch):
     assert captured["send_default_pii"] is False
 
 
+def test_init_sentry_against_real_sdk_does_not_crash(monkeypatch):
+    """Regression: ``sentry_sdk.init`` rejects unknown options with a
+    TypeError. Tests that monkeypatch ``init`` away never exercise the
+    real option whitelist, so SDK 2.x renames (e.g. ``request_bodies`` →
+    ``max_request_body_size``) slip through. This test calls the REAL
+    init and asserts it returns cleanly — if a future SDK bump removes
+    or renames an option we use, this fails immediately.
+    """
+    from app.config import settings as cfg
+    monkeypatch.setattr(cfg, "SENTRY_DSN",
+                        "https://public@sentry.example.com/1")
+    monkeypatch.setattr(cfg, "SENTRY_ENVIRONMENT", "test-real-init")
+    # The DSN is fake — no events will ever be sent (the SDK only
+    # validates DSN format, not reachability, during init).
+    assert init_sentry() is True
+
+
 # ── End-to-end with fake transport ─────────────────────────────────────────
 
 


### PR DESCRIPTION
Live smoke против реального Sentry-проекта поймал:

```
TypeError: Unknown option 'request_bodies'
```

sentry-sdk 2.x переименовал `request_bodies` → `max_request_body_size`. Значение то же (`"never"`).

## Почему юнит-тесты не словили

Все тесты в `tests/test_sentry.py` monkeypatch-ат `sentry_sdk.init` и captured-init никогда не проходит через real option-whitelist. Real `sentry_sdk.init` валидирует kwargs strict и поднимает TypeError на неизвестные опции.

## Regression test

Новый `test_init_sentry_against_real_sdk_does_not_crash` вызывает REAL `init_sentry()` без mock-а — любой future rename / removal ловится сразу. С фейковым DSN `https://public@sentry.example.com/1` — SDK валидирует только формат DSN, не пытается connect.

## Verification

- Manual smoke: реальный capture_exception против `o4510994041602048.ingest.de.sentry.io` → event `d656d6b5cda74369ac8c9a15ae3aaf82` доставлено
- Scrubbing работает на боевом канале: ни `topsecret` (DSN-пароль из exception message), ни `should-be-redacted` (значение password-extra) не появились в итоговом event-е
- pytest: 11 passed (1 новый); ruff clean