### PR TITLE
feat(#173): добавить seed demo workspace

### DIFF
--- a/docs/demo/SCENARIO_3_2.md
+++ b/docs/demo/SCENARIO_3_2.md
@@ -10,9 +10,21 @@ audit trail.
 
 ## Участники и проекты
 
+Подготовить пользователей, проекты и подключения можно командой:
+
+```bash
+python -m scripts.seed_demo_workspace
+```
+
+Скрипт идемпотентен: повторный запуск переиспользует уже созданных
+пользователей, проекты и connections. В конце он печатает `PROJECT_ID` и
+`CONNECTION_ID` для следующих шагов (`seed_metrics_db`, `warmup_ml`,
+`live_demo`).
+
 ### Demo user 1
 
 - Email: `demo@dbmonitor.app`
+- Password: `demo12345`
 - Основные проекты:
   - `Retail Postgres`
   - `Events ClickHouse`
@@ -20,6 +32,7 @@ audit trail.
 ### Demo user 2
 
 - Email: `lake@dbmonitor.app`
+- Password: `demo12345`
 - Основной проект:
   - `Iceberg Lakehouse`
 

--- a/docs/demo/SCENARIO_3_2.md
+++ b/docs/demo/SCENARIO_3_2.md
@@ -13,11 +13,13 @@ audit trail.
 Подготовить пользователей, проекты и подключения можно командой:
 
 ```bash
-python -m scripts.seed_demo_workspace
+python -m scripts.seed_demo_workspace --reset-password
 ```
 
 Скрипт идемпотентен: повторный запуск переиспользует уже созданных
-пользователей, проекты и connections. В конце он печатает `PROJECT_ID` и
+пользователей, проекты и connections. Флаг `--reset-password` нужен для
+репетиции и демо-стенда: если demo-пользователи уже существовали, он явно
+выставляет им пароль из команды. В конце скрипт печатает `PROJECT_ID` и
 `CONNECTION_ID` для следующих шагов (`seed_metrics_db`, `warmup_ml`,
 `live_demo`).
 

--- a/scripts/seed_demo_workspace.py
+++ b/scripts/seed_demo_workspace.py
@@ -1,0 +1,240 @@
+"""Create the Demo 3.2 workspace in the monitoring DB.
+
+This script prepares application-level demo entities only: users, projects,
+and encrypted DB connections. It does not seed target databases and does not
+run collectors/ML warmup. Those steps stay explicit because they depend on
+local Docker services being available.
+
+Usage:
+    python -m scripts.seed_demo_workspace
+    python -m scripts.seed_demo_workspace --password demo12345
+    python -m scripts.seed_demo_workspace --postgres-dsn postgresql://...
+"""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+from werkzeug.security import generate_password_hash
+
+from app import crypto, metrics_storage
+from app.config import settings
+
+DEFAULT_PASSWORD = "demo12345"
+DEFAULT_CLICKHOUSE_DSN = "clickhouse+native://default@localhost:19000/demo"
+
+
+def default_iceberg_dsn() -> str:
+    params = urlencode({
+        "warehouse": "s3://iceberg-smoke/warehouse",
+        "s3.endpoint": "http://localhost:9000",
+        "s3.access-key-id": "minioadmin",
+        "s3.secret-access-key": "minioadmin",
+        "s3.path-style-access": "true",
+    })
+    return f"iceberg+rest://localhost:8181?{params}"
+
+
+@dataclass(frozen=True)
+class DemoConnectionSpec:
+    name: str
+    dsn: str
+    schema_name: str
+    interval_minutes: int = 15
+    is_active: bool = True
+
+
+@dataclass(frozen=True)
+class DemoProjectSpec:
+    user_email: str
+    name: str
+    slug: str
+    connection: DemoConnectionSpec
+
+
+def ensure_user(email: str, password: str) -> dict:
+    email = email.strip().lower()
+    existing = metrics_storage.get_user_by_email(email)
+    if existing is not None:
+        return existing
+    return metrics_storage.create_user(
+        user_id=uuid.uuid4().hex,
+        email=email,
+        password_hash=generate_password_hash(password),
+    )
+
+
+def ensure_project(user_id: str, name: str, slug: str) -> dict:
+    slug = slug.strip().lower()
+    existing = metrics_storage.get_project_by_slug(user_id, slug)
+    if existing is not None:
+        return existing
+    return metrics_storage.create_project(
+        project_id=uuid.uuid4().hex,
+        user_id=user_id,
+        name=name,
+        slug=slug,
+    )
+
+
+def ensure_connection(project_id: str, spec: DemoConnectionSpec) -> dict:
+    for conn in metrics_storage.list_connections_for_project(project_id):
+        if conn["name"] == spec.name:
+            return conn
+    return metrics_storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project_id,
+        name=spec.name,
+        dsn_encrypted=crypto.encrypt_dsn(spec.dsn),
+        schema_name=spec.schema_name,
+        interval_minutes=spec.interval_minutes,
+        is_active=spec.is_active,
+    )
+
+
+def build_project_specs(
+    *,
+    postgres_dsn: str,
+    clickhouse_dsn: str,
+    iceberg_dsn: str,
+) -> list[DemoProjectSpec]:
+    return [
+        DemoProjectSpec(
+            user_email="demo@dbmonitor.app",
+            name="Retail Postgres",
+            slug="retail-postgres",
+            connection=DemoConnectionSpec(
+                name="Local Postgres",
+                dsn=postgres_dsn,
+                schema_name="public",
+            ),
+        ),
+        DemoProjectSpec(
+            user_email="demo@dbmonitor.app",
+            name="Events ClickHouse",
+            slug="events-clickhouse",
+            connection=DemoConnectionSpec(
+                name="Local ClickHouse",
+                dsn=clickhouse_dsn,
+                schema_name="demo",
+            ),
+        ),
+        DemoProjectSpec(
+            user_email="lake@dbmonitor.app",
+            name="Iceberg Lakehouse",
+            slug="iceberg-lakehouse",
+            connection=DemoConnectionSpec(
+                name="Local Iceberg REST",
+                dsn=iceberg_dsn,
+                schema_name="smoke_ns",
+            ),
+        ),
+    ]
+
+
+def seed_demo_workspace(
+    *,
+    password: str = DEFAULT_PASSWORD,
+    postgres_dsn: str | None = None,
+    clickhouse_dsn: str = DEFAULT_CLICKHOUSE_DSN,
+    iceberg_dsn: str | None = None,
+) -> dict:
+    postgres_dsn = postgres_dsn or settings.DATABASE_URL
+    iceberg_dsn = iceberg_dsn or default_iceberg_dsn()
+
+    users: dict[str, dict] = {}
+    projects: dict[str, dict] = {}
+    connections: dict[str, dict] = {}
+
+    for email in ("demo@dbmonitor.app", "lake@dbmonitor.app"):
+        users[email] = ensure_user(email, password)
+
+    for spec in build_project_specs(
+        postgres_dsn=postgres_dsn,
+        clickhouse_dsn=clickhouse_dsn,
+        iceberg_dsn=iceberg_dsn,
+    ):
+        user = users[spec.user_email]
+        project = ensure_project(user["id"], spec.name, spec.slug)
+        connection = ensure_connection(project["id"], spec.connection)
+        projects[spec.slug] = project
+        connections[spec.slug] = connection
+
+    return {
+        "password": password,
+        "users": users,
+        "projects": projects,
+        "connections": connections,
+    }
+
+
+def _print_summary(result: dict) -> None:
+    print("Demo users:")
+    for email in ("demo@dbmonitor.app", "lake@dbmonitor.app"):
+        print(f"  {email} / {result['password']}")
+
+    project_env_names = {
+        "retail-postgres": "RETAIL_POSTGRES",
+        "events-clickhouse": "CLICKHOUSE",
+        "iceberg-lakehouse": "ICEBERG",
+    }
+    print("\nProjects and connections:")
+    for slug, prefix in project_env_names.items():
+        project = result["projects"][slug]
+        connection = result["connections"][slug]
+        print(f"  {project['name']}:")
+        print(f"    {prefix}_PROJECT_ID={project['id']}")
+        print(f"    {prefix}_CONNECTION_ID={connection['id']}")
+
+    retail = result["projects"]["retail-postgres"]
+    retail_conn = result["connections"]["retail-postgres"]
+    print("\nNext Postgres demo commands:")
+    print(
+        "  python -m scripts.seed_metrics_db --reset "
+        f"--project-id {retail['id']}"
+    )
+    print(f"  python -m scripts.warmup_ml --project-id {retail['id']}")
+    print(
+        "  python -m scripts.live_demo "
+        f"--project-id {retail['id']} "
+        f"--connection-id {retail_conn['id']} "
+        "--ticks 20 --interval 5 --incident-at 8 --changepoints"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create Demo 3.2 users, projects, and encrypted connections.",
+    )
+    parser.add_argument("--password", default=DEFAULT_PASSWORD)
+    parser.add_argument(
+        "--postgres-dsn",
+        default=None,
+        help="Postgres DSN for Retail Postgres. Defaults to DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--clickhouse-dsn",
+        default=DEFAULT_CLICKHOUSE_DSN,
+        help=f"ClickHouse DSN (default: {DEFAULT_CLICKHOUSE_DSN}).",
+    )
+    parser.add_argument(
+        "--iceberg-dsn",
+        default=None,
+        help="Iceberg DSN. Defaults to local Iceberg REST + MinIO.",
+    )
+    args = parser.parse_args()
+
+    result = seed_demo_workspace(
+        password=args.password,
+        postgres_dsn=args.postgres_dsn,
+        clickhouse_dsn=args.clickhouse_dsn,
+        iceberg_dsn=args.iceberg_dsn,
+    )
+    _print_summary(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_demo_workspace.py
+++ b/scripts/seed_demo_workspace.py
@@ -7,6 +7,7 @@ local Docker services being available.
 
 Usage:
     python -m scripts.seed_demo_workspace
+    python -m scripts.seed_demo_workspace --reset-password
     python -m scripts.seed_demo_workspace --password demo12345
     python -m scripts.seed_demo_workspace --postgres-dsn postgresql://...
 """
@@ -55,10 +56,20 @@ class DemoProjectSpec:
     connection: DemoConnectionSpec
 
 
-def ensure_user(email: str, password: str) -> dict:
+def ensure_user(email: str, password: str, *, reset_password: bool = False) -> dict:
     email = email.strip().lower()
     existing = metrics_storage.get_user_by_email(email)
     if existing is not None:
+        if reset_password:
+            metrics_storage.update_user_password(
+                existing["id"],
+                generate_password_hash(password),
+            )
+            updated = metrics_storage.get_user_by_email(email)
+            if updated is None:
+                msg = f"User disappeared after password reset: {email}"
+                raise RuntimeError(msg)
+            return updated
         return existing
     return metrics_storage.create_user(
         user_id=uuid.uuid4().hex,
@@ -138,6 +149,7 @@ def build_project_specs(
 def seed_demo_workspace(
     *,
     password: str = DEFAULT_PASSWORD,
+    reset_password: bool = False,
     postgres_dsn: str | None = None,
     clickhouse_dsn: str = DEFAULT_CLICKHOUSE_DSN,
     iceberg_dsn: str | None = None,
@@ -150,7 +162,11 @@ def seed_demo_workspace(
     connections: dict[str, dict] = {}
 
     for email in ("demo@dbmonitor.app", "lake@dbmonitor.app"):
-        users[email] = ensure_user(email, password)
+        users[email] = ensure_user(
+            email,
+            password,
+            reset_password=reset_password,
+        )
 
     for spec in build_project_specs(
         postgres_dsn=postgres_dsn,
@@ -211,6 +227,14 @@ def main() -> None:
     )
     parser.add_argument("--password", default=DEFAULT_PASSWORD)
     parser.add_argument(
+        "--reset-password",
+        action="store_true",
+        help=(
+            "Reset demo users' password if they already exist. "
+            "Useful for preparing a repeatable demo stand."
+        ),
+    )
+    parser.add_argument(
         "--postgres-dsn",
         default=None,
         help="Postgres DSN for Retail Postgres. Defaults to DATABASE_URL.",
@@ -229,6 +253,7 @@ def main() -> None:
 
     result = seed_demo_workspace(
         password=args.password,
+        reset_password=args.reset_password,
         postgres_dsn=args.postgres_dsn,
         clickhouse_dsn=args.clickhouse_dsn,
         iceberg_dsn=args.iceberg_dsn,

--- a/tests/test_seed_demo_workspace.py
+++ b/tests/test_seed_demo_workspace.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from cryptography.fernet import Fernet
+
+
+def _setup_storage(tmp_path, monkeypatch):
+    db_path = tmp_path / "demo_workspace.db"
+    import app.metrics_storage as storage
+
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    from app import crypto
+
+    crypto.reset_for_tests()
+    return storage
+
+
+def test_seed_demo_workspace_creates_users_projects_connections(tmp_path, monkeypatch):
+    storage = _setup_storage(tmp_path, monkeypatch)
+
+    from app import crypto
+    from scripts.seed_demo_workspace import seed_demo_workspace
+
+    result = seed_demo_workspace(
+        password="demo12345",
+        postgres_dsn="postgresql://postgres:dev@localhost:5432/monitor",
+        clickhouse_dsn="clickhouse+native://default@localhost:19000/demo",
+        iceberg_dsn="iceberg+rest://localhost:8181?warehouse=s3://w",
+    )
+
+    demo = storage.get_user_by_email("demo@dbmonitor.app")
+    lake = storage.get_user_by_email("lake@dbmonitor.app")
+    assert demo is not None
+    assert lake is not None
+
+    demo_projects = storage.list_projects_for_user(demo["id"])
+    lake_projects = storage.list_projects_for_user(lake["id"])
+    assert {p["slug"] for p in demo_projects} == {
+        "retail-postgres",
+        "events-clickhouse",
+    }
+    assert {p["slug"] for p in lake_projects} == {"iceberg-lakehouse"}
+
+    retail = result["projects"]["retail-postgres"]
+    retail_connections = storage.list_connections_for_project(retail["id"])
+    assert len(retail_connections) == 1
+    encrypted = retail_connections[0]["dsn_encrypted"]
+    assert b"postgres:dev" not in encrypted
+    assert crypto.decrypt_dsn(encrypted) == (
+        "postgresql://postgres:dev@localhost:5432/monitor"
+    )
+
+
+def test_seed_demo_workspace_is_idempotent(tmp_path, monkeypatch):
+    storage = _setup_storage(tmp_path, monkeypatch)
+
+    from scripts.seed_demo_workspace import seed_demo_workspace
+
+    kwargs = {
+        "password": "demo12345",
+        "postgres_dsn": "postgresql://postgres:dev@localhost:5432/monitor",
+        "clickhouse_dsn": "clickhouse+native://default@localhost:19000/demo",
+        "iceberg_dsn": "iceberg+rest://localhost:8181?warehouse=s3://w",
+    }
+    first = seed_demo_workspace(**kwargs)
+    second = seed_demo_workspace(**kwargs)
+
+    assert first["users"]["demo@dbmonitor.app"]["id"] == (
+        second["users"]["demo@dbmonitor.app"]["id"]
+    )
+    assert first["projects"]["retail-postgres"]["id"] == (
+        second["projects"]["retail-postgres"]["id"]
+    )
+    assert first["connections"]["retail-postgres"]["id"] == (
+        second["connections"]["retail-postgres"]["id"]
+    )
+
+    demo = storage.get_user_by_email("demo@dbmonitor.app")
+    demo_projects = storage.list_projects_for_user(demo["id"])
+    assert len(demo_projects) == 2
+    for project in demo_projects:
+        assert len(storage.list_connections_for_project(project["id"])) == 1

--- a/tests/test_seed_demo_workspace.py
+++ b/tests/test_seed_demo_workspace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from cryptography.fernet import Fernet
+from werkzeug.security import check_password_hash, generate_password_hash
 
 
 def _setup_storage(tmp_path, monkeypatch):
@@ -83,3 +84,31 @@ def test_seed_demo_workspace_is_idempotent(tmp_path, monkeypatch):
     assert len(demo_projects) == 2
     for project in demo_projects:
         assert len(storage.list_connections_for_project(project["id"])) == 1
+
+
+def test_seed_demo_workspace_can_reset_existing_demo_password(tmp_path, monkeypatch):
+    storage = _setup_storage(tmp_path, monkeypatch)
+
+    from scripts.seed_demo_workspace import seed_demo_workspace
+
+    storage.create_user(
+        user_id="existing-demo",
+        email="demo@dbmonitor.app",
+        password_hash=generate_password_hash("old-password"),
+    )
+
+    kwargs = {
+        "password": "demo12345",
+        "postgres_dsn": "postgresql://postgres:dev@localhost:5432/monitor",
+        "clickhouse_dsn": "clickhouse+native://default@localhost:19000/demo",
+        "iceberg_dsn": "iceberg+rest://localhost:8181?warehouse=s3://w",
+    }
+    seed_demo_workspace(**kwargs)
+    demo = storage.get_user_by_email("demo@dbmonitor.app")
+    assert check_password_hash(demo["password_hash"], "old-password")
+
+    seed_demo_workspace(**kwargs, reset_password=True)
+
+    demo = storage.get_user_by_email("demo@dbmonitor.app")
+    assert demo["id"] == "existing-demo"
+    assert check_password_hash(demo["password_hash"], "demo12345")


### PR DESCRIPTION
## Что сделано

- Добавлен scripts/seed_demo_workspace.py для создания Demo 3.2 users/projects/connections.
- Скрипт идемпотентно создает demo@dbmonitor.app, lake@dbmonitor.app, проекты Retail Postgres / Events ClickHouse / Iceberg Lakehouse и encrypted connections.
- Добавлены тесты на создание, идемпотентность и encrypted DSN.
- Обновлен docs/demo/SCENARIO_3_2.md с командой запуска demo seed и demo password.

## Проверка

- pytest tests/test_seed_demo_workspace.py -q
- ruff check scripts/seed_demo_workspace.py tests/test_seed_demo_workspace.py

Closes #173