### PR TITLE
feat(#178): подготовить Iceberg Lakehouse demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT_ID    ?= legacy
 CONNECTION_ID ?=
 DEMO_PROJECT_SLUG ?= retail-postgres
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg demo-ids clickhouse-up clickhouse-down seed-clickhouse backup restore backup-cron-up backup-cron-down
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg iceberg-demo demo-ids clickhouse-up clickhouse-down seed-clickhouse backup restore backup-cron-up backup-cron-down
 
 build:
 	docker build -t $(IMAGE) .
@@ -119,12 +119,23 @@ iceberg-up:
 	@echo "Iceberg REST: http://localhost:8181"
 
 iceberg-down:
-	docker compose --profile iceberg down
+	docker compose --profile iceberg stop iceberg-rest minio
+	docker compose --profile iceberg rm -f iceberg-rest minio
 
 smoke-iceberg: ## Run live smoke test against local Iceberg REST + MinIO (requires make iceberg-up)
 	@curl -sf http://localhost:8181/v1/config >/dev/null 2>&1 || \
 		(echo "Iceberg REST не запущен. Сначала выполни: make iceberg-up" && exit 1)
 	python -m scripts.smoke_iceberg
+
+iceberg-demo: ## Prepare full Iceberg Lakehouse demo path (#178)
+	@curl -sf http://localhost:8181/v1/config >/dev/null 2>&1 || \
+		(echo "Iceberg REST не запущен. Сначала выполни: make iceberg-up" && exit 1)
+	@set -e; \
+		echo "Stopping app scheduler while Iceberg demo history is prepared..."; \
+		docker compose stop app >/dev/null; \
+		trap 'echo "Starting app with refreshed scheduler..."; docker compose up -d --build app >/dev/null' EXIT; \
+		python -m scripts.prepare_iceberg_demo; \
+		echo "Iceberg demo is ready: http://localhost:5001/dashboard/"
 
 # ── ClickHouse demo target (#141) ────────────────────────────────────
 clickhouse-up:

--- a/app/api.py
+++ b/app/api.py
@@ -52,6 +52,13 @@ _NOTIFICATION_STATUSES = {"sent", "failed"}
 _MAX_NOTIFICATIONS_LIMIT = 200
 
 
+def _has_project_table_metrics(table_name: str, project_id: str) -> bool:
+    """Return true when the current project has monitored data for a table."""
+    if get_latest_metric(table_name, "row_count", project_id):
+        return True
+    return bool(get_anomaly_scores(table_name, project_id=project_id, window=_RANGES["14d"]))
+
+
 @api.route("/tables")
 def tables():
     """List monitored tables with their latest collected metrics.
@@ -235,11 +242,11 @@ def explain():
     if cached:
         return jsonify(cached)
 
-    known_tables = {t["table_name"] for t in list_tables()}
-    if table not in known_tables:
+    project_id = _current_project_id()
+    if not _has_project_table_metrics(table, project_id):
         return jsonify({"error": "table not found"}), 404
 
-    result = explain_anomaly(table, metric, ts, project_id=_current_project_id())
+    result = explain_anomaly(table, metric, ts, project_id=project_id)
     save_explanation(
         table=table,
         metric=metric,

--- a/app/app.py
+++ b/app/app.py
@@ -33,6 +33,22 @@ def _fmt_iso_in_text(text: str) -> str:
     return _ISO_TS_RE.sub(lambda m: m.group()[:16].replace("T", " ") + " UTC", text)
 
 
+def _fmt_interval_minutes(minutes: int | str | None) -> str:
+    """Human-readable collection interval for connection cards."""
+    try:
+        value = int(minutes)
+    except (TypeError, ValueError):
+        return "интервал не задан"
+    if value == 1440:
+        return "раз в сутки"
+    if value == 60:
+        return "каждый час"
+    if value % 60 == 0:
+        hours = value // 60
+        return f"каждые {hours} ч"
+    return f"каждые {value} мин"
+
+
 _logging_filter_installed = False
 
 
@@ -89,6 +105,7 @@ def create_app(config: dict | None = None):
     app.config.setdefault("SESSION_COOKIE_HTTPONLY", True)
     app.jinja_env.filters["status_class"] = status_class
     app.jinja_env.filters["fmt_iso_in_text"] = _fmt_iso_in_text
+    app.jinja_env.filters["fmt_interval_minutes"] = _fmt_interval_minutes
 
     if config:
         app.config.update(config)

--- a/app/crypto.py
+++ b/app/crypto.py
@@ -29,6 +29,7 @@ from cryptography.fernet import Fernet, InvalidToken
 logger = logging.getLogger(__name__)
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+_ENV = _REPO_ROOT / ".env"
 _ENV_LOCAL = _REPO_ROOT / ".env.local"
 
 _fernet: Fernet | None = None
@@ -57,6 +58,11 @@ def _load_key() -> bytes:
             "throwaway key. See .env.example."
         )
 
+    existing = _load_key_from_dotenv(_ENV) or _load_key_from_dotenv(_ENV_LOCAL)
+    if existing:
+        os.environ["FERNET_KEY"] = existing.decode("ascii")
+        return existing
+
     # Dev fallback: generate, persist, warn.
     new_key = Fernet.generate_key()
     try:
@@ -78,6 +84,29 @@ def _load_key() -> bytes:
     # Propagate to the current process so the next caller sees it via env.
     os.environ["FERNET_KEY"] = new_key.decode()
     return new_key
+
+
+def _load_key_from_dotenv(path: Path) -> bytes | None:
+    """Return the last FERNET_KEY from a dotenv file, if present.
+
+    Local CLI scripts should use the same key as docker-compose (`.env`)
+    before falling back to `.env.local`; otherwise they can re-encrypt DSNs
+    with a key the app container does not know.
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for line in reversed(lines):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not stripped.startswith("FERNET_KEY="):
+            continue
+        value = stripped.split("=", 1)[1].strip().strip("\"'")
+        if value:
+            return value.encode("ascii")
+    return None
 
 
 def _get_fernet() -> Fernet:

--- a/docs/demo/SCENARIO_3_2.md
+++ b/docs/demo/SCENARIO_3_2.md
@@ -102,8 +102,8 @@ python -m scripts.seed_demo_workspace --reset-password \
 
 ### Ожидаемые ограничения до следующих задач
 
-- Iceberg connection может не проходить `Тест`, пока не подготовлены Iceberg
-  REST + MinIO или внешний Iceberg catalog. Это закрывается задачей `#178`.
+- Iceberg connection проходит `Тест` только после подготовки Iceberg REST +
+  MinIO и demo tables через `make iceberg-up` + `make iceberg-demo`.
 - Shared project между двумя пользователями не показываем как готовую функцию,
   пока не закрыта задача `#172`.
 - Telegram alerts показываем только после проверки env vars и live demo path.
@@ -285,17 +285,50 @@ docker compose exec app python -m scripts.live_demo \
 
 ### Iceberg Lakehouse
 
-Показывает lakehouse-сценарий.
+Показывает lakehouse-сценарий на уровне полноценного demo path, а не только
+smoke-test.
 
 Что показываем:
 
 - Iceberg REST + MinIO;
 - Iceberg connection;
-- таблицу Iceberg;
-- schema и null counts из metadata/manifest.
+- несколько Iceberg tables: `events`, `orders`, `customers`, `sessions`;
+- schema и null counts из metadata/manifest;
+- 14-дневную lakehouse history в monitoring DB;
+- NULL-rate incident по `events.device_id`;
+- anomaly/changepoint на графике.
 
-Важно: `make smoke-iceberg` уже проверяет adapter и collector path. Для
-полноценного UI demo нужно подготовить отдельный demo project и connection.
+Важно: live connection/schema/table metadata читаются из реального локального
+Iceberg catalog. Исторические метрики за 14 дней seed-ятся в monitoring DB для
+воспроизводимого демо, чтобы не ждать две недели реальных collector runs.
+
+Подготовка локально:
+
+```bash
+make iceberg-up
+make iceberg-demo
+```
+
+`make iceberg-demo` — единый pipeline подготовки Iceberg demo:
+
+- временно останавливает `app`, чтобы scheduler не перетёр synthetic history
+  маленьким live snapshot на 4-5 строк;
+- создаёт/reuse Iceberg namespace `lakehouse` и 4 таблицы;
+- проверяет live collector path;
+- seed-ит 14 дней lakehouse metrics в monitoring DB;
+- ставит connection interval `1440` минут;
+- прогревает ML/changepoint/forecast/drift;
+- поднимает `app` обратно с обновлённым scheduler;
+- печатает URL, login, `PROJECT_ID` и `CONNECTION_ID`.
+
+Скрипт использует `localhost` для подготовки Iceberg catalog с host-машины, но
+в connection проекта сохраняет Docker-internal DSN (`iceberg-rest:8181`,
+`minio:9000`), потому что браузерный UI работает через контейнер `app`.
+Connection остаётся активным: кнопка `Тест` и live schema работают, а для
+демо-показа latest metrics остаются synthetic lakehouse history.
+
+`make smoke-iceberg` — опциональная диагностика adapter/catalog path. Для
+показа главным readiness-критерием считаем именно успешный `make iceberg-demo`.
 
 ## Тайминг
 
@@ -586,19 +619,30 @@ project.
 
 Показать:
 
-- Iceberg connection;
-- schema/table detail;
-- null counts.
+- `Подключения`: `Local Iceberg REST`, schema `lakehouse`, DSN замаскирован,
+  кнопка `Тест` возвращает success;
+- `Обзор`: несколько lakehouse-таблиц и большие row counts;
+- `Схема`: `events`, `orders`, `customers`, `sessions`;
+- table detail `events`;
+- график за 14 дней;
+- переключение на `NULL rate`;
+- anomaly/changepoint по росту NULL в `device_id`;
+- `История`: не пустая, видны проверки/сигналы по Iceberg project.
 
 Что сказать:
 
 > Iceberg-путь показывает lakehouse-сценарий. Для таких таблиц мы читаем
-> метаданные и manifest-информацию, не делая полный скан данных.
+> live schema и текущие metadata из Iceberg catalog/manifest, не делая полный
+> скан данных. История за 14 дней подготовлена как demo history в monitoring DB,
+> чтобы сценарий был воспроизводимым на локальном стенде.
 
 Ожидаемый результат:
 
-- Iceberg table видна в UI;
-- row count и null counts заполнены.
+- Iceberg tables видны в UI;
+- row count, size, last check и null counts заполнены;
+- `events.device_id` показывает понятный NULL-rate incident;
+- реальные Telegram alerts по Iceberg не проверяем здесь, они вынесены в
+  `#182`.
 
 ### 12. Operational signals
 

--- a/scripts/prepare_iceberg_demo.py
+++ b/scripts/prepare_iceberg_demo.py
@@ -1,0 +1,581 @@
+"""Prepare the Demo 3.2 Iceberg Lakehouse path.
+
+The script keeps two concerns deliberately separate:
+
+* live Iceberg catalog state: real namespace/tables in local REST + MinIO;
+* dashboard history: synthetic 14-day metrics in the monitoring DB.
+
+This gives a repeatable demo without pretending that 14 days passed in the
+local Iceberg catalog.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlencode
+
+from sqlalchemy import text
+
+from app import crypto
+from app.metrics_storage import (
+    get_engine as get_monitor_engine,
+    save_metrics,
+    save_schema_events,
+)
+from collectors.per_project import collect_for_connection
+from scripts.seed_demo_workspace import seed_demo_workspace
+
+logger = logging.getLogger(__name__)
+
+BUCKET = "iceberg-smoke"
+WAREHOUSE = f"s3://{BUCKET}/warehouse"
+NAMESPACE = "lakehouse"
+REST_HOST = "localhost:8181"
+MINIO_ENDPOINT = "http://localhost:9000"
+MINIO_USER = "minioadmin"
+MINIO_PASSWORD = "minioadmin"
+
+
+def default_iceberg_dsn() -> str:
+    return _iceberg_dsn(REST_HOST, MINIO_ENDPOINT)
+
+
+def default_app_iceberg_dsn() -> str:
+    return _iceberg_dsn("iceberg-rest:8181", "http://minio:9000")
+
+
+def _iceberg_dsn(rest_host: str, minio_endpoint: str) -> str:
+    params = urlencode({
+        "warehouse": WAREHOUSE,
+        "s3.endpoint": minio_endpoint,
+        "s3.access-key-id": MINIO_USER,
+        "s3.secret-access-key": MINIO_PASSWORD,
+        "s3.path-style-access": "true",
+    })
+    return f"iceberg+rest://{rest_host}?{params}"
+
+
+@dataclass(frozen=True)
+class DemoColumn:
+    name: str
+    iceberg_type: object
+    arrow_type: object
+    nullable: bool
+    null_rate: float
+
+
+@dataclass(frozen=True)
+class DemoTable:
+    name: str
+    row_count: int
+    size_bytes: int
+    columns: tuple[DemoColumn, ...]
+    rows: dict[str, list]
+
+
+def _table_specs() -> list[DemoTable]:
+    import pyarrow as pa
+    from pyiceberg.types import DoubleType, IntegerType, LongType, StringType
+
+    return [
+        DemoTable(
+            name="events",
+            row_count=4_250_000,
+            size_bytes=1_740_800_000,
+            columns=(
+                DemoColumn("event_id", StringType(), pa.string(), False, 0.0),
+                DemoColumn("device_id", StringType(), pa.string(), True, 0.16),
+                DemoColumn("ip_address", StringType(), pa.string(), True, 0.11),
+                DemoColumn("event_type", StringType(), pa.string(), False, 0.0),
+                DemoColumn("value", DoubleType(), pa.float64(), True, 0.03),
+            ),
+            rows={
+                "event_id": ["evt-001", "evt-002", "evt-003", "evt-004", "evt-005"],
+                "device_id": ["ios-1", None, "web-3", None, "android-5"],
+                "ip_address": ["10.0.0.1", None, "10.0.0.3", "10.0.0.4", None],
+                "event_type": ["checkout", "view", "click", "view", "purchase"],
+                "value": [12.0, None, 3.5, 9.1, 42.0],
+            },
+        ),
+        DemoTable(
+            name="orders",
+            row_count=620_000,
+            size_bytes=308_400_000,
+            columns=(
+                DemoColumn("order_id", StringType(), pa.string(), False, 0.0),
+                DemoColumn("customer_id", StringType(), pa.string(), False, 0.0),
+                DemoColumn("status", StringType(), pa.string(), True, 0.02),
+                DemoColumn("amount", DoubleType(), pa.float64(), True, 0.01),
+            ),
+            rows={
+                "order_id": ["ord-001", "ord-002", "ord-003", "ord-004"],
+                "customer_id": ["cus-001", "cus-002", "cus-003", "cus-004"],
+                "status": ["paid", "paid", None, "refunded"],
+                "amount": [120.0, 75.5, 210.0, None],
+            },
+        ),
+        DemoTable(
+            name="customers",
+            row_count=96_000,
+            size_bytes=84_800_000,
+            columns=(
+                DemoColumn("customer_id", StringType(), pa.string(), False, 0.0),
+                DemoColumn("email", StringType(), pa.string(), True, 0.04),
+                DemoColumn("segment", StringType(), pa.string(), True, 0.02),
+                DemoColumn("lifetime_value", DoubleType(), pa.float64(), True, 0.01),
+            ),
+            rows={
+                "customer_id": ["cus-001", "cus-002", "cus-003", "cus-004"],
+                "email": ["a@example.com", None, "c@example.com", "d@example.com"],
+                "segment": ["retail", "vip", None, "retail"],
+                "lifetime_value": [1500.0, 4200.0, None, 230.0],
+            },
+        ),
+        DemoTable(
+            name="sessions",
+            row_count=1_380_000,
+            size_bytes=512_900_000,
+            columns=(
+                DemoColumn("session_id", StringType(), pa.string(), False, 0.0),
+                DemoColumn("user_id", StringType(), pa.string(), True, 0.06),
+                DemoColumn("source", StringType(), pa.string(), True, 0.03),
+                DemoColumn("duration_sec", IntegerType(), pa.int32(), True, 0.02),
+            ),
+            rows={
+                "session_id": ["ses-001", "ses-002", "ses-003", "ses-004"],
+                "user_id": ["usr-1", None, "usr-3", "usr-4"],
+                "source": ["mobile", "web", None, "partner"],
+                "duration_sec": [35, 280, None, 42],
+            },
+        ),
+    ]
+
+
+def _catalog():
+    from pyiceberg.catalog.rest import RestCatalog
+
+    return RestCatalog(
+        "rest",
+        uri=f"http://{REST_HOST}",
+        warehouse=WAREHOUSE,
+        **{
+            "s3.endpoint": MINIO_ENDPOINT,
+            "s3.access-key-id": MINIO_USER,
+            "s3.secret-access-key": MINIO_PASSWORD,
+            "s3.path-style-access": "true",
+        },
+    )
+
+
+def _ensure_bucket() -> None:
+    import boto3
+    from botocore.exceptions import ClientError
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=MINIO_ENDPOINT,
+        aws_access_key_id=MINIO_USER,
+        aws_secret_access_key=MINIO_PASSWORD,
+        region_name="us-east-1",
+    )
+    try:
+        s3.create_bucket(Bucket=BUCKET)
+        print(f"  bucket {BUCKET!r} created")
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        if code in {"BucketAlreadyOwnedByYou", "BucketAlreadyExists"}:
+            print(f"  bucket {BUCKET!r} already exists")
+            return
+        raise
+
+
+def _ensure_namespace(catalog) -> None:
+    from pyiceberg.exceptions import NoSuchNamespaceError
+
+    try:
+        catalog.load_namespace_properties(NAMESPACE)
+        print(f"  namespace {NAMESPACE!r} already exists")
+    except NoSuchNamespaceError:
+        catalog.create_namespace(NAMESPACE)
+        print(f"  namespace {NAMESPACE!r} created")
+
+
+def _table_exists(catalog, table_name: str) -> bool:
+    from pyiceberg.exceptions import NoSuchTableError
+
+    try:
+        catalog.load_table((NAMESPACE, table_name))
+        return True
+    except NoSuchTableError:
+        return False
+
+
+def _create_table(catalog, spec: DemoTable) -> bool:
+    import pyarrow as pa
+    from pyiceberg.schema import Schema
+    from pyiceberg.types import NestedField
+
+    if _table_exists(catalog, spec.name):
+        print(f"  table {NAMESPACE}.{spec.name} already exists")
+        return False
+
+    fields = [
+        NestedField(i + 1, col.name, col.iceberg_type, required=not col.nullable)
+        for i, col in enumerate(spec.columns)
+    ]
+    for attempt in range(1, 6):
+        try:
+            catalog.create_table(
+                identifier=(NAMESPACE, spec.name),
+                schema=Schema(*fields),
+                location=f"{WAREHOUSE}/{NAMESPACE}/{spec.name}",
+                properties={"write.target-file-size-bytes": "536870912"},
+            )
+            break
+        except Exception:
+            if _table_exists(catalog, spec.name):
+                print(f"  table {NAMESPACE}.{spec.name} appeared after retry")
+                return False
+            if attempt == 5:
+                raise
+            time.sleep(float(attempt))
+    table = catalog.load_table((NAMESPACE, spec.name))
+    arrow_schema = pa.schema([
+        pa.field(col.name, col.arrow_type, nullable=col.nullable)
+        for col in spec.columns
+    ])
+    arrow_table = pa.table(
+        {
+            col.name: pa.array(spec.rows[col.name], type=col.arrow_type)
+            for col in spec.columns
+        },
+        schema=arrow_schema,
+    )
+    table.append(arrow_table)
+    print(f"  table {NAMESPACE}.{spec.name} created")
+    return True
+
+
+def ensure_iceberg_tables() -> dict:
+    print("[1/4] Iceberg catalog")
+    _ensure_bucket()
+    catalog = _catalog()
+    _ensure_namespace(catalog)
+    created = 0
+    for spec in _table_specs():
+        created += int(_create_table(catalog, spec))
+    return {"tables": len(_table_specs()), "created": created}
+
+
+def _get_demo_project_and_connection() -> tuple[str, str]:
+    result = seed_demo_workspace(
+        reset_password=True,
+        iceberg_dsn=default_iceberg_dsn(),
+    )
+    project = result["projects"]["iceberg-lakehouse"]
+    connection = result["connections"]["iceberg-lakehouse"]
+    _repair_iceberg_connection(project["id"], connection["id"], default_iceberg_dsn())
+    return project["id"], connection["id"]
+
+
+def _repair_iceberg_connection(
+    project_id: str,
+    connection_id: str,
+    desired_dsn: str,
+    *,
+    interval_minutes: int = 15,
+) -> None:
+    """Re-save the demo DSN when a local Fernet key changed.
+
+    `seed_demo_workspace` is intentionally idempotent and does not mutate an
+    existing connection. For demo preparation we need the stronger guarantee:
+    the Iceberg connection must be decryptable in the current environment.
+    """
+    needs_update = False
+
+    from app.metrics_storage import get_connection
+
+    conn = get_connection(project_id, connection_id)
+    if conn is None:
+        return
+    try:
+        current_dsn = crypto.decrypt_dsn(conn["dsn_encrypted"])
+        needs_update = current_dsn != desired_dsn or conn["schema_name"] != NAMESPACE
+    except crypto.InvalidToken:
+        needs_update = True
+
+    if not needs_update:
+        return
+
+    with get_monitor_engine().begin() as db_conn:
+        db_conn.execute(
+            text("""
+                UPDATE connections
+                SET dsn_encrypted = :dsn,
+                    schema_name = :schema,
+                    interval_minutes = :interval_minutes,
+                    is_active = 1
+                WHERE project_id = :project_id AND id = :connection_id
+            """),
+            {
+                "dsn": crypto.encrypt_dsn(desired_dsn),
+                "schema": NAMESPACE,
+                "interval_minutes": interval_minutes,
+                "project_id": project_id,
+                "connection_id": connection_id,
+            },
+        )
+    print("  Iceberg connection DSN re-saved for current Fernet key")
+
+
+def _purge_project_history(project_id: str, table_names: list[str]) -> int:
+    scoped_tables = (
+        "metrics", "notifications", "anomaly_scores", "changepoints",
+        "drift_reports",
+    )
+    deleted = 0
+    with get_monitor_engine().begin() as conn:
+        for table_name in scoped_tables:
+            result = conn.execute(
+                text(f"DELETE FROM {table_name} WHERE project_id = :pid"),
+                {"pid": project_id},
+            )
+            deleted += result.rowcount or 0
+        for table in table_names:
+            result = conn.execute(
+                text("DELETE FROM schema_events WHERE table_name = :table_name"),
+                {"table_name": table},
+            )
+            deleted += result.rowcount or 0
+    return deleted
+
+
+def _timestamps(days: int, interval_minutes: int) -> list[datetime]:
+    end = datetime.now(UTC).replace(second=0, microsecond=0)
+    step = timedelta(minutes=interval_minutes)
+    ticks = max(1, (days * 24 * 60) // interval_minutes)
+    return [end - step * (ticks - 1 - i) for i in range(ticks)]
+
+
+def _row_count(spec: DemoTable, progress: float) -> int:
+    base = spec.row_count * (0.58 + 0.28 * progress)
+    steps = {
+        "events": ((0.52, 680_000), (0.75, 720_000), (0.97, 910_000)),
+        "orders": ((0.54, 85_000), (0.76, 95_000), (0.97, 125_000)),
+        "customers": ((0.50, 12_000), (0.73, 18_000), (0.96, 21_000)),
+        "sessions": ((0.53, 210_000), (0.76, 240_000), (0.98, 320_000)),
+    }.get(spec.name, ())
+    base += sum(value for point, value in steps if progress >= point)
+    return min(spec.row_count, max(0, round(base)))
+
+
+def _null_rate(spec: DemoTable, col: DemoColumn, progress: float, tick_idx: int) -> float:
+    if spec.name == "events" and col.name == "device_id":
+        rate = 0.015 if progress < 0.50 else col.null_rate
+    else:
+        rate = col.null_rate
+    if spec.name == "events" and tick_idx == 68:
+        rate = min(1.0, rate + 0.18)
+    return rate
+
+
+def _distribution_rows(spec: DemoTable, days: int, end: datetime) -> list[dict]:
+    rows: list[dict] = []
+    for day in range(days):
+        ts = end - timedelta(days=days - 1 - day)
+        progress = day / (days - 1) if days > 1 else 1.0
+        for col in spec.columns:
+            if not col.nullable:
+                continue
+            drift = 1.0 if spec.name == "events" and col.name == "device_id" else 0.0
+            buckets = []
+            for i, label in enumerate(("ios", "android", "web", "partner", "unknown")):
+                baseline = (0.34, 0.28, 0.22, 0.12, 0.04)[i]
+                target = (0.12, 0.16, 0.20, 0.22, 0.30)[i]
+                weight = baseline + (target - baseline) * drift * progress
+                buckets.append({"value": label, "count": round(weight * 1000)})
+            rows.append({
+                "ts": ts,
+                "table_name": spec.name,
+                "metric_name": "column_distribution",
+                "value": float(sum(b["count"] for b in buckets)),
+                "tags": {
+                    "column": col.name,
+                    "data_type": "string",
+                    "buckets": buckets,
+                },
+            })
+    return rows
+
+
+def _metric_rows(spec: DemoTable, timestamps: list[datetime]) -> list[dict]:
+    rows: list[dict] = []
+    avg_row_size = spec.size_bytes / spec.row_count
+    for i, ts in enumerate(timestamps):
+        progress = i / (len(timestamps) - 1) if len(timestamps) > 1 else 1.0
+        rc = _row_count(spec, progress)
+        rows.extend([
+            {"ts": ts, "table_name": spec.name, "metric_name": "row_count", "value": rc},
+            {
+                "ts": ts,
+                "table_name": spec.name,
+                "metric_name": "size_bytes",
+                "value": int(rc * avg_row_size),
+            },
+            {
+                "ts": ts,
+                "table_name": spec.name,
+                "metric_name": "last_modified",
+                "value": ts.timestamp(),
+            },
+        ])
+        rates: list[float] = []
+        for col in spec.columns:
+            if not col.nullable:
+                continue
+            rate = _null_rate(spec, col, progress, i)
+            rates.append(rate)
+            rows.append({
+                "ts": ts,
+                "table_name": spec.name,
+                "metric_name": "null_count",
+                "value": round(rc * rate),
+                "tags": {"column": col.name},
+            })
+        if rates:
+            rows.append({
+                "ts": ts,
+                "table_name": spec.name,
+                "metric_name": "null_rate",
+                "value": round(sum(rates) / len(rates), 4),
+            })
+    return rows
+
+
+def _schema_events(days: int) -> list[dict]:
+    end = datetime.now(UTC).replace(second=0, microsecond=0)
+    return [
+        {
+            "ts": end - timedelta(days=days * 0.50),
+            "table_name": "events",
+            "change_type": "nullable_changed",
+            "column_name": "device_id",
+            "details": {
+                "before": {"name": "device_id", "type": "string", "nullable": False},
+                "after": {"name": "device_id", "type": "string", "nullable": True},
+            },
+        },
+        {
+            "ts": end - timedelta(days=days * 0.42),
+            "table_name": "sessions",
+            "change_type": "column_added",
+            "column_name": "source",
+            "details": {"after": {"name": "source", "type": "string", "nullable": True}},
+        },
+    ]
+
+
+def seed_iceberg_history(
+    project_id: str,
+    *,
+    days: int = 14,
+    interval_minutes: int = 60,
+    reset: bool = True,
+) -> dict:
+    print("[3/4] Iceberg demo history")
+    specs = _table_specs()
+    table_names = [s.name for s in specs]
+    deleted = _purge_project_history(project_id, table_names) if reset else 0
+    timestamps = _timestamps(days, interval_minutes)
+    rows: list[dict] = []
+    end = timestamps[-1] if timestamps else datetime.now(UTC)
+    for spec in specs:
+        rows.extend(_metric_rows(spec, timestamps))
+        rows.extend(_distribution_rows(spec, days, end))
+    saved = save_metrics(rows, project_id)
+    schema_events_saved = save_schema_events(_schema_events(days))
+    print(
+        f"  saved {saved} metrics, {schema_events_saved} schema-events "
+        f"for {len(specs)} tables; deleted {deleted} old rows"
+    )
+    return {
+        "rows": saved,
+        "schema_events": schema_events_saved,
+        "deleted": deleted,
+        "tables": len(specs),
+        "ticks": len(timestamps),
+    }
+
+
+def prepare_iceberg_demo(
+    days: int = 14,
+    interval_minutes: int = 60,
+    *,
+    warmup_ml: bool = True,
+) -> dict:
+    catalog_result = ensure_iceberg_tables()
+    print("[2/5] Demo workspace + collector")
+    project_id, connection_id = _get_demo_project_and_connection()
+    collect_for_connection(project_id, connection_id)
+    print(f"  collected live Iceberg snapshot for project={project_id}")
+    history_result = seed_iceberg_history(
+        project_id,
+        days=days,
+        interval_minutes=interval_minutes,
+        reset=True,
+    )
+    _repair_iceberg_connection(
+        project_id,
+        connection_id,
+        default_app_iceberg_dsn(),
+        interval_minutes=1440,
+    )
+    warmup_result = None
+    if warmup_ml:
+        print("[4/5] ML warmup")
+        from scripts.warmup_ml import main as warmup_main
+
+        warmup_result = warmup_main(project_id=project_id)
+    print("[5/5] Demo ready")
+    print("  URL: http://localhost:5001/dashboard/")
+    print("  Login: lake@dbmonitor.app / demo12345")
+    print(f"  PROJECT_ID={project_id}")
+    print(f"  CONNECTION_ID={connection_id}")
+    return {
+        "project_id": project_id,
+        "connection_id": connection_id,
+        "catalog": catalog_result,
+        "history": history_result,
+        "warmup": warmup_result,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare Iceberg Lakehouse demo tables and history.",
+    )
+    parser.add_argument("--days", type=int, default=14)
+    parser.add_argument("--interval-minutes", type=int, default=60)
+    parser.add_argument(
+        "--skip-warmup-ml",
+        action="store_true",
+        help="Only seed Iceberg tables/history; do not run ML warmup.",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    result = prepare_iceberg_demo(
+        days=args.days,
+        interval_minutes=args.interval_minutes,
+        warmup_ml=not args.skip_warmup_ml,
+    )
+    print("\nIceberg demo prepared:")
+    print(f"  ICEBERG_PROJECT_ID={result['project_id']}")
+    print(f"  ICEBERG_CONNECTION_ID={result['connection_id']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_iceberg_demo.py
+++ b/scripts/prepare_iceberg_demo.py
@@ -23,6 +23,8 @@ from sqlalchemy import text
 from app import crypto
 from app.metrics_storage import (
     get_engine as get_monitor_engine,
+)
+from app.metrics_storage import (
     save_metrics,
     save_schema_events,
 )
@@ -79,7 +81,7 @@ class DemoTable:
 
 def _table_specs() -> list[DemoTable]:
     import pyarrow as pa
-    from pyiceberg.types import DoubleType, IntegerType, LongType, StringType
+    from pyiceberg.types import DoubleType, IntegerType, StringType
 
     return [
         DemoTable(

--- a/scripts/smoke_iceberg.py
+++ b/scripts/smoke_iceberg.py
@@ -117,20 +117,22 @@ def setup_catalog() -> None:
     }
     catalog = RestCatalog("rest", uri=f"http://{REST_HOST}", warehouse=WAREHOUSE, **s3_props)
 
-    # Always drop + recreate so row/null counts are deterministic on re-runs.
+    # The tabulario REST catalog may return 500 on repeated drop_table calls
+    # against its embedded JDBC store. For a smoke test, reusing the existing
+    # fixture is safer than trying to purge it.
     try:
-        catalog.drop_table((NAMESPACE, TABLE))
-        _ok(f"dropped stale table {NAMESPACE}.{TABLE!r}")
+        catalog.load_table((NAMESPACE, TABLE))
+        _ok(f"table {NAMESPACE}.{TABLE!r} already exists")
+        return
     except NoSuchTableError:
         pass
-    try:
-        catalog.drop_namespace(NAMESPACE)
-        _ok(f"dropped stale namespace {NAMESPACE!r}")
-    except NoSuchNamespaceError:
-        pass
 
-    catalog.create_namespace(NAMESPACE)
-    _ok(f"namespace {NAMESPACE!r} created")
+    try:
+        catalog.load_namespace_properties(NAMESPACE)
+        _ok(f"namespace {NAMESPACE!r} already exists")
+    except NoSuchNamespaceError:
+        catalog.create_namespace(NAMESPACE)
+        _ok(f"namespace {NAMESPACE!r} created")
 
     schema = Schema(
         NestedField(1, "id", LongType(), required=True),

--- a/templates/connections/list.html
+++ b/templates/connections/list.html
@@ -29,7 +29,7 @@
           </div>
           <div class="col-span-2 text-xs text-slate-500 dark:text-slate-400">
             <span class="font-mono">{{ c.schema_name }}</span><br>
-            каждые {{ c.interval_minutes }} мин
+            {{ c.interval_minutes|fmt_interval_minutes }}
           </div>
           <div class="col-span-2 text-xs">
             {% if c.is_active %}

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -44,7 +44,7 @@
           </div>
           <div class="mt-1 truncate font-mono text-xs text-slate-500 dark:text-slate-400">{{ c.dsn_masked }}</div>
           <div class="text-xs text-slate-400 dark:text-slate-500">
-            <span class="font-mono">{{ c.schema_name }}</span> · каждые {{ c.interval_minutes }} мин
+            <span class="font-mono">{{ c.schema_name }}</span> · {{ c.interval_minutes|fmt_interval_minutes }}
           </div>
         </div>
       {% else %}

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -86,6 +86,51 @@ def test_fernet_key_missing_in_production_raises(monkeypatch):
         crypto.encrypt_dsn("postgresql://u:p@h/d")
 
 
+def test_dev_fallback_reuses_env_local_key(tmp_path, monkeypatch):
+    from app import crypto
+
+    env = tmp_path / ".env"
+    env_local = tmp_path / ".env.local"
+    monkeypatch.setattr(crypto, "_ENV", env)
+    monkeypatch.setattr(crypto, "_ENV_LOCAL", env_local)
+    monkeypatch.delenv("FERNET_KEY", raising=False)
+    monkeypatch.delenv("FLASK_ENV", raising=False)
+    crypto.reset_for_tests()
+
+    ciphertext = crypto.encrypt_dsn("postgresql://u:p@h/d")
+    generated_key = env_local.read_text(encoding="utf-8")
+    assert "FERNET_KEY=" in generated_key
+
+    monkeypatch.delenv("FERNET_KEY", raising=False)
+    crypto.reset_for_tests()
+
+    assert crypto.decrypt_dsn(ciphertext) == "postgresql://u:p@h/d"
+
+
+def test_dev_fallback_prefers_dotenv_over_env_local(tmp_path, monkeypatch):
+    from cryptography.fernet import Fernet
+
+    from app import crypto
+
+    docker_key = Fernet.generate_key()
+    stale_local_key = Fernet.generate_key()
+    env = tmp_path / ".env"
+    env_local = tmp_path / ".env.local"
+    env.write_text(f"FERNET_KEY={docker_key.decode()}\n", encoding="utf-8")
+    env_local.write_text(f"FERNET_KEY={stale_local_key.decode()}\n", encoding="utf-8")
+    monkeypatch.setattr(crypto, "_ENV", env)
+    monkeypatch.setattr(crypto, "_ENV_LOCAL", env_local)
+    monkeypatch.delenv("FERNET_KEY", raising=False)
+    monkeypatch.delenv("FLASK_ENV", raising=False)
+    crypto.reset_for_tests()
+
+    ciphertext = crypto.encrypt_dsn("iceberg+rest://iceberg-rest:8181")
+
+    assert Fernet(docker_key).decrypt(ciphertext) == b"iceberg+rest://iceberg-rest:8181"
+    with pytest.raises(Exception):
+        Fernet(stale_local_key).decrypt(ciphertext)
+
+
 # --- Helpers ---------------------------------------------------------------
 
 
@@ -392,3 +437,14 @@ def test_iceberg_adapter_list_namespaces():
     result = adapter.list_namespaces()
     assert result == [("warehouse",)]
     fake_catalog.list_namespaces.assert_called_once()
+
+
+def test_interval_minutes_filter_formats_daily_interval():
+    from app.app import create_app
+
+    app = create_app({"TESTING": True})
+    fmt = app.jinja_env.filters["fmt_interval_minutes"]
+
+    assert fmt(15) == "каждые 15 мин"
+    assert fmt(60) == "каждый час"
+    assert fmt(1440) == "раз в сутки"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -219,7 +219,8 @@ def test_explain_endpoint_returns_200(client):
     with patch("app.llm.explain_anomaly", return_value=payload), \
          patch("app.api.get_cached_explanation", return_value=None), \
          patch("app.api.save_explanation"), \
-         patch("app.api.list_tables", return_value=_KNOWN_TABLES):
+         patch("app.api.get_latest_metric", return_value={"value": 42, "ts": _ts()}), \
+         patch("app.api.get_anomaly_scores", return_value=[]):
         resp = client.post("/api/explain", json={"table": "orders", "metric": "row_count", "ts": _ts()})
     assert resp.status_code == 200
     data = resp.get_json()
@@ -227,9 +228,23 @@ def test_explain_endpoint_returns_200(client):
     assert data["confidence"] == pytest.approx(0.8)
 
 
+def test_explain_endpoint_accepts_project_scoped_anomaly_table(client):
+    payload = {"explanation": "iceberg reason", "suggested_fix": "iceberg fix", "confidence": 0.7}
+    with patch("app.llm.explain_anomaly", return_value=payload), \
+         patch("app.api.get_cached_explanation", return_value=None), \
+         patch("app.api.save_explanation"), \
+         patch("app.api.get_latest_metric", return_value=None), \
+         patch("app.api.get_anomaly_scores", return_value=[{"ts": _ts(), "is_anomaly": True}]), \
+         patch("app.api.list_tables", return_value=[]):
+        resp = client.post("/api/explain", json={"table": "sessions", "metric": "row_count", "ts": _ts()})
+    assert resp.status_code == 200
+    assert resp.get_json()["explanation"] == "iceberg reason"
+
+
 def test_explain_endpoint_unknown_table_returns_404(client):
     with patch("app.api.get_cached_explanation", return_value=None), \
-         patch("app.api.list_tables", return_value=_KNOWN_TABLES):
+         patch("app.api.get_latest_metric", return_value=None), \
+         patch("app.api.get_anomaly_scores", return_value=[]):
         resp = client.post("/api/explain", json={"table": "nonexistent", "metric": "row_count", "ts": _ts()})
     assert resp.status_code == 404
 

--- a/tests/test_prepare_iceberg_demo.py
+++ b/tests/test_prepare_iceberg_demo.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+
+def test_default_iceberg_dsn_points_to_local_rest_and_minio():
+    from scripts.prepare_iceberg_demo import (
+        default_app_iceberg_dsn,
+        default_iceberg_dsn,
+    )
+
+    dsn = default_iceberg_dsn()
+
+    assert dsn.startswith("iceberg+rest://localhost:8181?")
+    assert "warehouse=s3%3A%2F%2Ficeberg-smoke%2Fwarehouse" in dsn
+    assert "s3.endpoint=http%3A%2F%2Flocalhost%3A9000" in dsn
+    assert "s3.path-style-access=true" in dsn
+
+    app_dsn = default_app_iceberg_dsn()
+    assert app_dsn.startswith("iceberg+rest://iceberg-rest:8181?")
+    assert "s3.endpoint=http%3A%2F%2Fminio%3A9000" in app_dsn
+
+
+def test_timestamps_build_expected_number_of_ticks():
+    from scripts.prepare_iceberg_demo import _timestamps
+
+    ticks = _timestamps(days=14, interval_minutes=60)
+
+    assert len(ticks) == 14 * 24
+    assert ticks == sorted(ticks)
+
+
+def test_events_history_contains_device_id_null_rate_incident():
+    from scripts.prepare_iceberg_demo import _metric_rows, _table_specs, _timestamps
+
+    events = next(spec for spec in _table_specs() if spec.name == "events")
+    rows = _metric_rows(events, _timestamps(days=14, interval_minutes=60))
+
+    device_nulls = [
+        r for r in rows
+        if r["table_name"] == "events"
+        and r["metric_name"] == "null_count"
+        and r.get("tags", {}).get("column") == "device_id"
+    ]
+    row_counts = [
+        r for r in rows
+        if r["table_name"] == "events" and r["metric_name"] == "row_count"
+    ]
+
+    assert len(device_nulls) == 14 * 24
+    assert len(row_counts) == 14 * 24
+    early_rate = device_nulls[0]["value"] / row_counts[0]["value"]
+    late_rate = device_nulls[-1]["value"] / row_counts[-1]["value"]
+    assert early_rate < 0.03
+    assert late_rate > 0.15
+
+
+def test_repair_iceberg_connection_reencrypts_invalid_dsn(tmp_path, monkeypatch):
+    from cryptography.fernet import Fernet
+
+    db_path = tmp_path / "iceberg_demo.db"
+    import app.metrics_storage as storage
+
+    monkeypatch.setattr(storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage, "_engine", None)
+    monkeypatch.setattr(storage, "_initialized", False)
+
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    from app import crypto
+
+    crypto.reset_for_tests()
+
+    user = storage.create_user("u1", "lake@example.com", "hash")
+    project = storage.create_project("p1", user["id"], "Iceberg Lakehouse", "iceberg")
+    stale_ciphertext = Fernet(Fernet.generate_key()).encrypt(b"iceberg+rest://old")
+    storage.create_connection(
+        connection_id="c1",
+        project_id=project["id"],
+        name="Local Iceberg REST",
+        dsn_encrypted=stale_ciphertext,
+        schema_name="old_ns",
+    )
+
+    from scripts.prepare_iceberg_demo import (
+        _repair_iceberg_connection,
+        default_iceberg_dsn,
+    )
+
+    _repair_iceberg_connection(
+        project["id"],
+        "c1",
+        default_iceberg_dsn(),
+        interval_minutes=1440,
+    )
+
+    repaired = storage.get_connection(project["id"], "c1")
+    assert crypto.decrypt_dsn(repaired["dsn_encrypted"]) == default_iceberg_dsn()
+    assert repaired["schema_name"] == "lakehouse"
+    assert repaired["interval_minutes"] == 1440
+    assert repaired["is_active"] is True


### PR DESCRIPTION
## Что сделано

- Добавлен `scripts.prepare_iceberg_demo` для подготовки локального Iceberg demo path.
- Создаются/reuse Iceberg REST + MinIO таблицы в namespace `lakehouse`.
- Seed-ится 14-дневная synthetic lakehouse history для `events`, `orders`, `customers`, `sessions`.
- `make iceberg-demo` стал единым pipeline: останавливает `app`, готовит историю, прогревает ML и поднимает `app` обратно.
- `smoke_iceberg` сделан идемпотентным для повторных прогонов.
- `/api/explain` теперь проверяет таблицы по project-scoped metrics, чтобы LLM explanations работали для Iceberg.
- Crypto fallback теперь сначала берёт `FERNET_KEY` из `.env`, чтобы host scripts и Docker app шифровали DSN одним ключом.
- Connection interval в UI форматируется человекочитаемо.
- `docs/demo/SCENARIO_3_2.md` обновлён под Iceberg demo сценарий.

## Важно для демо

Локальные Iceberg tables маленькие и нужны для проверки adapter/schema/connectivity. Красивая 14-дневная история seed-ится в monitoring DB для воспроизводимого демо. Если вручную выключить/включить Iceberg connection, immediate collector может снова записать tiny live rows. Перед показом нужно заново выполнить `make iceberg-demo`.

## Проверено

- `pytest tests/test_connections.py tests/test_prepare_iceberg_demo.py tests/test_llm.py tests/test_iceberg_adapter.py -q`
- `make iceberg-up`
- `make iceberg-demo`

Closes #178