### PR TITLE
feat(#106 #107): Backup + Rollback runbooks, авто-pg_dump, /admin/rollback-checklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PORT          ?= 5001
 PROJECT_ID    ?= legacy
 CONNECTION_ID ?=
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg demo-ids clickhouse-up clickhouse-down seed-clickhouse
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg demo-ids clickhouse-up clickhouse-down seed-clickhouse backup restore backup-cron-up backup-cron-down
 
 build:
 	docker build -t $(IMAGE) .
@@ -137,6 +137,20 @@ seed-clickhouse: ## Заполнить ClickHouse-демо тестовыми д
 	@curl -sf http://localhost:8123/ping >/dev/null 2>&1 || \
 		(echo "ClickHouse не запущен. Сначала выполни: make clickhouse-up" && exit 1)
 	python -m scripts.seed_clickhouse $(ARGS)
+
+# ── Backup / restore (#106) ──────────────────────────────────────────
+backup: ## Снять бэкап target + monitor DB в ./backups
+	@scripts/backup.sh
+
+restore: ## Восстановить из бэкапа: make restore FILE=backups/...sql.gz [RESTORE_URL=...]
+	@test -n "$(FILE)" || (echo "Usage: make restore FILE=<path> [RESTORE_URL=postgresql://...]" && exit 1)
+	@scripts/restore.sh $(FILE)
+
+backup-cron-up: ## Запустить фоновый backup-сервис (cron в Docker)
+	docker compose --profile backup up -d backup
+
+backup-cron-down: ## Остановить фоновый backup-сервис
+	docker compose --profile backup stop backup
 
 # Ruff: linter + import sort + pyupgrade in one tool. Config in pyproject.toml.
 # Runs locally via venv (fast, no docker round-trip). Same command runs in CI.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pinned: false
 - [Поддерживаемые СУБД](#поддерживаемые-субд)
 - [Запуск в Docker](#запуск-в-docker)
 - [Переменные окружения](#переменные-окружения)
+- [Операционные процедуры (runbooks)](#операционные-процедуры-runbooks)
 - [Релизы и откат (Docker tags)](#релизы-и-откат-docker-tags)
 - [Feature flags](#feature-flags)
 - [Sentry (error tracking)](#sentry-error-tracking)
@@ -453,6 +454,25 @@ DATABASE_URL=postgresql://postgres.<project>:<PASSWORD>@aws-0-<region>.pooler.su
 | `FLASK_DEBUG`        | —            | `1` (Docker — `0`)        | Включает дебаг и автоперезапуск Flask         |
 
 > ⚠️ Файл `.env` содержит секреты — не коммитить в git.
+
+---
+
+## Операционные процедуры (runbooks)
+
+Пошаговые инструкции «что делать когда» — отдельные документы чтобы
+README не разбухал и runbook можно было кинуть дежурному ссылкой.
+
+- [Backup и восстановление](docs/runbooks/backup.md) — автоматические дампы, ротация (7 daily + 4 weekly), SHA-256 проверка, RPO/RTO.
+- [Откат релиза](docs/runbooks/rollback.md) — decision-tree от `/healthz` через feature flags до восстановления из бэкапа.
+- `/admin/rollback-checklist` — статичная страница с чекбоксами для оператора в момент инцидента (краткая версия rollback runbook).
+
+Связанная инфраструктура:
+
+```bash
+make backup                # snap shot обеих БД в ./backups
+make restore FILE=...      # восстановление с проверкой sha256
+make backup-cron-up        # фоновый сервис: 1 бэкап/сутки в 03:15 UTC
+```
 
 ---
 

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, render_template
 from flask_login import current_user
 
 from collectors.per_project import list_jobs_for_user, parse_job_id, user_owns_job
@@ -71,6 +71,17 @@ def run_job(job_id: str):
         "job_id": job_id,
         "next_run_time": job.next_run_time.isoformat() if job.next_run_time else None,
     })
+
+
+@bp.route("/rollback-checklist")
+def rollback_checklist():
+    """Static checklist for the operator at incident time (#107).
+
+    Cribbed straight from docs/runbooks/rollback.md but as a checklist with
+    checkboxes — dejavu UX so a frazzled on-call doesn't have to scroll
+    through Mermaid diagrams. Pure server-side render, no JS dependencies.
+    """
+    return render_template("admin/rollback_checklist.html")
 
 
 @bp.route("/feature-flags")

--- a/backups/.gitignore
+++ b/backups/.gitignore
@@ -1,0 +1,3 @@
+# Backup files are local-only — never tracked.
+*
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,48 @@ services:
       timeout: 5s
       retries: 20
 
+  # ── Backup cron (#106) ────────────────────────────────────────────────
+  # Запускает scripts/backup.sh каждый день в 03:15 UTC. Профиль "backup"
+  # — иначе невозможно запустить app локально без поднятия cron.
+  # docker compose --profile backup up -d backup
+  # Контейнер с postgres-client + bash + cron; ничего самобытного.
+  backup:
+    image: postgres:18
+    container_name: db-monitoring-backup
+    profiles: ["backup"]
+    environment:
+      # Бэкап-скрипт читает DATABASE_URL и MONITOR_DB_URL — те же что app.
+      DATABASE_URL: ${DATABASE_URL:-}
+      MONITOR_DB_URL: ${MONITOR_DB_URL:-postgresql://postgres:dev@postgres:5432/monitor}
+      BACKUP_DIR: /backups
+      RETENTION_DAILY: 7
+      RETENTION_WEEKLY: 4
+    volumes:
+      - ./scripts/backup.sh:/usr/local/bin/backup.sh:ro
+      - ./scripts/restore.sh:/usr/local/bin/restore.sh:ro
+      - ./backups:/backups
+    # crond не входит в стандартный postgres-образ. Решение: запускаем
+    # лёгкий sleep-loop, который раз в сутки вызывает скрипт. Cron-как-
+    # сервис избыточен для одной задачи — bash справляется.
+    command:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        # Установка sqlite3 (для SQLite-бэкапов monitor.db) + apt cleanup.
+        apt-get update -qq && apt-get install -yqq sqlite3 && rm -rf /var/lib/apt/lists/*
+        # Дожидаемся ближайших 03:15 UTC, потом sleep 24h в цикле.
+        while true; do
+          now=$$(date -u +%s); next=$$(date -u -d 'today 03:15' +%s)
+          [ "$$next" -lt "$$now" ] && next=$$(date -u -d 'tomorrow 03:15' +%s)
+          sleep $$(($$next - $$now))
+          /usr/local/bin/backup.sh || echo "[backup] tick failed at $$(date -u +%FT%TZ)"
+        done
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+
 volumes:
   pg_data:
   timescale_data:

--- a/docs/runbooks/backup.md
+++ b/docs/runbooks/backup.md
@@ -1,0 +1,148 @@
+# Backup runbook (#106)
+
+> **Когда читать:** перед каждым релизом, перед миграциями, при подозрении
+> на data corruption. **Ожидаемое время прочтения:** 3 минуты.
+
+## TL;DR
+
+```bash
+# Бэкап обоих DB здесь и сейчас:
+make backup
+
+# Восстановление из конкретного дампа:
+RESTORE_URL=postgresql://postgres:dev@localhost:5432/monitor \
+  scripts/restore.sh backups/target-monitor-20260530-031500.sql.gz
+```
+
+## Что и куда бэкапится
+
+| Источник | Скрипт пишет | Что внутри |
+|---|---|---|
+| `DATABASE_URL` (target prod DB) | `backups/target-<dbname>-YYYYMMDD-HHMMSS.sql.gz` | `pg_dump` целиком |
+| `MONITOR_DB_URL` (metrics store) | `backups/metrics-<dbname>-{YYYYMMDD-HHMMSS}.{sql,sqlite}.gz` | Postgres → `pg_dump`, SQLite → `sqlite3 .backup` |
+
+Рядом с каждым дампом — `.sha256` sidecar. Восстановление **отказывается**
+работать без валидной контрольной суммы (защита от bit-rot).
+
+## Где лежат бэкапы
+
+- **Локально**: `./backups/` в репозитории (gitignored).
+- **В Docker**: проброшено host-volume в сервис `backup` (см. ниже).
+- **Production**: рекомендуется `./backups/` смонтировать на сетевой
+  storage (NFS / s3fs / restic remote) — локальный диск даст потерять
+  бэкапы вместе с хостом при cascade-failure.
+
+## Расписание (автомат)
+
+Сервис `backup` в `docker-compose.yml` запускает `scripts/backup.sh`
+каждые **сутки в 03:15 UTC**. Профиль `backup` — стартует только когда
+просишь:
+
+```bash
+docker compose --profile backup up -d backup
+
+# Логи:
+docker compose logs -f backup
+```
+
+Один бэкап в сутки = RPO 24h. Если нужен меньший — крути cron-schedule
+в command-секции, или переходи на streaming-репликацию (выходит за рамки
+этого runbook).
+
+## Ротация
+
+- **Daily**: последние 7 дней.
+- **Weekly**: каждое воскресенье отдельно маркируется `.weekly` файлом;
+  такие дампы живут 4 недели (т.е. последние 4 воскресенья).
+
+```
+backups/
+├── target-monitor-20260524-031500.sql.gz          (Sunday)
+├── target-monitor-20260524-031500.sql.gz.weekly   ← marker
+├── target-monitor-20260525-031500.sql.gz          (Monday)
+└── target-monitor-20260525-031500.sql.gz.sha256
+```
+
+После 7 дней Monday-Saturday backups удаляются. Sunday-backup остаётся
+ещё 3 недели.
+
+Кастомизация:
+
+```bash
+RETENTION_DAILY=14 RETENTION_WEEKLY=8 scripts/backup.sh
+```
+
+## Manual backup (без cron)
+
+```bash
+make backup
+# или напрямую:
+DATABASE_URL=postgresql://... MONITOR_DB_URL=postgresql://... \
+  scripts/backup.sh
+```
+
+## Восстановление
+
+### Postgres (`target-*.sql.gz`)
+
+1. **Подними чистую базу** на той же major-версии Postgres. НЕ
+   восстанавливай поверх живой prod без явного `DROP DATABASE` —
+   `psql` сольёт два дампа.
+2. Прогон:
+
+   ```bash
+   RESTORE_URL=postgresql://postgres:dev@new-host:5432/monitor \
+     scripts/restore.sh backups/target-monitor-20260530-031500.sql.gz
+   ```
+
+3. Проверка:
+
+   ```bash
+   psql "$RESTORE_URL" -c "SELECT count(*) FROM users;"
+   ```
+
+### SQLite (`metrics-monitor.sqlite.gz`)
+
+1. **Останови app** (`docker compose stop app`) — иначе новые писатели
+   создадут расхождение с восстановленным файлом.
+2. Прогон:
+
+   ```bash
+   RESTORE_PATH=monitor.db.restored scripts/restore.sh \
+     backups/metrics-monitor-20260530-031500.sqlite.gz
+   ```
+
+3. Замена + старт:
+
+   ```bash
+   mv monitor.db monitor.db.broken
+   mv monitor.db.restored monitor.db
+   docker compose start app
+   curl localhost:5001/healthz | jq .checks.monitor_db
+   ```
+
+## SLO
+
+| Метрика | Цель | Как меряем |
+|---|---|---|
+| **RPO** (Recovery Point Objective — сколько данных теряем) | 24 ч | один автоматический бэкап в сутки |
+| **RTO** (Recovery Time Objective — сколько идёт восстановление) | < 5 мин | smoke-тест в CI на demo-датасете |
+
+Если pg-база растёт > 1 ГБ и dump перестанет влезать в 5 минут — переходи на
+`pg_dump --format=custom` + `pg_restore -j N` (быстрее) или на физический
+бэкап через `pg_basebackup` + WAL-archiving (constant-time RPO).
+
+## Проверки которые иногда нужно делать руками
+
+- Quarterly: проверить что хотя бы один последний weekly-бэкап **реально**
+  восстанавливается (не просто валиден по чексумме). Запустить
+  `restore.sh` → `psql RESTORE_URL -c '\dt'` → ожидать список таблиц.
+- После любого изменения схемы (миграции, ALTER, DROP): сразу прогнать
+  ручной бэкап ДО релиза. Автоматический в 03:15 не успеет, если что-то
+  пойдёт не так в течение дня.
+
+## Ссылки
+
+- [Rollback runbook](./rollback.md) — что делать когда релиз поломал прод
+- `scripts/backup.sh` — реализация
+- `scripts/restore.sh` — реализация

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -1,0 +1,144 @@
+# Rollback runbook (#107)
+
+> **Когда читать:** прод горит после релиза. **Ожидаемое время прочтения:** < 5 минут.
+> **Ожидаемое время отката:** < 10 минут на тестовом окружении, ~3 минуты на проде.
+
+## Decision tree
+
+```mermaid
+graph TD
+    A[Релиз → инцидент] --> B{curl /healthz?strict=true}
+    B -->|200 OK| C[Возможно не релиз. Сравни /healthz.version<br/>с тэгом релиза.<br/>Совпадает? → проблема НЕ в коде]
+    B -->|503| D[docker compose logs --tail=200 app<br/>Sentry → последние events]
+    D --> E{Виновная фича<br/>обёрнута Feature Flag?}
+    E -->|Да| F[FF_NAME=false → restart воркер<br/>30 сек, без передеплоя]
+    E -->|Нет / не помогло| G[docker pull ...:previous<br/>docker compose up -d app]
+    G --> H{curl /healthz после отката}
+    H -->|200 OK| I[Готово. Postmortem.]
+    H -->|503| J{Данные битые?}
+    J -->|Да| K[scripts/restore.sh из последнего бэкапа<br/>см. backup.md]
+    J -->|Нет / не уверен| L[Эскалация: пинг команду]
+```
+
+## Шаг 1 — Подтвердить что это инцидент
+
+```bash
+curl -sf "http://<prod>/healthz?strict=true" | jq .
+```
+
+| Ответ | Что значит | Действие |
+|---|---|---|
+| 200 + `status: ok` | Зависимости здоровы | Проблема не на нашей стороне (target DB? сеть?) |
+| 503 + `status: degraded` | Хотя бы одна зависимость `down` | → шаг 2 |
+| Connection refused | App вообще не отвечает | Сразу → шаг 4 (откат) |
+
+Сверка версии:
+
+```bash
+curl -s http://<prod>/healthz | jq .version
+# должна совпадать с git tag релиза
+```
+
+## Шаг 2 — Идентифицировать виновную фичу
+
+Логи (последние 200 строк App-контейнера):
+
+```bash
+docker compose logs --tail=200 app
+```
+
+JSON-логи (`LOG_FORMAT=json`) фильтруются jq-grep'ом:
+
+```bash
+docker compose logs app | jq 'select(.level == "ERROR" or .level == "WARNING")'
+```
+
+Sentry: открой [Issues → последние 15 минут](https://sentry.io/) →
+ищи всплеск exceptions с release tag = текущий релиз.
+
+Цель — связать симптом с конкретной фичей. Если непонятно → шаг 4
+(откат и разбираешься в спокойной обстановке).
+
+## Шаг 3 — Попробовать выключить через feature flag
+
+Если фича обёрнута `@require_flag("…")`:
+
+```bash
+# .env или docker-compose.override.yml:
+FF_FORECAST=false
+docker compose restart app
+curl http://<prod>/api/forecast/users  # должно вернуть 404
+```
+
+Это самый дешёвый откат: минуты вместо часов, без редеплоя. Если
+feature flag нет — переходи к шагу 4.
+
+Какие фичи под флагами — `curl http://<prod>/admin/feature-flags`.
+
+## Шаг 4 — Откат на предыдущий образ
+
+```bash
+docker pull ghcr.io/aleksandr-novikov/db-monitoring:previous
+docker compose up -d app
+```
+
+Проверка:
+
+```bash
+# Версия должна смениться:
+curl -s http://<prod>/healthz | jq .version
+
+# Health-check:
+curl -sf "http://<prod>/healthz?strict=true" || echo "still bad"
+```
+
+Если откат **не помогает** — проверь:
+- Тэг `:previous` действительно указывает на ту версию что ты ждёшь (`docker inspect ...:previous | jq '.[0].Config.Env' | grep APP_VERSION`)
+- Образ скачался (не cached старый): `docker image rm ...:previous && docker pull ...`
+
+## Шаг 5 — Восстановление из бэкапа (если данные битые)
+
+Делай **только** если:
+1. Откат образа не помог
+2. В логах/Sentry — ошибки про data corruption / constraint violations
+3. Подтверждено что недавняя миграция (DROP, NOT NULL) повредила данные
+
+→ Полный сценарий в [backup.md](./backup.md#восстановление).
+
+Краткая версия:
+
+```bash
+docker compose stop app
+RESTORE_URL=postgresql://... scripts/restore.sh backups/target-monitor-<latest-before-bad>.sql.gz
+docker compose start app
+curl -sf http://<prod>/healthz?strict=true
+```
+
+## Шаг 6 — Подтвердить + закрыть инцидент
+
+После любого rollback-шага:
+
+1. ✅ `curl /healthz?strict=true` → 200
+2. ✅ Smoke API: `curl /api/notifications?limit=5` отдаёт payload
+3. ✅ Sentry: новые errors прекратились (interval 15 мин)
+4. ✅ Prometheus: `http_requests_total{status=~"5.."}` перестала расти
+5. 📝 Postmortem в issue tracker: что было, что сделали, почему этой
+   фичи нет под feature flag (если она должна быть)
+
+## Ссылки
+
+- [Backup runbook](./backup.md) — если нужен шаг 5
+- [Feature flags README](../../README.md#feature-flags) — список фич за флагами
+- [Релизы и Docker tags](../../README.md#релизы-и-откат-docker-tags) — как именно `:previous` обновляется
+- `/admin/feature-flags` — текущее состояние флагов в проде
+- `/healthz?strict=true` — глубокая проверка зависимостей
+
+## Контакты
+
+| Кто | Когда звонить |
+|---|---|
+| Sentry — owner проекта | Если события не приходят (sentry-sdk сломан в проде) |
+| GHCR — кто пушит | Если `:previous` тэг указывает не туда (race в release workflow) |
+
+> **Реgular dry-run:** хотя бы раз в квартал прогнать сценарий «откатить
+> релиз» на staging. Без этого runbook гниёт молча.

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Backup script for the monitored target DB AND the metrics store (#106).
+#
+# What it does
+# ------------
+# 1. Reads connection URLs from the environment (DATABASE_URL = monitored
+#    target DB, MONITOR_DB_URL = metrics store; SQLite is supported for
+#    the latter too).
+# 2. Runs pg_dump on each (or `sqlite3 .backup` for SQLite metrics).
+# 3. Gzips the result + writes ``backups/<dbname>-YYYYMMDD-HHMMSS.sql.gz``.
+# 4. Computes SHA-256 alongside the dump so restore.sh can verify integrity.
+# 5. Rotates: keeps last 7 daily + last 4 weekly (= last 4 Sundays).
+#    Daily backups older than 7 days that AREN'T weekly archives are deleted.
+#
+# Usage
+# -----
+#   scripts/backup.sh                 # both DBs, default ./backups dir
+#   BACKUP_DIR=/srv/dumps scripts/backup.sh
+#
+# Environment
+# -----------
+#   DATABASE_URL       — required for target backup; empty → skip
+#   MONITOR_DB_URL     — required for metrics backup; empty → skip
+#   BACKUP_DIR         — output directory; default ./backups
+#   RETENTION_DAILY    — daily-copy retention, default 7
+#   RETENTION_WEEKLY   — weekly-copy retention, default 4
+#
+# Exit codes: 0 ok, 1 fatal (no DBs reachable / unable to write dumps).
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+RETENTION_DAILY="${RETENTION_DAILY:-7}"
+RETENTION_WEEKLY="${RETENTION_WEEKLY:-4}"
+
+mkdir -p "$BACKUP_DIR"
+
+TS="$(date -u +%Y%m%d-%H%M%S)"
+DOW="$(date -u +%u)"  # 1 (Mon) .. 7 (Sun)
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+_log() { printf '%s [backup] %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        # macOS — shasum -a 256 is preinstalled.
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+# Extract just the path component (database name) from a libpq URL.
+_dbname() {
+    local url="$1"
+    # postgresql://user:pass@host:port/dbname?opts → dbname
+    python3 - <<PY 2>/dev/null || echo "db"
+from urllib.parse import urlparse
+p = urlparse("$url")
+name = p.path.lstrip("/")
+print(name if name else "db")
+PY
+}
+
+_dump_postgres() {
+    local url="$1" label="$2"
+    local dbname; dbname="$(_dbname "$url")"
+    local outfile="${BACKUP_DIR}/${label}-${dbname}-${TS}.sql.gz"
+    _log "→ pg_dump ${label} (${dbname}) to ${outfile}"
+    # --no-owner / --no-acl keep the dump portable across users/clusters
+    # (we restore into a fresh DB on the same image — owners differ).
+    # --format=plain is what gzip eats nicely; for >10G consider -Fc later.
+    pg_dump --no-owner --no-acl --format=plain "$url" | gzip -9 > "$outfile"
+    _sha256 "$outfile" > "${outfile}.sha256"
+    _log "  done. sha256 → ${outfile}.sha256"
+}
+
+_dump_sqlite() {
+    # SQLite metrics store — ``sqlite3 source .backup dest`` produces a
+    # consistent on-disk snapshot even under concurrent writes (uses the
+    # backup API, not a file copy).
+    local url="$1" label="$2"
+    local path="${url#sqlite:///}"
+    path="${path#sqlite://}"
+    if [[ ! -f "$path" ]]; then
+        _log "  SQLite file not found at ${path}; skipping ${label}"
+        return 0
+    fi
+    local outfile="${BACKUP_DIR}/${label}-$(basename "$path" .db)-${TS}.sqlite.gz"
+    _log "→ sqlite3 backup ${label} (${path}) to ${outfile}"
+    local tmp; tmp="$(mktemp)"
+    sqlite3 "$path" ".backup '$tmp'"
+    gzip -9 -c "$tmp" > "$outfile"
+    rm -f "$tmp"
+    _sha256 "$outfile" > "${outfile}.sha256"
+    _log "  done. sha256 → ${outfile}.sha256"
+}
+
+_dump_any() {
+    local url="$1" label="$2"
+    [[ -z "$url" ]] && { _log "  ${label}: empty URL, skipping"; return 0; }
+    case "$url" in
+        postgresql://*|postgres://*)  _dump_postgres "$url" "$label" ;;
+        sqlite://*|sqlite:///*)       _dump_sqlite   "$url" "$label" ;;
+        *) _log "  ${label}: unsupported URL scheme, skipping (${url%%:*}://...)" ;;
+    esac
+}
+
+# ── Rotation ──────────────────────────────────────────────────────────────
+#
+# Strategy: every backup is "daily" by default. On Sundays we also mark it
+# "weekly" by writing a sibling marker file ``*.weekly``. Pruning then:
+# - delete daily older than RETENTION_DAILY days that have NO .weekly marker
+# - delete weekly older than (RETENTION_WEEKLY * 7) days
+#
+# Implemented in pure ``find`` so it works in busybox / minimal images.
+
+_mark_weekly() {
+    if [[ "$DOW" == "7" ]]; then
+        for f in "$BACKUP_DIR"/*"${TS}".sql.gz "$BACKUP_DIR"/*"${TS}".sqlite.gz; do
+            [[ -f "$f" ]] && touch "${f}.weekly"
+        done
+        _log "Marked today's backups as weekly (Sunday)"
+    fi
+}
+
+_rotate() {
+    # Daily: older than RETENTION_DAILY without .weekly companion.
+    find "$BACKUP_DIR" -maxdepth 1 -type f \
+        \( -name '*.sql.gz' -o -name '*.sqlite.gz' \) \
+        -mtime "+${RETENTION_DAILY}" \
+        | while read -r f; do
+            if [[ ! -e "${f}.weekly" ]]; then
+                _log "Rotating daily: ${f}"
+                rm -f "$f" "${f}.sha256"
+            fi
+        done
+
+    # Weekly: older than RETENTION_WEEKLY*7 days.
+    local weekly_age=$((RETENTION_WEEKLY * 7))
+    find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.weekly' \
+        -mtime "+${weekly_age}" \
+        | while read -r marker; do
+            local data="${marker%.weekly}"
+            _log "Rotating weekly: ${data}"
+            rm -f "$data" "${data}.sha256" "$marker"
+        done
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+_log "Starting backup at ${TS}"
+_dump_any "${DATABASE_URL:-}"    "target"
+_dump_any "${MONITOR_DB_URL:-}"  "metrics"
+_mark_weekly
+_rotate
+_log "Done."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Restore from a backup created by ``scripts/backup.sh`` (#106).
+#
+# Usage
+# -----
+#   scripts/restore.sh backups/target-monitor-20260530-031500.sql.gz
+#
+# What it does
+# ------------
+# 1. Verifies the SHA-256 sidecar (``<file>.sha256``) — refuses to restore
+#    if the dump has bit-rotted on disk or in transit.
+# 2. Detects format by extension: .sql.gz → ``psql``, .sqlite.gz → copy.
+# 3. For Postgres restores: prompts for the target DSN (or reads RESTORE_URL
+#    env). DROP + CREATE DATABASE is intentionally NOT performed — operator
+#    decides whether to wipe; we just stream the dump into whatever DSN is
+#    given. This avoids accidentally nuking the live DB by typo.
+# 4. For SQLite: writes to a new file alongside the backup unless
+#    RESTORE_PATH is set. Live monitor.db is never overwritten silently.
+#
+# Exit codes: 0 ok, 1 file/checksum problem, 2 restore failure.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <backup-file> [RESTORE_URL=postgresql://...]" >&2
+    exit 1
+fi
+
+BACKUP="$1"
+
+# ── Checksum verification ────────────────────────────────────────────────
+
+if [[ ! -f "$BACKUP" ]]; then
+    echo "FATAL: backup file not found: $BACKUP" >&2
+    exit 1
+fi
+if [[ ! -f "${BACKUP}.sha256" ]]; then
+    echo "FATAL: missing sidecar ${BACKUP}.sha256 — refusing to trust dump" >&2
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$BACKUP" | awk '{print $1}')"
+else
+    actual="$(shasum -a 256 "$BACKUP" | awk '{print $1}')"
+fi
+expected="$(awk '{print $1}' "${BACKUP}.sha256")"
+
+if [[ "$actual" != "$expected" ]]; then
+    echo "FATAL: sha256 mismatch" >&2
+    echo "  expected: $expected" >&2
+    echo "  actual:   $actual" >&2
+    echo "Dump is corrupt — try the previous backup." >&2
+    exit 1
+fi
+echo "[restore] sha256 verified: $expected"
+
+# ── Dispatch by format ───────────────────────────────────────────────────
+
+case "$BACKUP" in
+    *.sql.gz)
+        if [[ -z "${RESTORE_URL:-}" ]]; then
+            echo "FATAL: set RESTORE_URL=postgresql://... to point the restore" >&2
+            echo "       (we won't guess to avoid clobbering the live DB)" >&2
+            exit 1
+        fi
+        echo "[restore] streaming dump into $RESTORE_URL"
+        gunzip -c "$BACKUP" | psql "$RESTORE_URL"
+        echo "[restore] done."
+        ;;
+    *.sqlite.gz)
+        RESTORE_PATH="${RESTORE_PATH:-${BACKUP%.sqlite.gz}.restored.sqlite}"
+        if [[ -e "$RESTORE_PATH" ]]; then
+            echo "FATAL: $RESTORE_PATH already exists, refusing to overwrite" >&2
+            exit 1
+        fi
+        echo "[restore] decompressing to $RESTORE_PATH"
+        gunzip -c "$BACKUP" > "$RESTORE_PATH"
+        echo "[restore] sqlite3 integrity_check:"
+        sqlite3 "$RESTORE_PATH" "PRAGMA integrity_check;" | head -5
+        echo "[restore] done. To use:  cp $RESTORE_PATH monitor.db  (after stopping the app)"
+        ;;
+    *)
+        echo "FATAL: unrecognised backup format: $BACKUP" >&2
+        echo "       expected .sql.gz (Postgres) or .sqlite.gz (SQLite)" >&2
+        exit 2
+        ;;
+esac

--- a/templates/admin/rollback_checklist.html
+++ b/templates/admin/rollback_checklist.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% block title %}Rollback checklist — DB Monitor{% endblock %}
+{% block breadcrumb %}
+  <span class="font-medium text-slate-700 dark:text-slate-200">Rollback checklist</span>
+{% endblock %}
+
+{% block content %}
+  <div class="mx-auto max-w-3xl space-y-6">
+    <header>
+      <h1 class="text-2xl font-semibold tracking-tight">Rollback checklist</h1>
+      <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+        Прод горит после релиза. Иди по шагам сверху вниз. Полная версия — в
+        <a href="https://github.com/aleksandr-novikov/db-monitoring/blob/master/docs/runbooks/rollback.md"
+           class="text-accent hover:underline">docs/runbooks/rollback.md</a>.
+        Дочитай за 5 минут, откатись за 10.
+      </p>
+    </header>
+
+    {% set steps = [
+      ("1. Подтвердить инцидент",
+       "curl -sf http://&lt;prod&gt;/healthz?strict=true",
+       "503 → шаг 2.  200 OK + version совпадает с релизом → проблема НЕ в коде."),
+      ("2. Идентифицировать виновную фичу",
+       "docker compose logs --tail=200 app  |  Sentry → последние 15 мин",
+       "Связать симптом с фичей. Непонятно — сразу к шагу 4."),
+      ("3. Попробовать feature flag",
+       "FF_NAME=false; docker compose restart app",
+       "Какие фичи под флагами — /admin/feature-flags. Самый дешёвый откат."),
+      ("4. Откат на :previous образ",
+       "docker pull ghcr.io/aleksandr-novikov/db-monitoring:previous  &&  docker compose up -d app",
+       "После — curl /healthz и сравнить .version с предыдущим релизом."),
+      ("5. Восстановление из бэкапа (только если данные битые)",
+       "scripts/restore.sh backups/target-monitor-&lt;timestamp&gt;.sql.gz",
+       "Только при подтверждённой data corruption. Шаги в docs/runbooks/backup.md.")
+    ] %}
+
+    {% for title, cmd, note in steps %}
+      <article class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <label class="flex cursor-pointer items-start gap-3">
+          <input type="checkbox" class="mt-1 h-5 w-5 rounded border-slate-300 text-accent focus:ring-accent dark:border-slate-700 dark:bg-slate-950">
+          <div class="flex-1">
+            <h2 class="text-base font-medium">{{ title }}</h2>
+            <pre class="mt-2 overflow-x-auto rounded bg-slate-100 px-3 py-2 text-xs text-slate-700 dark:bg-slate-950 dark:text-slate-200"><code>{{ cmd|safe }}</code></pre>
+            <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">{{ note|safe }}</p>
+          </div>
+        </label>
+      </article>
+    {% endfor %}
+
+    <article class="rounded-xl border border-emerald-200 bg-emerald-50 p-5 dark:border-emerald-900/50 dark:bg-emerald-950/30">
+      <h2 class="text-base font-medium text-emerald-800 dark:text-emerald-200">6. Подтвердить отбой</h2>
+      <ul class="mt-3 space-y-2 text-sm text-emerald-700 dark:text-emerald-300">
+        <li>✅ <code>curl /healthz?strict=true</code> → 200</li>
+        <li>✅ Sentry: новые errors прекратились (15 мин)</li>
+        <li>✅ Prometheus: <code>http_requests_total{status=~"5.."}</code> перестала расти</li>
+        <li>📝 Postmortem: что было, почему фичи нет под feature flag (если должна быть)</li>
+      </ul>
+    </article>
+  </div>
+{% endblock %}

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,208 @@
+"""Backup + restore smoke tests (#106).
+
+End-to-end: seed a SQLite DB → backup.sh produces a dump + sidecar →
+restore.sh validates the sidecar and reproduces the same data. Covers the
+acceptance criterion "backup → restore on a clean DB → SELECT count(*)
+matches" without needing a real Postgres in CI.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKUP_SH = REPO_ROOT / "scripts" / "backup.sh"
+RESTORE_SH = REPO_ROOT / "scripts" / "restore.sh"
+
+
+def _seed_sqlite(path: Path, *, n_users: int = 5) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(
+        "CREATE TABLE users(id INT PRIMARY KEY, email TEXT);\n"
+        + "\n".join(
+            f"INSERT INTO users VALUES({i}, 'u{i}@example.com');"
+            for i in range(1, n_users + 1)
+        )
+    )
+    con.commit()
+    con.close()
+
+
+def _run(cmd: list[str], **env_extra: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env.update(env_extra)
+    return subprocess.run(
+        cmd, env=env, capture_output=True, text=True, check=False,
+    )
+
+
+# ── Backup ─────────────────────────────────────────────────────────────────
+
+
+def test_backup_sqlite_produces_dump_and_sha(tmp_path):
+    """backup.sh writes <prefix>.sqlite.gz + .sha256 sidecar."""
+    src = tmp_path / "monitor.db"
+    _seed_sqlite(src, n_users=3)
+    backup_dir = tmp_path / "bkup"
+
+    proc = _run(
+        ["bash", str(BACKUP_SH)],
+        DATABASE_URL="",
+        MONITOR_DB_URL=f"sqlite:///{src}",
+        BACKUP_DIR=str(backup_dir),
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    dumps = list(backup_dir.glob("metrics-*.sqlite.gz"))
+    sha = list(backup_dir.glob("metrics-*.sqlite.gz.sha256"))
+    assert len(dumps) == 1, f"expected one dump, got {dumps}"
+    assert len(sha) == 1
+    # Sidecar has 64-char hex sha256.
+    sha_value = sha[0].read_text().split()[0]
+    assert len(sha_value) == 64
+    assert all(c in "0123456789abcdef" for c in sha_value)
+
+
+def test_backup_skips_when_url_is_empty(tmp_path):
+    """Empty DATABASE_URL / MONITOR_DB_URL → script exits cleanly without
+    producing files. Operators set only one of the two when running ad-hoc."""
+    backup_dir = tmp_path / "bkup"
+    proc = _run(
+        ["bash", str(BACKUP_SH)],
+        DATABASE_URL="",
+        MONITOR_DB_URL="",
+        BACKUP_DIR=str(backup_dir),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert list(backup_dir.glob("*.gz")) == []
+
+
+# ── Restore ────────────────────────────────────────────────────────────────
+
+
+def test_restore_round_trip_sqlite(tmp_path):
+    """Acceptance: SELECT count(*) FROM users after restore must match."""
+    src = tmp_path / "monitor.db"
+    _seed_sqlite(src, n_users=42)
+    backup_dir = tmp_path / "bkup"
+
+    _run(
+        ["bash", str(BACKUP_SH)],
+        DATABASE_URL="",
+        MONITOR_DB_URL=f"sqlite:///{src}",
+        BACKUP_DIR=str(backup_dir),
+    )
+    dump = next(backup_dir.glob("metrics-*.sqlite.gz"))
+
+    restored = tmp_path / "restored.db"
+    proc = _run(
+        ["bash", str(RESTORE_SH), str(dump)],
+        RESTORE_PATH=str(restored),
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    con = sqlite3.connect(restored)
+    n = con.execute("SELECT count(*) FROM users").fetchone()[0]
+    con.close()
+    assert n == 42
+
+
+def test_restore_refuses_corrupted_dump(tmp_path):
+    """Tamper with the dump bytes → sha256 mismatch → exit 1, no restore."""
+    src = tmp_path / "monitor.db"
+    _seed_sqlite(src)
+    backup_dir = tmp_path / "bkup"
+
+    _run(
+        ["bash", str(BACKUP_SH)],
+        DATABASE_URL="",
+        MONITOR_DB_URL=f"sqlite:///{src}",
+        BACKUP_DIR=str(backup_dir),
+    )
+    dump = next(backup_dir.glob("metrics-*.sqlite.gz"))
+
+    # Flip one byte in the middle of the gzipped dump.
+    data = bytearray(dump.read_bytes())
+    data[len(data) // 2] ^= 0xFF
+    dump.write_bytes(data)
+
+    proc = _run(
+        ["bash", str(RESTORE_SH), str(dump)],
+        RESTORE_PATH=str(tmp_path / "should-not-exist.db"),
+    )
+    assert proc.returncode == 1
+    assert "sha256 mismatch" in proc.stderr
+    assert not (tmp_path / "should-not-exist.db").exists()
+
+
+def test_restore_refuses_missing_sidecar(tmp_path):
+    """Sidecar removed → cannot verify integrity → refuse."""
+    src = tmp_path / "monitor.db"
+    _seed_sqlite(src)
+    backup_dir = tmp_path / "bkup"
+
+    _run(
+        ["bash", str(BACKUP_SH)],
+        DATABASE_URL="",
+        MONITOR_DB_URL=f"sqlite:///{src}",
+        BACKUP_DIR=str(backup_dir),
+    )
+    dump = next(backup_dir.glob("metrics-*.sqlite.gz"))
+    sidecar = backup_dir / f"{dump.name}.sha256"
+    sidecar.unlink()
+
+    proc = _run(["bash", str(RESTORE_SH), str(dump)])
+    assert proc.returncode == 1
+    assert "missing sidecar" in proc.stderr
+
+
+# ── /admin/rollback-checklist (#107) ───────────────────────────────────────
+
+
+@pytest.fixture
+def admin_client(tmp_path, monkeypatch):
+    import app.metrics_storage as storage
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "admin.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    app = create_app({"TESTING": True})
+    return app.test_client()
+
+
+def test_rollback_checklist_renders(admin_client):
+    """Page renders with each step + a final "confirm all-clear" section."""
+    resp = admin_client.get("/admin/rollback-checklist")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # Every step heading is present.
+    for marker in [
+        "1. Подтвердить инцидент",
+        "2. Идентифицировать виновную фичу",
+        "3. Попробовать feature flag",
+        "4. Откат на :previous образ",
+        "5. Восстановление из бэкапа",
+        "6. Подтвердить отбой",
+    ]:
+        assert marker in body, f"missing step: {marker}"
+    # Link to the full runbook is present (operators may want the full text).
+    assert "docs/runbooks/rollback.md" in body
+
+
+# Skip backup tests on Windows-ish CI (just-in-case future portability check).
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="backup scripts require bash"
+)


### PR DESCRIPTION
Закрывает оба тикета из Sprint 4 production-readiness одним PR — runbooks и инфраструктура backup/restore связаны логически (rollback runbook ссылается на restore.sh).

## #106 — Backup runbook + автоматический pg_dump

### `scripts/backup.sh`
- pg_dump для Postgres URL-ов + `sqlite3 .backup` для SQLite
- Имя файла `target-<dbname>-YYYYMMDD-HHMMSS.sql.gz` (или `metrics-...sqlite.gz`)
- `.sha256` sidecar рядом с каждым дампом
- Пустые `DATABASE_URL` / `MONITOR_DB_URL` silently пропускаются

### Ротация
**7 daily + 4 weekly**. Воскресные бэкапы маркируются `.weekly` файлом и живут дольше. `RETENTION_DAILY` / `RETENTION_WEEKLY` env для кастомизации.

### `scripts/restore.sh`
- Отказывается работать без валидного sha256 (защита от bit-rot)
- Postgres путь требует `RESTORE_URL` чтобы случайно не сбросить prod
- SQLite путь отказывается перезаписывать существующий файл

### Cron (docker-compose)
Новый сервис `backup` под профилем `backup`: `postgres:18` + apt-install `sqlite3` + bash-while-loop с sleep до **03:15 UTC**, потом цикл по 24h. Crond избыточен для одной задачи. `make backup-cron-up` / `-down`.

### `docs/runbooks/backup.md`
Где лежат бэкапы, команды backup/restore, ротация, **RPO 24h / RTO < 5 мин**, quarterly verification checklist.

## #107 — Rollback runbook

### `docs/runbooks/rollback.md`
5-шаговый алгоритм с **Mermaid decision-tree** наверху. Каждый шаг — копи-пастабельная команда + что проверить. Ссылки на /healthz, /admin/feature-flags, backup runbook, Docker tags секцию README.

### `/admin/rollback-checklist` (новый route)
Статичная страница для оператора в момент инцидента: 5 шагов с чекбоксами + финальная зелёная карточка «подтвердить отбой». На базе `base.html`.

## README

Новый раздел **«Операционные процедуры (runbooks)»** между Sentry и Релизами:
- Ссылки на backup.md, rollback.md, /admin/rollback-checklist
- Quick reference для make backup / restore / backup-cron-up

TOC обновлён.

## Acceptance

### #106
- [x] `scripts/backup.sh` (pg_dump + sqlite3)
- [x] Имя `backups/<dbname>-YYYYMMDD-HHMMSS.sql.gz`
- [x] Ротация 7 daily + 4 weekly
- [x] Cron в docker-compose (профиль backup)
- [x] `scripts/restore.sh <file>` с sha256 проверкой
- [x] `docs/runbooks/backup.md`: где лежат / команды / RPO / RTO
- [x] **Smoke-тест**: backup → restore на чистой БД → `SELECT count(*) FROM users` совпадает

### #107
- [x] `docs/runbooks/rollback.md` с 5 шагами
- [x] Mermaid decision-tree
- [x] `/admin/rollback-checklist` статичная страница
- [ ] Dry-run прогон по одному пункту в день — это **manual** активность, не автоматизируется

## Тесты (6 новых, `tests/test_backup_restore.py`)

End-to-end на SQLite чтобы не зависеть от Postgres в CI:
- `backup.sh` пишет dump + sidecar; sha256 — 64 hex chars
- `backup.sh` с пустыми URL — exits 0, файлов не создаёт
- **Round-trip**: seed→backup→restore→`SELECT count(*)` совпадает (acceptance из тикета)
- **Tampered dump** (flip byte) → `restore.sh` exit 1 + "sha256 mismatch", ничего не восстанавливается
- **Missing sidecar** → `restore.sh` exit 1 + "missing sidecar"
- `/admin/rollback-checklist` рендерит все 5 шагов + ссылку на runbook

## Manual smoke

Прогнал на локальном `/tmp/smoke.db` с 3 users:

```bash
$ DATABASE_URL='' MONITOR_DB_URL='sqlite:////tmp/smoke.db' BACKUP_DIR=/tmp/bkup scripts/backup.sh
$ RESTORE_PATH=/tmp/smoke-restored.db scripts/restore.sh /tmp/bkup/metrics-*.sqlite.gz
$ sqlite3 /tmp/smoke-restored.db "SELECT count(*) FROM users;"
3
```

## Verification

- **625 passed** (+6 новых)
- ruff clean
- `docker-compose.yml` parses
- Live SQLite round-trip ok

## Test plan

- [x] Юнит/integration на backup + restore
- [x] Tampering / missing sidecar — refuse to restore
- [x] `/admin/rollback-checklist` renders
- [x] Manual SQLite round-trip
- [ ] Live cron сервис: `make backup-cron-up` → ждать 24h → проверить что бэкап появился (manual, после merge)