### PR TITLE
Demo 3.2 — Telegram demo path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT_ID    ?= legacy
 CONNECTION_ID ?=
 DEMO_PROJECT_SLUG ?= retail-postgres
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo iceberg-up iceberg-down smoke-iceberg iceberg-demo demo-ids clickhouse-up clickhouse-down seed-clickhouse backup restore backup-cron-up backup-cron-down
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo telegram-demo iceberg-up iceberg-down smoke-iceberg iceberg-demo demo-ids clickhouse-up clickhouse-down seed-clickhouse backup restore backup-cron-up backup-cron-down
 
 build:
 	docker build -t $(IMAGE) .
@@ -69,6 +69,9 @@ live-demo:
 		--project-id $(PROJECT_ID) \
 		$(if $(CONNECTION_ID),--connection-id $(CONNECTION_ID),) \
 		$(ARGS)
+
+telegram-demo: ## Demo 3.2 Telegram path (#182): make telegram-demo ARGS=all
+	python -m scripts.telegram_demo $(ARGS)
 
 # Print PROJECT_ID and CONNECTION_ID for the demo account (demo@dbmonitor.app).
 demo-ids:

--- a/app/api.py
+++ b/app/api.py
@@ -46,7 +46,7 @@ _RANGES = {
 }
 _HORIZONS = {"1d": 1, "3d": 3, "7d": 7, "14d": 14, "30d": 30}
 _NOTIFICATION_EVENT_TYPES = {
-    "anomaly", "schema_drift", "changepoint", "forecast", "root_cause",
+    "anomaly", "schema_drift", "changepoint", "forecast", "root_cause", "test",
 }
 _NOTIFICATION_STATUSES = {"sent", "failed"}
 _MAX_NOTIFICATIONS_LIMIT = 200

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -136,6 +136,7 @@ _NOTIFICATION_EVENT_LABELS = {
     "changepoint": "Change-point",
     "forecast": "Прогноз",
     "root_cause": "Root cause",
+    "test": "Тест",
 }
 _NOTIFICATION_PAGE_SIZE = 25
 

--- a/app/llm.py
+++ b/app/llm.py
@@ -172,11 +172,13 @@ def _parse_nim_response(raw: str) -> dict:
     }
 
 
-def _rule_based_explain(table: str, metric: str, ts: str) -> dict:
+def _rule_based_explain(
+    table: str, metric: str, ts: str, project_id: str = "legacy"
+) -> dict:
     """Template fallback when NIM is unavailable. confidence=0.3."""
     window = _context_window(ts)
-    all_rc = get_metrics(table, "row_count", "legacy", window=window)
-    all_nr = get_metrics(table, "null_rate", "legacy", window=window)
+    all_rc = get_metrics(table, "row_count", project_id, window=window)
+    all_nr = get_metrics(table, "null_rate", project_id, window=window)
 
     # Use only rows up to and including ts so the comparison reflects
     # conditions at the moment of the anomaly, not current state.
@@ -248,7 +250,7 @@ def explain_anomaly(
     Never raises — falls back to rule-based on any NIM failure.
     """
     if not settings.NIM_API_KEY:
-        return _rule_based_explain(table, metric, ts)
+        return _rule_based_explain(table, metric, ts, project_id=project_id)
 
     try:
         prompt = _build_prompt(table, metric, ts, project_id=project_id)
@@ -257,6 +259,6 @@ def explain_anomaly(
         if parsed:
             return parsed
         # JSON parsing failed — use rule-based
-        return _rule_based_explain(table, metric, ts)
+        return _rule_based_explain(table, metric, ts, project_id=project_id)
     except Exception:
-        return _rule_based_explain(table, metric, ts)
+        return _rule_based_explain(table, metric, ts, project_id=project_id)

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -1370,7 +1370,7 @@ def delete_project_notifications(project_id: str) -> None:
 # --- Notification history (#76) ---
 
 _NOTIFICATION_EVENT_TYPES = {
-    "anomaly", "schema_drift", "changepoint", "forecast", "root_cause",
+    "anomaly", "schema_drift", "changepoint", "forecast", "root_cause", "test",
 }
 
 

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -22,11 +22,17 @@ metrics_storage.save_notification so the UI can show a full audit trail (#76).
 import asyncio
 import logging
 
+from sqlalchemy import text
 from telegram import Bot
 from telegram.error import TelegramError
 
 from app.llm import explain_anomaly
-from app.metrics_storage import is_throttled, save_notification, update_throttle
+from app.metrics_storage import (
+    get_engine,
+    is_throttled,
+    save_notification,
+    update_throttle,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +101,25 @@ def _fmt_ts(ts: str) -> str:
     return ts.replace("T", " ")[:16] + " UTC"
 
 
+def _project_label(project_id: str) -> str:
+    """Best-effort human-readable project label for Telegram text."""
+    try:
+        with get_engine().connect() as conn:
+            row = conn.execute(
+                text("SELECT name, slug FROM projects WHERE id = :project_id"),
+                {"project_id": project_id},
+            ).fetchone()
+        if row:
+            name = str(row[0] or "").strip()
+            slug = str(row[1] or "").strip()
+            if name and slug:
+                return f"{name} ({slug})"
+            return name or slug or project_id
+    except Exception as exc:  # pragma: no cover - label lookup is best-effort
+        logger.debug("Project label lookup failed for %s: %s", project_id, exc)
+    return project_id
+
+
 def notify_anomaly(
     project_id: str,
     table: str,
@@ -111,14 +136,19 @@ def notify_anomaly(
     if is_throttled(project_id, table, event_key, throttle_minutes=throttle_minutes):
         return
 
-    result = explain_anomaly(table, metric, ts)
+    project_label = _project_label(project_id)
+    result = explain_anomaly(table, metric, ts, project_id=project_id)
     is_llm = result.get("confidence", 0) > _RULE_BASED_CONFIDENCE
     body = result.get("explanation", "Требуется ручная проверка данных.") if is_llm else "Требуется ручная проверка данных."
 
     text = (
-        f"\U0001f6a8 [{table}] Аномалия (score: {score:.4f})\n"
-        f"Обнаружена аномалия в таблице {table} по метрике {metric}"
-        f" в момент {_fmt_ts(ts)}. {body}"
+        f"\U0001f6a8 DB Monitor: аномалия\n"
+        f"Проект: {project_label}\n"
+        f"Таблица: {table}\n"
+        f"Метрика: {metric}\n"
+        f"Время: {_fmt_ts(ts)}\n"
+        f"Score: {score:.4f}\n\n"
+        f"{body}"
     )
     ok, error = send_message(text, bot_token=bot_token, chat_id=chat_id)
     _record(project_id=project_id, event_type="anomaly", message=text,

--- a/app/settings.py
+++ b/app/settings.py
@@ -189,9 +189,18 @@ def test_notification(slug: str):
         flash("Заполните Bot Token и Chat ID перед тестом.", "error")
         return redirect(url_for("settings.notifications", slug=slug))
 
+    message = f"✅ Тестовое сообщение из DB Monitor для проекта «{project['name']}»."
     ok, error = send_message(
-        f"✅ Тестовое сообщение из DB Monitor для проекта «{project['name']}».",
+        message,
         bot_token=raw_token, chat_id=chat_id,
+    )
+    metrics_storage.save_notification(
+        project_id=project["id"],
+        event_type="test",
+        message=message,
+        status="sent" if ok else "failed",
+        error=error,
+        chat_id=chat_id,
     )
     if ok:
         flash("Тестовое сообщение отправлено.", "success")

--- a/docs/demo/SCENARIO_3_2.md
+++ b/docs/demo/SCENARIO_3_2.md
@@ -535,14 +535,45 @@ Connection остаётся активным: кнопка `Тест` и live sc
 
 ### 8. Telegram settings
 
-Открыть настройки уведомлений проекта.
+Перед показом проверить, что в `.env` локально заданы секреты:
+
+```bash
+TELEGRAM_BOT_TOKEN=...
+TELEGRAM_CHAT_ID=...
+```
+
+Секреты не коммитить и не показывать на экране.
+
+Сохранить настройки для demo-проектов:
+
+```bash
+make telegram-demo ARGS=configure
+```
+
+Команда сохраняет project-level Telegram settings для:
+
+- `Retail Postgres`;
+- `Iceberg Lakehouse`.
+
+Открыть настройки уведомлений проекта:
+
+```text
+/projects/retail-postgres/settings/notifications
+/projects/iceberg-lakehouse/settings/notifications
+```
 
 Показать:
 
-- bot token;
+- сохранённый masked bot token;
 - chat id;
 - throttle;
 - test notification.
+
+Проверить test notification:
+
+```bash
+make telegram-demo ARGS=test
+```
 
 Что сказать:
 
@@ -556,11 +587,26 @@ Connection остаётся активным: кнопка `Тест` и live sc
 
 ### 9. Incident and notification history
 
-Запустить live incident заранее или во время демо:
+Для Postgres можно запустить live incident заранее или во время демо:
 
 ```bash
 make live-demo PROJECT_ID=<project_id> CONNECTION_ID=<connection_id> \
   ARGS="--ticks 20 --interval 5 --incident-at 8 --changepoints"
+```
+
+Для быстрой проверки Telegram delivery по Postgres и Iceberg:
+
+```bash
+make telegram-demo ARGS=alert
+```
+
+Эта команда отправляет anomaly alert через тот же `notify_anomaly` path,
+который использует collector, и пишет audit row в notification history.
+Для повторных прогонов demo-команда обходит throttle; если нужно проверить
+боевой throttle, использовать:
+
+```bash
+make telegram-demo ARGS="alert --respect-throttle"
 ```
 
 Открыть:
@@ -586,6 +632,15 @@ make live-demo PROJECT_ID=<project_id> CONNECTION_ID=<connection_id> \
 
 - в Telegram есть alert или подготовленный fallback;
 - `/dashboard/notifications` содержит запись.
+
+Fallback, если Telegram API недоступен:
+
+```bash
+make telegram-demo ARGS=fallback
+```
+
+После этого `/dashboard/notifications` содержит `failed` запись с
+`fallback_only`, которую можно показать как audit trail доставки.
 
 ### 10. ClickHouse project
 
@@ -678,7 +733,8 @@ project.
 
 1. Использовать заранее подготовленный `monitor.db`.
 2. Показывать Postgres dashboard как основной сценарий.
-3. Для Telegram использовать заранее созданные notification rows или скрин.
+3. Для Telegram выполнить `make telegram-demo ARGS=fallback` или использовать
+   заранее подготовленный скрин.
 4. ClickHouse/Iceberg показать через smoke output или скринкаст.
 5. Не показывать live incident, а открыть уже заполненную деталку `events`.
 
@@ -690,7 +746,8 @@ project.
   двум пользователям не показать честно.
 - `#178` Iceberg demo: smoke path есть, нужен устойчивый UI path.
 - `#176` history/ML warmup: нужно прогревать данные по каждому demo project.
-- `#182` Telegram demo path: нужен стабильный bot/chat или fallback.
+- `#182` Telegram demo path: нужен стабильный bot/chat; fallback фиксируется
+  через `make telegram-demo ARGS=fallback`.
 - `#180` / `#171` anomaly alert quality: важно убрать ложные и противоречивые
   уведомления перед показом.
 

--- a/scripts/telegram_demo.py
+++ b/scripts/telegram_demo.py
@@ -1,0 +1,199 @@
+"""Prepare and verify the Demo 3.2 Telegram path (#182).
+
+The script never prints Telegram secrets. It reads ``TELEGRAM_BOT_TOKEN`` and
+``TELEGRAM_CHAT_ID`` from ``.env``/environment, saves project-level settings,
+sends test messages, and can send a real anomaly alert through the same
+``notify_anomaly`` path used by collectors.
+
+Usage:
+    python -m scripts.telegram_demo configure
+    python -m scripts.telegram_demo test
+    python -m scripts.telegram_demo alert
+    python -m scripts.telegram_demo fallback
+    python -m scripts.telegram_demo all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from app import crypto, metrics_storage
+from app.config import settings
+from app.notifications.telegram import notify_anomaly, send_message
+
+
+@dataclass(frozen=True)
+class DemoTelegramProject:
+    email: str
+    slug: str
+    table: str
+    metric: str
+    score: float
+
+
+DEFAULT_PROJECTS = (
+    DemoTelegramProject(
+        email="demo@dbmonitor.app",
+        slug="retail-postgres",
+        table="events",
+        metric="null_rate",
+        score=-0.42,
+    ),
+    DemoTelegramProject(
+        email="lake@dbmonitor.app",
+        slug="iceberg-lakehouse",
+        table="sessions",
+        metric="row_count",
+        score=-0.37,
+    ),
+)
+
+
+def _require_env() -> tuple[str, str]:
+    token = settings.TELEGRAM_BOT_TOKEN.strip()
+    chat_id = settings.TELEGRAM_CHAT_ID.strip()
+    if not token or not chat_id:
+        msg = (
+            "TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are required in .env "
+            "or the environment."
+        )
+        raise SystemExit(msg)
+    return token, chat_id
+
+
+def _resolve_project(spec: DemoTelegramProject) -> dict:
+    user = metrics_storage.get_user_by_email(spec.email)
+    if user is None:
+        raise SystemExit(f"Demo user not found: {spec.email}")
+    project = metrics_storage.get_project_by_slug(user["id"], spec.slug)
+    if project is None:
+        raise SystemExit(f"Demo project not found: {spec.email}/{spec.slug}")
+    return project
+
+
+def configure(projects: tuple[DemoTelegramProject, ...], throttle_minutes: int) -> None:
+    token, chat_id = _require_env()
+    for spec in projects:
+        project = _resolve_project(spec)
+        metrics_storage.save_project_notifications(
+            project["id"],
+            telegram_bot_token=crypto.encrypt_token(token),
+            telegram_chat_id=chat_id,
+            throttle_minutes=throttle_minutes,
+        )
+        print(f"configured: {project['name']} ({project['slug']})")
+
+
+def test(projects: tuple[DemoTelegramProject, ...]) -> None:
+    token, chat_id = _require_env()
+    failed = False
+    for spec in projects:
+        project = _resolve_project(spec)
+        text = (
+            "✅ DB Monitor demo Telegram test\n"
+            f"Project: {project['name']} ({project['slug']})"
+        )
+        ok, error = send_message(text, bot_token=token, chat_id=chat_id)
+        if ok:
+            print(f"test sent: {project['name']} ({project['slug']})")
+        else:
+            failed = True
+            print(f"test failed: {project['name']} ({project['slug']}): {error}")
+    if failed:
+        raise SystemExit(1)
+
+
+def alert(projects: tuple[DemoTelegramProject, ...], *, respect_throttle: bool) -> None:
+    for spec in projects:
+        project = _resolve_project(spec)
+        cfg = metrics_storage.get_project_notifications(project["id"])
+        if not cfg or not cfg.get("telegram_bot_token") or not cfg.get("telegram_chat_id"):
+            raise SystemExit(
+                f"Telegram settings are not configured for {project['name']}."
+            )
+        try:
+            token = crypto.decrypt_token(cfg["telegram_bot_token"])
+        except crypto.InvalidToken as exc:
+            raise SystemExit(
+                f"Saved Telegram token cannot be decrypted for {project['name']}."
+            ) from exc
+
+        throttle = int(cfg.get("throttle_minutes") or 30) if respect_throttle else 0
+        notify_anomaly(
+            project["id"],
+            spec.table,
+            datetime.now(UTC).isoformat(timespec="seconds"),
+            spec.score,
+            bot_token=token,
+            chat_id=cfg["telegram_chat_id"],
+            throttle_minutes=throttle,
+            metric=spec.metric,
+        )
+        print(
+            "alert attempted: "
+            f"{project['name']} ({project['slug']}) {spec.table}/{spec.metric}"
+        )
+
+
+def fallback(projects: tuple[DemoTelegramProject, ...]) -> None:
+    for spec in projects:
+        project = _resolve_project(spec)
+        message = (
+            "🚨 DB Monitor fallback: Telegram API недоступен на демо.\n"
+            f"Проект: {project['name']} ({project['slug']})\n"
+            f"Таблица: {spec.table}\n"
+            f"Метрика: {spec.metric}\n"
+            "Статус: fallback notification row для audit trail."
+        )
+        metrics_storage.save_notification(
+            project_id=project["id"],
+            event_type="anomaly",
+            table_name=spec.table,
+            metric_name=spec.metric,
+            message=message,
+            status="failed",
+            error="fallback_only",
+            chat_id=settings.TELEGRAM_CHAT_ID.strip() or None,
+        )
+        print(f"fallback row: {project['name']} ({project['slug']})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=("configure", "test", "alert", "fallback", "all"),
+        help="Demo Telegram action to run.",
+    )
+    parser.add_argument(
+        "--throttle-minutes",
+        type=int,
+        default=30,
+        help="Throttle saved by configure (default: 30).",
+    )
+    parser.add_argument(
+        "--respect-throttle",
+        action="store_true",
+        help="Do not bypass throttle for the alert command.",
+    )
+    args = parser.parse_args()
+
+    projects = DEFAULT_PROJECTS
+    if args.command in {"configure", "all"}:
+        configure(projects, args.throttle_minutes)
+    if args.command in {"test", "all"}:
+        test(projects)
+    if args.command in {"alert", "all"}:
+        alert(projects, respect_throttle=args.respect_throttle)
+    if args.command == "fallback":
+        fallback(projects)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,6 +71,12 @@
               <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M12 5l7 7-7 7" /></svg>
               Подключения
             </a>
+            {% set tg_url = url_for('settings.notifications', slug=g.current_project.slug) %}
+            {% set tg_active = request.path.startswith(tg_url) %}
+            <a href="{{ tg_url }}" class="flex items-center gap-2 rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 {% if tg_active %}bg-slate-100 font-medium text-slate-900 dark:bg-slate-800 dark:text-white{% endif %}">
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 15a4 4 0 0 1-4 4H7l-4 4V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z" /></svg>
+              Telegram
+            </a>
           {% endif %}
         </nav>
       </aside>

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -15,7 +15,7 @@
     <div class="flex items-center gap-2">
       <a href="{{ url_for('settings.notifications', slug=project.slug) }}"
          class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
-        Уведомления
+        Telegram
       </a>
       <a href="{{ url_for('connections.list_connections', slug=project.slug) }}"
          class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">

--- a/templates/projects/list.html
+++ b/templates/projects/list.html
@@ -26,6 +26,10 @@
             </div>
           </div>
           <div class="flex items-center gap-2">
+            <a href="{{ url_for('settings.notifications', slug=project.slug) }}"
+               class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
+              Telegram
+            </a>
             {% if g.current_project and g.current_project.id == project.id %}
               <span class="rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">текущий</span>
             {% else %}

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -125,6 +125,18 @@ def test_rule_based_explain_high_null_rate(monkeypatch):
     assert "null" in result["explanation"].lower() or "пропуск" in result["explanation"].lower()
 
 
+def test_rule_based_explain_uses_project_id(monkeypatch):
+    seen = []
+
+    def _fake_metrics(table, metric, project_id=None, **kw):
+        seen.append(project_id)
+        return []
+
+    monkeypatch.setattr("app.llm.get_metrics", _fake_metrics)
+    llm_mod._rule_based_explain("orders", "row_count", _ts(), project_id="iceberg")
+    assert seen == ["iceberg", "iceberg"]
+
+
 # ---------------------------------------------------------------------------
 # explain_anomaly — fallback on network error
 # ---------------------------------------------------------------------------

--- a/tests/test_project_notifications.py
+++ b/tests/test_project_notifications.py
@@ -381,7 +381,8 @@ def test_disable_wipes_config(client):
 
 def test_test_button_calls_send_message_without_persisting(client, monkeypatch):
     """The Test action submits form values to /test, calls send_message
-    once, and does NOT write a project_notifications row."""
+    once, audits the delivery attempt, and does NOT write a
+    project_notifications row."""
     _register(client, "test@example.com")
     sent = {}
 
@@ -406,8 +407,10 @@ def test_test_button_calls_send_message_without_persisting(client, monkeypatch):
     assert sent["bot_token"] == _FAKE_TG_TOKEN
     assert sent["chat_id"] == "42"
     assert "DB Monitor" in sent["text"]
-    # No row written — Test is non-destructive.
+    # No project_notifications row written — Test is non-destructive for
+    # saved settings. Delivery is still audited in notifications history.
     from app.metrics_storage import (
+        get_notifications,
         get_project_by_slug,
         get_project_notifications,
         get_user_by_email,
@@ -415,3 +418,41 @@ def test_test_button_calls_send_message_without_persisting(client, monkeypatch):
     user = get_user_by_email("test@example.com")
     project = get_project_by_slug(user["id"], "default")
     assert get_project_notifications(project["id"]) is None
+    rows = get_notifications(project_id=project["id"])
+    assert len(rows) == 1
+    assert rows[0]["event_type"] == "test"
+    assert rows[0]["status"] == "sent"
+    assert rows[0]["chat_id"] == "42"
+
+
+def test_test_button_audits_failed_send(client, monkeypatch):
+    _register(client, "test-failed@example.com")
+
+    def fake_send(text, *, bot_token, chat_id):
+        return False, "telegram_error: bad"
+
+    monkeypatch.setattr("app.notifications.telegram.send_message", fake_send)
+
+    resp = client.post(
+        "/projects/default/settings/notifications/test",
+        data={
+            "telegram_bot_token": _FAKE_TG_TOKEN,
+            "telegram_chat_id": "42",
+            "throttle_minutes": "30",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+
+    from app.metrics_storage import (
+        get_notifications,
+        get_project_by_slug,
+        get_user_by_email,
+    )
+    user = get_user_by_email("test-failed@example.com")
+    project = get_project_by_slug(user["id"], "default")
+    rows = get_notifications(project_id=project["id"])
+    assert len(rows) == 1
+    assert rows[0]["event_type"] == "test"
+    assert rows[0]["status"] == "failed"
+    assert rows[0]["error"] == "telegram_error: bad"

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -137,7 +137,11 @@ def test_throttle_is_per_table_and_key(storage):
 def _explain_stub(monkeypatch, *, confidence=0.85, explanation="ETL сбой"):
     monkeypatch.setattr(
         "app.notifications.telegram.explain_anomaly",
-        lambda t, m, ts: {"explanation": explanation, "suggested_fix": "", "confidence": confidence},
+        lambda t, m, ts, project_id="legacy": {
+            "explanation": explanation,
+            "suggested_fix": "",
+            "confidence": confidence,
+        },
     )
 
 
@@ -153,6 +157,10 @@ def test_notify_anomaly_sends_message(storage, monkeypatch):
     assert "row_count" in text
     assert "UTC" in text
     assert "ETL сбой" in text
+    assert "Проект:" in text
+    assert "Таблица: orders" in text
+    assert "Метрика: row_count" in text
+    assert "Score: -0.1400" in text
     # bot_token/chat_id flow through to send_message.
     assert mock_send.call_args.kwargs["bot_token"] == "tok"
     assert mock_send.call_args.kwargs["chat_id"] == "42"
@@ -187,9 +195,10 @@ def test_notify_anomaly_fallback_message(storage, monkeypatch):
 def test_notify_anomaly_passes_raw_ts_and_metric_to_explain(storage, monkeypatch):
     received = {}
 
-    def capture(t, m, ts):
+    def capture(t, m, ts, project_id="legacy"):
         received["ts"] = ts
         received["metric"] = m
+        received["project_id"] = project_id
         return {"explanation": "ok", "suggested_fix": "", "confidence": 0.85}
 
     monkeypatch.setattr("app.notifications.telegram.explain_anomaly", capture)
@@ -199,6 +208,7 @@ def test_notify_anomaly_passes_raw_ts_and_metric_to_explain(storage, monkeypatch
                        bot_token="tok", chat_id="42", metric="null_rate")
     assert received["ts"] == raw_ts
     assert received["metric"] == "null_rate"
+    assert received["project_id"] == _PID
 
 
 def test_notify_anomaly_message_contains_score(storage, monkeypatch):


### PR DESCRIPTION
## Что сделано

- Добавлен `scripts.telegram_demo` и `make telegram-demo` для сценариев `configure`, `test`, `alert`, `fallback`.
- Telegram alert стал понятнее для демо: проект, таблица, метрика, время и score выводятся отдельными строками.
- `notify_anomaly` теперь передает `project_id` в `explain_anomaly`, чтобы Postgres/Iceberg не брали legacy-контекст.
- Rule-based LLM fallback теперь читает метрики нужного `project_id`.
- Кнопка Telegram `Тест` теперь пишет audit row в `/dashboard/notifications` со статусом `sent` / `failed`.
- Добавлен тип notification event `test` в storage/API/dashboard.
- Telegram settings стали доступны из UI: sidebar, список проектов и detail проекта.
- `docs/demo/SCENARIO_3_2.md` обновлён под configure/test/alert/fallback demo path.

## Почему

- На демо нужно показать реальный project-level Telegram path, а не только seeded notification history.
- Пользователь должен видеть, что тестовая отправка попадает в историю доставки.
- Настройки Telegram должны быть доступны из dashboard без скрытых URL.

## Проверено

- `ruff check app/settings.py app/dashboard.py app/api.py app/metrics_storage.py tests/test_project_notifications.py`
- `ruff check app/llm.py app/notifications/telegram.py scripts/telegram_demo.py tests/test_llm.py tests/test_telegram.py`
- `pytest tests/test_project_notifications.py tests/test_telegram.py tests/test_llm.py -q`
- Локально: `make telegram-demo ARGS=configure/test/alert/fallback`
- Локально: `docker compose up -d --build app`, app healthy

Closes #182