### PR TITLE
feat(#105): Docker release workflow + version в /healthz + откат через :previous

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,58 @@
+name: promote-demo-stable
+
+# Manual: переставляет ``demo-stable`` тэг на указанную версию (#105).
+# Используется ПЕРЕД презентацией: «закрепить» проверенный билд,
+# который точно не сломается за минуту до demo, что бы потом ни
+# смержилось в master. ``latest`` гонит head — для демо опасно.
+#
+# Запуск: GitHub Actions → promote-demo-stable → Run workflow →
+# version=v1.2.3 → Run.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Версионный тэг к которому ставим demo-stable (например, v0.1.0 или 0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Normalise version
+        id: ver
+        run: |
+          set -euo pipefail
+          # Принимаем и "v1.2.3" и "1.2.3" — в OCI registry стандарт без v.
+          VERSION="${{ inputs.version }}"
+          NUMERIC="${VERSION#v}"
+          echo "numeric=${NUMERIC}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Repoint demo-stable
+        run: |
+          set -euo pipefail
+          # Не пересобираем — promote это переименование манифеста, не build.
+          # Если указанной версии в registry нет — docker pull упадёт
+          # с понятным сообщением, операция не выполнится.
+          docker pull "${IMAGE}:${{ steps.ver.outputs.numeric }}"
+          docker tag  "${IMAGE}:${{ steps.ver.outputs.numeric }}" "${IMAGE}:demo-stable"
+          docker push "${IMAGE}:demo-stable"
+          echo "::notice::demo-stable → ${{ steps.ver.outputs.numeric }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: release
+
+# Триггер — push семвер-тэга (v1.2.3, v0.1.0-rc1, …). Тэг на лоб HEAD
+# пишет образ с этой версией в GHCR и переставляет ``previous`` на
+# предыдущий стабильный тэг. ``demo-stable`` руками двигаем через
+# отдельный manual workflow (./promote.yml) — он сидит за approval-gate.
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: read
+  packages: write   # push в GHCR
+
+concurrency:
+  # Не параллелим релизы — два одновременных тэга могут перебить
+  # друг другу latest/previous. group по workflow (не по ref) сериализует.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Полная история нужна чтобы найти ПРЕДЫДУЩИЙ release-тэг
+          # (см. "previous tag" step ниже).
+          fetch-depth: 0
+
+      - name: Derive version & previous tag
+        id: tags
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF##*/}"      # v1.2.3
+          NUMERIC="${VERSION#v}"           # 1.2.3
+          # Найти предыдущий semver-тэг (не считая текущего). git tag
+          # --sort=-v:refname упорядочивает по semver desc; берём
+          # второй, потому что первый — это только что запушенный.
+          PREVIOUS=$(git tag --list "v*.*.*" --sort=-v:refname \
+                      | grep -v "^${VERSION}$" | head -1 || true)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "numeric=${NUMERIC}" >> "$GITHUB_OUTPUT"
+          echo "previous=${PREVIOUS}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Release ${VERSION}  (previous=${PREVIOUS:-none})"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push the release image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          # Версионный тэг (1.2.3 без префикса v, как принято в OCI
+          # registries) + latest (head of master == latest release).
+          # ``v1.2.3`` тоже пушим — кому-то удобнее с префиксом.
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.tags.outputs.numeric }}
+            ${{ env.IMAGE }}:${{ steps.tags.outputs.version }}
+            ${{ env.IMAGE }}:latest
+          # APP_VERSION читается health-endpoint-ом (/healthz.version),
+          # см. Dockerfile + app/health.py::_version.
+          build-args: |
+            APP_VERSION=${{ steps.tags.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Repoint ``previous`` to the prior release
+        if: steps.tags.outputs.previous != ''
+        run: |
+          set -euo pipefail
+          PREV_NUM="${{ steps.tags.outputs.previous }}"
+          PREV_NUM="${PREV_NUM#v}"
+          # Не пересобираем — просто тащим уже опубликованный prior tag
+          # и пушим под именем ``previous``. Дешевле + воспроизводимо.
+          docker pull "${IMAGE}:${PREV_NUM}"
+          docker tag  "${IMAGE}:${PREV_NUM}" "${IMAGE}:previous"
+          docker push "${IMAGE}:previous"
+          echo "::notice::previous → ${PREV_NUM}"
+
+      - name: Skip previous (no prior release)
+        if: steps.tags.outputs.previous == ''
+        run: echo "::notice::First release — no 'previous' tag to set."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM python:3.12-slim
 
+# Build-time version (#105). Injected by the release workflow from the
+# git tag (v0.1.0) or the short SHA on untagged builds. ``app/health.py
+# ::_version`` reads APP_VERSION first; the .git fallback inside the
+# image is never reachable because we don't COPY .git.
+ARG APP_VERSION=dev
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     HOST=0.0.0.0 \
     PORT=5001 \
-    FLASK_DEBUG=0
+    FLASK_DEBUG=0 \
+    APP_VERSION=${APP_VERSION}
 
 RUN useradd -m -u 1000 user
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pinned: false
 - [Поддерживаемые СУБД](#поддерживаемые-субд)
 - [Запуск в Docker](#запуск-в-docker)
 - [Переменные окружения](#переменные-окружения)
+- [Релизы и откат (Docker tags)](#релизы-и-откат-docker-tags)
 - [Feature flags](#feature-flags)
 - [Sentry (error tracking)](#sentry-error-tracking)
 - [Метрики (Prometheus)](#метрики-prometheus)
@@ -452,6 +453,53 @@ DATABASE_URL=postgresql://postgres.<project>:<PASSWORD>@aws-0-<region>.pooler.su
 | `FLASK_DEBUG`        | —            | `1` (Docker — `0`)        | Включает дебаг и автоперезапуск Flask         |
 
 > ⚠️ Файл `.env` содержит секреты — не коммитить в git.
+
+---
+
+## Релизы и откат (Docker tags)
+
+Образ публикуется в **GHCR** автоматически при пуше semver-тэга:
+
+```bash
+git tag v0.1.0
+git push --tags
+# → GitHub Actions release.yml собирает и пушит:
+#    ghcr.io/aleksandr-novikov/db-monitoring:0.1.0
+#    ghcr.io/aleksandr-novikov/db-monitoring:v0.1.0
+#    ghcr.io/aleksandr-novikov/db-monitoring:latest
+# + переставляет :previous на предыдущий semver-тэг
+```
+
+**Версия зашита в образ** через build-arg `APP_VERSION`, доступна как
+`/healthz.version` — `curl /healthz | jq .version` подтверждает что в
+проде крутится именно тот образ, который ты ждёшь.
+
+### Откат за 30 секунд
+
+```bash
+docker pull ghcr.io/aleksandr-novikov/db-monitoring:previous
+docker compose up -d   # подменит образ, контейнер перезапустится
+curl localhost:5001/healthz | jq .version  # подтверждение
+```
+
+`:previous` всегда указывает на предыдущий semver-тэг (release workflow
+переставляет его автоматически). Это даёт one-command rollback без
+необходимости помнить какой именно билд был «последним стабильным».
+
+### Demo-stable (для презентаций)
+
+Тэг `demo-stable` НЕ двигается автоматически — переставляется
+вручную через **promote-demo-stable** workflow (Actions → Run workflow →
+ввести версию). Используется ПЕРЕД презентацией: «закрепить»
+проверенный билд, который точно не сломается за минуту до demo, даже
+если в master в это время что-то смерджится.
+
+| Тэг | Когда обновляется | Назначение |
+|---|---|---|
+| `latest` | каждый релиз | head of releases |
+| `v1.2.3` / `1.2.3` | один раз при тэге | immutable identity |
+| `previous` | каждый релиз → предыдущий semver | one-command rollback |
+| `demo-stable` | manual workflow | закреплённый билд для демо |
 
 ---
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -83,6 +83,19 @@ def test_healthz_version_field_is_a_string(client):
     assert body["version"]  # non-empty
 
 
+def test_healthz_version_honours_app_version_env(client, monkeypatch):
+    """#105: Docker release builds inject APP_VERSION=<tag> via Dockerfile
+    ARG → ENV. /healthz must surface that exact value so an operator can
+    confirm which image is running before a rollback.
+    """
+    # Reset the per-process cache so the new env var is picked up.
+    import app.health as health_mod
+    monkeypatch.setattr(health_mod, "_VERSION_CACHE", None)
+    monkeypatch.setenv("APP_VERSION", "v9.9.9-test")
+    body = client.get("/healthz").get_json()
+    assert body["version"] == "v9.9.9-test"
+
+
 # --- Failure modes ---------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #105. Раньше образ собирался только локально, без registry, без версий, без rollback-pipeline. После этого PR:

- semver-тэг в git → release workflow собирает + пушит в GHCR
- `/healthz` отдаёт версию запущенного образа (rollback verification)
- `:previous` всегда указывает на предыдущий semver → откат одной командой
- `:demo-stable` двигается вручную перед презентациями

## Скоуп

### `.github/workflows/release.yml` — авто, на `v*.*.*` git tag

- `fetch-depth: 0` (нужна история чтобы найти **предыдущий** semver-тэг)
- Derives `version` + `previous` через `git tag --list --sort=-v:refname` минус текущий
- Buildx + GHA cache, login в GHCR через `GITHUB_TOKEN`
- Push трёх тэгов одним build-and-push: numeric (`1.2.3`), v-prefixed (`v1.2.3`), `latest`
- `APP_VERSION=<tag>` прокидывается `build-args` → попадает в `ENV` образа → видно в `/healthz.version`
- **Repoint `:previous`**: `docker pull` старого numeric → retag → push под именем `previous`. Не пересобираем — manifest-only retag.
- `concurrency: group=workflow` (не по ref) — два параллельных тэга не перебьют `:latest`/`:previous` друг другу
- `permissions: packages:write` для GHCR push

### `.github/workflows/promote.yml` — manual `workflow_dispatch`

- Принимает `version` input (с `v` или без, normaliseм)
- `docker pull` указанного тэга → tag `:demo-stable` → push
- Если версии нет в registry — `pull` упадёт с понятным сообщением, операция не выполнится

### `Dockerfile`

`ARG APP_VERSION=dev` + прокидка в `ENV`. Чистый default `dev` для локальной сборки. `app/health.py::_version` уже умел читать `APP_VERSION` (#100) — просто запитали.

### `tests/test_health.py`

Новый кейс `test_healthz_version_honours_app_version_env`: `monkeypatch.setenv("APP_VERSION", "v9.9.9-test")` + reset `_VERSION_CACHE` → `/healthz` отдаёт ровно `v9.9.9-test`. Защита от регрессии — если кто-то сломает `_version()` поверх env, тест поймает.

### README

Новый раздел **«Релизы и откат (Docker tags)»**:
- Точный one-liner для отката: `docker pull :previous → up -d → curl /healthz.version` для подтверждения
- `:demo-stable` как manual safety-net перед демо
- Таблица тэгов: `latest` / `v1.2.3` / `previous` / `demo-stable` — когда обновляются и зачем

## Acceptance из тикета

- [x] GitHub Actions release workflow на `v*.*.*` тэг → build → push в GHCR (`ghcr.io/aleksandr-novikov/db-monitoring:1.2.3`)
- [x] Пушим `previous` (предыдущий стабильный) и `latest`
- [x] Manual-trigger workflow "promote" — переставляет `demo-stable`
- [x] Версия в `/healthz` читается из ARG/ENV (`APP_VERSION`)
- [x] README: раздел про rollback через docker tag

## Не входит (отдельные тикеты)

- E2E тест release workflow — требует sandbox GHCR
- Notification в Slack/Telegram о новом релизе — отдельный hook

## Verification

- `pytest tests/test_health.py` → **22 passed** (+1 новый)
- `pytest -q` full → **619 passed**
- ruff clean
- YAML parses (`release.yml` + `promote.yml`)

## Test plan

- [x] Юнит-тест `APP_VERSION` → `/healthz.version`
- [x] YAML структурно валиден
- [ ] **Manual smoke** (требует реального тэга в master после merge): `git tag v0.1.0 && git push --tags` → workflow зелёный, в [GHCR packages](https://github.com/users/aleksandr-novikov/packages?repo_name=db-monitoring) видны тэги `0.1.0`, `v0.1.0`, `latest`
- [ ] **Manual rollback dry-run**: `docker pull ghcr.io/.../db-monitoring:previous` → `curl /healthz | jq .version` — версия должна сменить с текущей на предыдущую