### PR TITLE
feat(#104): Feature flags — env-based, 404-on-off, /admin/feature-flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pinned: false
 - [Поддерживаемые СУБД](#поддерживаемые-субд)
 - [Запуск в Docker](#запуск-в-docker)
 - [Переменные окружения](#переменные-окружения)
+- [Feature flags](#feature-flags)
 - [Sentry (error tracking)](#sentry-error-tracking)
 - [Метрики (Prometheus)](#метрики-prometheus)
 - [Логи](#логи)
@@ -451,6 +452,44 @@ DATABASE_URL=postgresql://postgres.<project>:<PASSWORD>@aws-0-<region>.pooler.su
 | `FLASK_DEBUG`        | —            | `1` (Docker — `0`)        | Включает дебаг и автоперезапуск Flask         |
 
 > ⚠️ Файл `.env` содержит секреты — не коммитить в git.
+
+---
+
+## Feature flags
+
+Простой механизм выключения фичи без редеплоя — `FF_<NAME>` env var.
+Truthy значения (case-insensitive): `1`, `true`, `yes`, `on`. Всё
+остальное (включая пустое / отсутствующее) — OFF.
+
+```bash
+# Выключить /api/forecast — Prophet начал сходить с ума, экстренный cut-off:
+FF_FORECAST=false make server
+
+# Снова включить:
+FF_FORECAST=1 make server
+```
+
+Использование в коде:
+
+```python
+from app.feature_flags import require_flag, is_enabled
+
+# В route — 404 если флаг off:
+@api.route("/forecast/<table>")
+@require_flag("forecast")
+def forecast_endpoint(table): ...
+
+# В произвольной точке кода:
+if is_enabled("forecast"):
+    schedule_forecast_retrain()
+```
+
+**Почему 404, а не 503?** Снаружи выключенная фича должна выглядеть как
+ненастроенный endpoint — сканер ничего не найдёт, мониторинг не
+заальертит на «легитимный» 503 во время планового cut-off.
+
+Текущий статус флагов: `GET /admin/feature-flags` (JSON-список с
+`name`, `env_key`, `enabled`).
 
 ---
 

--- a/app/admin.py
+++ b/app/admin.py
@@ -6,6 +6,8 @@ from flask_login import current_user
 from collectors.per_project import list_jobs_for_user, parse_job_id, user_owns_job
 from collectors.scheduler import get_scheduler
 
+from .feature_flags import snapshot as _ff_snapshot
+
 bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
@@ -69,3 +71,18 @@ def run_job(job_id: str):
         "job_id": job_id,
         "next_run_time": job.next_run_time.isoformat() if job.next_run_time else None,
     })
+
+
+@bp.route("/feature-flags")
+def feature_flags():
+    """List every known feature flag and its current value (#104).
+
+    Read-only — toggling still requires changing the env var + restart.
+    No write API on purpose: a runtime mutation surface would need its
+    own auth/audit story, which is out of scope for an env-only flag
+    system. Operators flip flags via deploy config.
+
+    Anonymous callers are tolerated (TESTING / health-check diagnostics)
+    so this stays consistent with /admin/jobs.
+    """
+    return jsonify(_ff_snapshot())

--- a/app/api.py
+++ b/app/api.py
@@ -4,6 +4,7 @@ from flask import Blueprint, g, jsonify, request
 from flask_login import current_user
 
 from .db import list_tables, table_schema
+from .feature_flags import require_flag
 from .metrics_storage import (
     count_notifications,
     get_anomaly_scores,
@@ -99,12 +100,17 @@ def metrics(table_name: str):
 
 
 @api.route("/forecast/<table_name>")
+@require_flag("forecast")
 def forecast_endpoint(table_name: str):
     """Return forecast points for a table metric over the requested horizon.
 
     Query params:
       metric  — row_count (default) or size_bytes
       horizon — 1d | 3d | 7d (default) | 14d | 30d
+
+    Gated by ``FF_FORECAST`` (#104) — when the flag is off the route 404s,
+    indistinguishable from a never-deployed endpoint. Useful for emergency
+    cut-off if the Prophet pipeline starts misbehaving in production.
     """
     from ml.forecast import InsufficientDataError
     from ml.forecast import forecast as run_forecast

--- a/app/feature_flags.py
+++ b/app/feature_flags.py
@@ -1,0 +1,117 @@
+"""Feature flags via environment variables (#104).
+
+Two ways to use:
+
+1. ``is_enabled("forecast")`` — direct check anywhere in the code:
+
+   .. code-block:: python
+
+      if is_enabled("forecast"):
+          run_forecast()
+
+2. ``require_flag("forecast")`` — decorator that 404s a Flask route when
+   the flag is off:
+
+   .. code-block:: python
+
+      @api.route("/forecast/<table>")
+      @require_flag("forecast")
+      def forecast_endpoint(table): ...
+
+   404 (not 503 / 501) on purpose: from the outside, a disabled feature
+   should look identical to a never-existed endpoint. Scanners won't
+   discover the route, monitoring won't alert on legit 503 spam during
+   a planned cut-off.
+
+Why ``os.environ`` and not pydantic-settings? Flags churn faster than the
+typed config — every new flag would otherwise need a code change to
+register. ``FF_<NAME>`` lookups keep flag additions to one env-var line.
+
+Truthy values (case-insensitive): ``1`` / ``true`` / ``yes`` / ``on``.
+Anything else (including empty / missing) — flag is OFF.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import wraps
+
+from flask import abort
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _env_key(flag_name: str) -> str:
+    """Normalise a flag name to its env var key. ``forecast`` → ``FF_FORECAST``."""
+    return f"FF_{flag_name.strip().upper().replace('-', '_')}"
+
+
+def is_enabled(flag_name: str) -> bool:
+    """Return True if the env var ``FF_<NAME>`` is set to a truthy value.
+
+    Default OFF — a missing env var is the same as ``FF_FORECAST=false``.
+    Treating "unknown" as "off" means a never-set flag can't accidentally
+    expose half-finished functionality in production.
+    """
+    raw = os.environ.get(_env_key(flag_name), "").strip().lower()
+    return raw in _TRUTHY
+
+
+def require_flag(flag_name: str):
+    """Decorator: 404 the wrapped Flask view when the flag is off.
+
+    Lookup happens on every request — toggling the env var + restarting
+    the worker flips the route within seconds. No code change, no
+    redeploy required for emergency feature shutdown.
+    """
+    def decorator(view):
+        @wraps(view)
+        def wrapper(*args, **kwargs):
+            if not is_enabled(flag_name):
+                logger.info(
+                    "feature-flag '%s' is off; serving 404 for view=%s",
+                    flag_name, view.__name__,
+                )
+                abort(404)
+            return view(*args, **kwargs)
+        # Surface the flag name on the wrapper so the /admin/feature-flags
+        # listing can show which routes are gated by which flag.
+        wrapper._feature_flag = flag_name  # type: ignore[attr-defined]
+        return wrapper
+    return decorator
+
+
+# Registry of flags we want shown on the admin page. Adding a flag here
+# is purely cosmetic — ``is_enabled`` works with any name — but the
+# admin UI needs *something* to enumerate. Keep alphabetically sorted.
+KNOWN_FLAGS: tuple[str, ...] = (
+    "forecast",
+)
+
+
+def snapshot() -> list[dict]:
+    """Return the current on/off state of every KNOWN_FLAGS entry.
+
+    Used by ``/admin/feature-flags`` to render the table. We don't read
+    every ``FF_*`` env var — that would expose unrelated env entries
+    starting with ``FF_``.
+    """
+    return [
+        {
+            "name": name,
+            "env_key": _env_key(name),
+            "enabled": is_enabled(name),
+        }
+        for name in KNOWN_FLAGS
+    ]
+
+
+__all__ = [
+    "KNOWN_FLAGS",
+    "is_enabled",
+    "require_flag",
+    "snapshot",
+]

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,0 +1,181 @@
+"""Feature flags tests (#104).
+
+Covers:
+- ``is_enabled`` truthy-value matrix and default-OFF behaviour
+- ``require_flag`` decorator: 404 when off, normal response when on
+- Real wiring on ``/api/forecast/<table>`` — FF_FORECAST controls visibility
+- ``/admin/feature-flags`` lists known flags with current values
+"""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask, jsonify
+
+from app.feature_flags import is_enabled, require_flag, snapshot
+
+# ── is_enabled matrix ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("raw, expected", [
+    ("1", True),
+    ("true", True),
+    ("TRUE", True),
+    ("yes", True),
+    ("on", True),
+    ("0", False),
+    ("false", False),
+    ("no", False),
+    ("off", False),
+    ("", False),
+    ("   ", False),
+    ("maybe", False),  # unknown → off
+])
+def test_is_enabled_truthy_matrix(monkeypatch, raw, expected):
+    monkeypatch.setenv("FF_DEMO", raw)
+    assert is_enabled("demo") is expected
+
+
+def test_is_enabled_default_off_when_env_missing(monkeypatch):
+    """Missing env var = OFF. Never-set flag must not accidentally expose
+    half-finished functionality."""
+    monkeypatch.delenv("FF_NOT_SET", raising=False)
+    assert is_enabled("not_set") is False
+
+
+def test_is_enabled_normalises_name(monkeypatch):
+    """``forecast``, ``FORECAST``, ``fore-cast`` all read FF_FORECAST."""
+    monkeypatch.setenv("FF_FORE_CAST", "1")
+    assert is_enabled("fore-cast") is True
+    assert is_enabled("FORE_CAST") is True
+    assert is_enabled("fore_cast") is True
+
+
+# ── require_flag decorator on a synthetic Flask app ────────────────────────
+
+
+def _make_app_with_gated_route():
+    app = Flask(__name__)
+
+    @app.route("/secret")
+    @require_flag("secret")
+    def secret():
+        return jsonify({"ok": True})
+
+    return app
+
+
+def test_require_flag_404s_when_off(monkeypatch):
+    """OFF: not 503, not 501, not a CORS pre-flight — exactly 404."""
+    monkeypatch.delenv("FF_SECRET", raising=False)
+    app = _make_app_with_gated_route()
+    resp = app.test_client().get("/secret")
+    assert resp.status_code == 404
+
+
+def test_require_flag_200_when_on(monkeypatch):
+    monkeypatch.setenv("FF_SECRET", "1")
+    app = _make_app_with_gated_route()
+    resp = app.test_client().get("/secret")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}
+
+
+def test_require_flag_lookup_is_per_request(monkeypatch):
+    """Toggling the env var between requests flips the route without
+    rebuilding the app — covers the "restart-free" UX implicitly."""
+    app = _make_app_with_gated_route()
+    client = app.test_client()
+
+    monkeypatch.setenv("FF_SECRET", "1")
+    assert client.get("/secret").status_code == 200
+
+    monkeypatch.setenv("FF_SECRET", "0")
+    assert client.get("/secret").status_code == 404
+
+    monkeypatch.setenv("FF_SECRET", "true")
+    assert client.get("/secret").status_code == 200
+
+
+def test_require_flag_attaches_marker():
+    """The wrapper carries the flag name so admin tooling can introspect."""
+    @require_flag("foo")
+    def view():
+        return "x"
+
+    assert getattr(view, "_feature_flag") == "foo"
+
+
+# ── snapshot / admin ───────────────────────────────────────────────────────
+
+
+def test_snapshot_returns_known_flags(monkeypatch):
+    monkeypatch.setenv("FF_FORECAST", "1")
+    snap = snapshot()
+    names = {row["name"] for row in snap}
+    assert "forecast" in names
+    forecast_row = next(r for r in snap if r["name"] == "forecast")
+    assert forecast_row["env_key"] == "FF_FORECAST"
+    assert forecast_row["enabled"] is True
+
+
+def test_snapshot_off_when_env_missing(monkeypatch):
+    monkeypatch.delenv("FF_FORECAST", raising=False)
+    forecast_row = next(r for r in snapshot() if r["name"] == "forecast")
+    assert forecast_row["enabled"] is False
+
+
+# ── Integration: real /api/forecast + /admin/feature-flags ────────────────
+
+
+@pytest.fixture
+def app_(tmp_path, monkeypatch):
+    """Full app with auth disabled (TESTING default) for endpoint tests."""
+    import app.metrics_storage as storage
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "ff.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    return create_app({"TESTING": True})
+
+
+def test_forecast_endpoint_404_when_flag_off(app_, monkeypatch):
+    """The integration test the issue asks for explicitly: FF_FORECAST=false
+    → /api/forecast/<table> returns 404, indistinguishable from a missing route."""
+    monkeypatch.delenv("FF_FORECAST", raising=False)
+    resp = app_.test_client().get("/api/forecast/users")
+    assert resp.status_code == 404
+
+
+def test_forecast_endpoint_reachable_when_flag_on(app_, monkeypatch):
+    """Flag ON: the route is reachable. We don't care about the actual
+    forecast logic here — anything other than 404 confirms the gate opened."""
+    monkeypatch.setenv("FF_FORECAST", "1")
+    resp = app_.test_client().get("/api/forecast/users")
+    # The route can legitimately respond 422 (insufficient data — no metrics
+    # seeded in this app fixture) or 200 (forecast computed). Both prove
+    # the flag didn't intercept.
+    assert resp.status_code != 404
+
+
+def test_admin_feature_flags_lists_state(app_, monkeypatch):
+    monkeypatch.setenv("FF_FORECAST", "1")
+    resp = app_.test_client().get("/admin/feature-flags")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert isinstance(body, list)
+    forecast = next(row for row in body if row["name"] == "forecast")
+    assert forecast["env_key"] == "FF_FORECAST"
+    assert forecast["enabled"] is True
+
+    monkeypatch.delenv("FF_FORECAST", raising=False)
+    body2 = app_.test_client().get("/admin/feature-flags").get_json()
+    forecast2 = next(row for row in body2 if row["name"] == "forecast")
+    assert forecast2["enabled"] is False

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -62,7 +62,11 @@ def test_retrain_all_skips_empty_tables(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
+    # /api/forecast is gated by FF_FORECAST (#104). Forecast tests
+    # exercise the endpoint, so opt in here once for the whole fixture
+    # rather than annotating every case.
+    monkeypatch.setenv("FF_FORECAST", "1")
     app = create_app({"TESTING": True})
     with app.test_client() as c:
         yield c


### PR DESCRIPTION
Closes #104. Sprint 4 production-readiness — без флагов любая экстренная отмена фичи требует hotfix-релиза. С флагами — env-var + рестарт воркера за секунды. Минимальная инфра: ничего распределённого (Unleash / LaunchDarkly — отдельный тикет если масштаб потребует).

## Что внутри

### `app/feature_flags.py`

- `is_enabled("name")` читает env `FF_<NAME>`; truthy = `{1, true, yes, on}` case-insensitive; всё остальное (включая отсутствие env) → OFF. Default OFF не случайно: never-set флаг не должен случайно показать half-finished функционал в проде.
- `require_flag("name")` — decorator: `abort(404)` если флаг off. **404 а не 503/501** чтобы снаружи фича выглядела как отсутствующий endpoint — сканер не найдёт, мониторинг не заальертит на легитимный 503 во время cut-off.
- `wrapper._feature_flag = name` для интроспекции admin-инструментами.
- `KNOWN_FLAGS` registry + `snapshot()` для /admin.

### Реальный пример: `/api/forecast` (явное требование тикета)

```python
@api.route("/forecast/<table_name>")
@require_flag("forecast")
def forecast_endpoint(...): ...
```

`FF_FORECAST=false make server` → /api/forecast 404 без редеплоя.

### `GET /admin/feature-flags`

Read-only JSON-список `{name, env_key, enabled}`. **Write-API намеренно отсутствует** — toggling требует env+restart; runtime mutation нуждался бы в собственной auth/audit истории, out of scope для env-flag системы.

### Обновление существующих тестов

`tests/test_forecast.py::client` теперь выставляет `FF_FORECAST=1` — forecast-тесты должны тестировать forecast-логику, а не feature-flag машинерию.

## Acceptance из тикета

- [x] `app/feature_flags.py` с `is_enabled` + `require_flag`
- [x] Pydantic-settings не трогаем — через `os.environ`
- [x] `/admin/feature-flags` GET с текущими значениями
- [x] Один реальный пример — `/api/forecast` обёрнут `FF_FORECAST`
- [x] Тесты: декоратор 404 на off, 200 на on; admin показывает состояние
- [x] README: новый раздел "Feature flags"

## Тесты (23 новых кейса)

**`is_enabled` matrix** (parametrized): truthy/falsy/whitespace/unknown — все 12 кейсов.

**`require_flag` decorator**:
- 404 когда off (не 503, не 501 — точная семантика)
- 200 + payload когда on
- per-request lookup: toggling env между запросами flip-ает route без rebuild
- `_feature_flag` attribute сохраняется

**snapshot / admin**:
- `/admin/feature-flags` возвращает `list[{name, env_key, enabled}]`
- forecast row отражает текущее значение `FF_FORECAST`

**Integration** (важное):
- `/api/forecast/<table>` → 404 когда `FF_FORECAST=false` (точная формулировка acceptance из тикета)
- `/api/forecast/<table>` → не-404 когда `FF_FORECAST=1`

## Verification

- **618 passed** (+23 + 4 обновлённых test_forecast)
- ruff clean

## Test plan

- [x] Юнит-тесты на all paths
- [x] Real `/api/forecast` за реальным flag-ом, обе стороны
- [x] /admin/feature-flags JSON-shape
- [ ] Manual smoke после merge: `curl /api/forecast/users` → 404, `FF_FORECAST=1 make server` + same curl → 200/422