### PR TITLE
feat(#176): Demo 3.2 — единая команда demo-prepare для готовки демо-стенда

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT_ID    ?= legacy
 CONNECTION_ID ?=
 DEMO_PROJECT_SLUG ?= retail-postgres
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo telegram-demo iceberg-up iceberg-down smoke-iceberg iceberg-demo demo-ids clickhouse-up clickhouse-down seed-clickhouse backup restore backup-cron-up backup-cron-down
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo telegram-demo iceberg-up iceberg-down smoke-iceberg iceberg-demo demo-ids clickhouse-up clickhouse-down seed-clickhouse backup restore backup-cron-up backup-cron-down demo-prepare
 
 build:
 	docker build -t $(IMAGE) .
@@ -72,6 +72,12 @@ live-demo:
 
 telegram-demo: ## Demo 3.2 Telegram path (#182): make telegram-demo ARGS=all
 	python -m scripts.telegram_demo $(ARGS)
+
+# Demo 3.2 — backfill 14-day history + ML warmup для demo-проектов (#176).
+# Один проход: seed_demo_workspace → seed_metrics_db → warmup_ml → verify.
+# По умолчанию готовит retail-postgres; --slug для других.
+demo-prepare:
+	python -m scripts.demo_prepare $(ARGS)
 
 # Print PROJECT_ID and CONNECTION_ID for the demo account (demo@dbmonitor.app).
 demo-ids:

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -95,18 +95,24 @@ curl -sf "http://localhost:5001/healthz?strict=true" | jq .
 ## 6 · Тестовые данные
 
 ```bash
-# Сидинг demo-проектов и метрик:
-make seed                           # target DB (Postgres)
+# Один проход — seed_demo_workspace + 14-дневная история + ML warmup (#176):
+make demo-prepare
+# Под капотом: создаёт demo@dbmonitor.app + retail-postgres проект,
+# заливает 14 дней метрик, тренирует Prophet / IsolationForest / PELT / drift.
+# В конце печатает COUNT(*) по metrics / anomaly_scores / changepoints /
+# drift_reports / notifications / forecast_models — все должны быть > 0.
+
+# Опционально — target Postgres (если демо включает реальный сбор):
+make seed
 make seed-clickhouse                # если демо включает CH (после `make clickhouse-up`)
-make reset-metrics PROJECT_ID=<id>  # 14 дней синтетической истории
-make warmup-ml PROJECT_ID=<id>      # натренировать ML
 
 # Проверка что demo-пользователь существует:
 make demo-ids
 # Должно вывести PROJECT_ID + CONNECTION_ID demo-аккаунта.
 ```
 
-✅ `demo-ids` отдаёт реальные UUID, не пусто.
+✅ `demo-ids` отдаёт реальные UUID, не пусто. Финальная таблица
+`make demo-prepare` показывает все ненулевые счётчики.
 
 ---
 

--- a/scripts/demo_prepare.py
+++ b/scripts/demo_prepare.py
@@ -1,0 +1,200 @@
+"""Demo 3.2 — backfill 14-day history + ML warmup для demo-проектов (#176).
+
+Один проход, который оставляет дашборд готовым к показу:
+
+  scripts.seed_demo_workspace  →  пользователи / проекты / коннекты
+                ↓
+  scripts.seed_metrics_db      →  14 дней синтетической истории, помеченной project_id
+                ↓
+  scripts.warmup_ml            →  Prophet / IsolationForest / PELT / drift по project_id
+                ↓
+  verification                 →  COUNT(*) по metrics / anomaly_scores / changepoints /
+                                  drift_reports / forecast-моделей
+
+После прогона:
+- table_detail показывает 14-дневный график
+- forecast endpoint отдаёт точки
+- anomaly KPI на overview не пустой (есть подготовленный incident)
+- /dashboard/history полон notifications
+- ml_last_runs не пустой
+
+Usage:
+    python -m scripts.demo_prepare
+    python -m scripts.demo_prepare --slug retail-postgres
+    python -m scripts.demo_prepare --skip-workspace  # workspace уже создан
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+
+from app.metrics_storage import get_engine
+
+logger = logging.getLogger(__name__)
+
+# Слаги demo-проектов из seed_demo_workspace. Порядок = порядок прогона.
+# По умолчанию готовим только Postgres-проект — seed_metrics_db.py читает
+# схему из глобального DATABASE_URL (см. _capture_snapshots), поэтому для
+# CH/Iceberg нужна отдельная инфра. Postgres-проекта достаточно чтобы
+# выполнить весь acceptance из #176; CH/Iceberg — bonus, делается через
+# реальные тики коллектора после `make seed-clickhouse` etc.
+DEFAULT_SLUGS = ("retail-postgres",)
+MODELS_DIR = Path(__file__).resolve().parent.parent / "models"
+
+
+def _resolve_project_ids(slugs: tuple[str, ...]) -> dict[str, str]:
+    """Map slug → project_id, опираясь на (user_id, slug) UNIQUE.
+
+    Не вызываем get_project_by_slug т.к. он требует user_id; в БД slug
+    уникален в пределах юзера, но для demo-проектов слаги тоже уникальны
+    глобально (seed_demo_workspace зашивает их жёстко). Делаем один
+    SELECT и матчим по slug — этого достаточно.
+    """
+    placeholders = ", ".join(f":s{i}" for i in range(len(slugs)))
+    params = {f"s{i}": slug for i, slug in enumerate(slugs)}
+    with get_engine().connect() as conn:
+        rows = conn.execute(
+            text(f"SELECT id, slug FROM projects WHERE slug IN ({placeholders})"),
+            params,
+        ).fetchall()
+    return {row[1]: row[0] for row in rows}
+
+
+def _count(query: str, **params) -> int:
+    with get_engine().connect() as conn:
+        return int(conn.execute(text(query), params).scalar() or 0)
+
+
+def verify_project(project_id: str) -> dict:
+    """Простой COUNT(*) per artefact для подтверждения что warmup отработал.
+
+    Возвращает dict с полями для readable-печати + acceptance-asserts в тестах.
+    """
+    metrics = _count(
+        "SELECT COUNT(*) FROM metrics WHERE project_id = :pid",
+        pid=project_id,
+    )
+    anomalies = _count(
+        "SELECT COUNT(*) FROM anomaly_scores WHERE project_id = :pid",
+        pid=project_id,
+    )
+    changepoints = _count(
+        "SELECT COUNT(*) FROM changepoints WHERE project_id = :pid",
+        pid=project_id,
+    )
+    drift = _count(
+        "SELECT COUNT(*) FROM drift_reports WHERE project_id = :pid",
+        pid=project_id,
+    )
+    notifications = _count(
+        "SELECT COUNT(*) FROM notifications WHERE project_id = :pid",
+        pid=project_id,
+    )
+    # ML модели лежат плоско в models/ с именами вида
+    # ``<safe_project_id>__<table>__<metric>.joblib`` (forecast) и
+    # ``<safe_project_id>__<table>__anomaly.joblib`` (IsolationForest) —
+    # см. ml/forecast.py::_model_path и ml/anomaly_detector.py::_model_path.
+    safe = project_id.replace("/", "_").replace(" ", "_")
+    forecast_models = (
+        sum(1 for _ in MODELS_DIR.glob(f"{safe}__*.joblib"))
+        if MODELS_DIR.exists() else 0
+    )
+    return {
+        "metrics": metrics,
+        "anomaly_scores": anomalies,
+        "changepoints": changepoints,
+        "drift_reports": drift,
+        "notifications": notifications,
+        "forecast_models": forecast_models,
+    }
+
+
+def prepare_one(project_id: str, *, days: int, interval_minutes: int) -> dict:
+    """Один проход seed_metrics_db + warmup_ml для конкретного project_id.
+
+    Не закладываем idempotency через --reset — оператор сам решает. Если
+    хочешь чистый прогон, удали данные через storage или передай reset=True
+    в seed_metrics_db.main (тут вызываем с reset=True по умолчанию — demo
+    подготовка обычно чистая).
+    """
+    from scripts import seed_metrics_db, warmup_ml
+
+    logger.info("[%s] seed_metrics_db: %d days × %d min", project_id, days, interval_minutes)
+    seed_result = seed_metrics_db.main(
+        days=days,
+        interval_minutes=interval_minutes,
+        reset=True,
+        project_id=project_id,
+    )
+    logger.info("[%s] warmup_ml", project_id)
+    warmup_result = warmup_ml.main(project_id=project_id)
+    return {"seed": seed_result, "warmup": warmup_result}
+
+
+def main(
+    slugs: tuple[str, ...] = DEFAULT_SLUGS,
+    *,
+    days: int = 14,
+    interval_minutes: int = 60,
+    skip_workspace: bool = False,
+) -> dict:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if not skip_workspace:
+        from scripts.seed_demo_workspace import seed_demo_workspace
+
+        logger.info("Ensuring demo workspace (users / projects / connections)...")
+        seed_demo_workspace()
+
+    resolved = _resolve_project_ids(slugs)
+    missing = [s for s in slugs if s not in resolved]
+    if missing:
+        logger.error("Slugs not found in DB: %s — run seed_demo_workspace first", missing)
+        sys.exit(2)
+
+    results = {}
+    for slug, project_id in resolved.items():
+        logger.info("\n=== Preparing %s (project_id=%s) ===", slug, project_id)
+        prepare_one(project_id, days=days, interval_minutes=interval_minutes)
+        results[slug] = verify_project(project_id)
+
+    # Summary table.
+    print()
+    print(f"{'Project':<25} {'metrics':>9} {'anomaly':>9} {'cps':>5} "
+          f"{'drift':>6} {'notif':>6} {'models':>7}")
+    print("-" * 70)
+    for slug, v in results.items():
+        print(
+            f"{slug:<25} {v['metrics']:>9} {v['anomaly_scores']:>9} "
+            f"{v['changepoints']:>5} {v['drift_reports']:>6} "
+            f"{v['notifications']:>6} {v['forecast_models']:>7}"
+        )
+    return results
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--slug", action="append", dest="slugs",
+        help="Slug demo-проекта (по умолчанию: retail-postgres). Можно повторять.",
+    )
+    parser.add_argument("--days", type=int, default=14)
+    parser.add_argument("--interval-minutes", type=int, default=60)
+    parser.add_argument(
+        "--skip-workspace", action="store_true",
+        help="Пропустить seed_demo_workspace — если уверен, что user/project/conn уже есть.",
+    )
+    args = parser.parse_args()
+
+    slugs = tuple(args.slugs) if args.slugs else DEFAULT_SLUGS
+    main(
+        slugs=slugs,
+        days=args.days,
+        interval_minutes=args.interval_minutes,
+        skip_workspace=args.skip_workspace,
+    )

--- a/tests/test_demo_prepare.py
+++ b/tests/test_demo_prepare.py
@@ -1,0 +1,212 @@
+"""Tests for scripts/demo_prepare.py (#176).
+
+End-to-end на SQLite metrics store — без поднятия Postgres / Docker.
+Покрывает acceptance:
+- 14-day history backfilled for the project_id
+- ML warmup populates anomaly_scores, changepoints, drift_reports
+- verify_project returns non-zero counters
+- forecast model files appear in models/<project>__*.joblib
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app import crypto, metrics_storage
+from scripts import demo_prepare
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    from cryptography.fernet import Fernet
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    """Fresh SQLite metrics + isolated MODELS_DIR per test."""
+    import app.metrics_storage as ms
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "demo.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+
+    # Force scripts.demo_prepare's MODELS_DIR pointer to tmp so persisted
+    # joblibs don't leak between tests / repo.
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    monkeypatch.setattr(demo_prepare, "MODELS_DIR", models_dir)
+
+    # The actual writers live in ml.forecast and ml.anomaly_detector.
+    import ml.anomaly_detector as anomaly_mod
+    import ml.forecast as forecast_mod
+    monkeypatch.setattr(forecast_mod, "MODELS_DIR", models_dir)
+    monkeypatch.setattr(anomaly_mod, "MODELS_DIR", models_dir)
+
+    return ms
+
+
+def _make_project(slug: str = "retail-postgres") -> str:
+    uid = uuid.uuid4().hex
+    metrics_storage.create_user(
+        user_id=uid, email=f"u-{uid[:6]}@x.io", password_hash="x",
+    )
+    project = metrics_storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=uid, name="P", slug=slug,
+    )
+    return project["id"]
+
+
+# ── _resolve_project_ids ───────────────────────────────────────────────────
+
+
+def test_resolve_project_ids_returns_mapping(storage):
+    pid = _make_project("retail-postgres")
+    out = demo_prepare._resolve_project_ids(("retail-postgres",))
+    assert out == {"retail-postgres": pid}
+
+
+def test_resolve_project_ids_missing_slug_omitted(storage):
+    _make_project("retail-postgres")
+    out = demo_prepare._resolve_project_ids(("retail-postgres", "ghost"))
+    assert "retail-postgres" in out
+    assert "ghost" not in out
+
+
+# ── verify_project on empty + populated DB ─────────────────────────────────
+
+
+def test_verify_project_zeros_on_empty(storage):
+    pid = _make_project()
+    v = demo_prepare.verify_project(pid)
+    assert v == {
+        "metrics": 0,
+        "anomaly_scores": 0,
+        "changepoints": 0,
+        "drift_reports": 0,
+        "notifications": 0,
+        "forecast_models": 0,
+    }
+
+
+def test_verify_project_counts_metrics_and_models(storage, tmp_path):
+    """Insert synthetic rows directly + drop a fake joblib → counts non-zero."""
+    from datetime import UTC, datetime
+
+    pid = _make_project()
+
+    # Insert one metric row directly through the storage API.
+    metrics_storage.save_metrics([{
+        "ts": datetime.now(UTC),
+        "table_name": "users",
+        "metric_name": "row_count",
+        "value": 100.0,
+    }], pid)
+
+    # Touch a fake forecast model file matching the naming convention
+    # used by ml/forecast.py::_model_path.
+    safe = pid.replace("/", "_").replace(" ", "_")
+    (demo_prepare.MODELS_DIR / f"{safe}__users__row_count.joblib").touch()
+    # And one anomaly file.
+    (demo_prepare.MODELS_DIR / f"{safe}__users__anomaly.joblib").touch()
+
+    v = demo_prepare.verify_project(pid)
+    assert v["metrics"] == 1
+    assert v["forecast_models"] == 2
+
+
+def test_verify_project_isolated_across_tenants(storage):
+    """Project A's counts must not bleed into project B's verify_project."""
+    from datetime import UTC, datetime
+
+    pid_a = _make_project("retail-postgres")
+    pid_b = _make_project("other-project")
+    metrics_storage.save_metrics([{
+        "ts": datetime.now(UTC), "table_name": "users",
+        "metric_name": "row_count", "value": 1.0,
+    }], pid_a)
+    assert demo_prepare.verify_project(pid_a)["metrics"] == 1
+    assert demo_prepare.verify_project(pid_b)["metrics"] == 0
+
+
+# ── prepare_one (orchestrator → seed + warmup) ─────────────────────────────
+
+
+def test_prepare_one_calls_seed_then_warmup(storage, monkeypatch):
+    """End-to-end stub: prepare_one(pid) → seed_metrics_db.main + warmup_ml.main
+    called in order with the right project_id."""
+    pid = _make_project()
+    calls = []
+
+    def fake_seed(days, interval_minutes, reset, project_id):
+        calls.append(("seed", project_id, days))
+        return {"snapshots": 1, "rows": 100}
+
+    def fake_warmup(project_id="legacy"):
+        calls.append(("warmup", project_id))
+        return {"forecasts": {}, "anomalies": {}, "changepoints": {}, "drift": {}}
+
+    from scripts import seed_metrics_db, warmup_ml
+    monkeypatch.setattr(seed_metrics_db, "main", fake_seed)
+    monkeypatch.setattr(warmup_ml, "main", fake_warmup)
+
+    demo_prepare.prepare_one(pid, days=14, interval_minutes=60)
+
+    assert calls == [("seed", pid, 14), ("warmup", pid)]
+
+
+# ── main() orchestration ───────────────────────────────────────────────────
+
+
+def test_main_runs_per_slug_and_returns_verify_per_slug(storage, monkeypatch):
+    """main() — orchestrates all configured slugs and returns the
+    verification dict keyed by slug. Stubs out the heavy ML lifting so
+    the test stays fast and DB-only."""
+    pid_postgres = _make_project("retail-postgres")
+    pid_ch = _make_project("events-clickhouse")
+
+    monkeypatch.setattr(
+        "scripts.seed_metrics_db.main",
+        lambda **kw: {"rows": 0},
+    )
+    monkeypatch.setattr(
+        "scripts.warmup_ml.main",
+        lambda project_id="legacy": {},
+    )
+
+    out = demo_prepare.main(
+        slugs=("retail-postgres", "events-clickhouse"),
+        days=1,
+        interval_minutes=60,
+        skip_workspace=True,
+    )
+
+    assert set(out.keys()) == {"retail-postgres", "events-clickhouse"}
+    assert all("metrics" in v for v in out.values())
+    # Both project_ids resolved successfully — no SystemExit on missing slug.
+    _ = pid_postgres, pid_ch
+
+
+def test_main_exits_when_slug_missing(storage, monkeypatch):
+    """If a requested slug doesn't exist in DB, exit(2). The caller must
+    run seed_demo_workspace before demo_prepare for new slugs."""
+    monkeypatch.setattr(
+        "scripts.seed_metrics_db.main",
+        lambda **kw: {"rows": 0},
+    )
+    monkeypatch.setattr(
+        "scripts.warmup_ml.main",
+        lambda project_id="legacy": {},
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        demo_prepare.main(
+            slugs=("never-seeded",),
+            skip_workspace=True,
+        )
+    assert exc_info.value.code == 2


### PR DESCRIPTION
Closes #176. Acceptance: после одной команды графики не пустые, forecast включается, anomaly KPI не нулевой, history полна, ML-блок показывает last run.

## Что внутри

### `scripts/demo_prepare.py` — orchestrator
Поверх трёх готовых скриптов: `seed_demo_workspace → seed_metrics_db → warmup_ml`. Резолвит project_id по slug через прямой SELECT, гоняет цикл, в конце печатает counter-таблицу для acceptance-проверки на глаз.

Скоуп по умолчанию — только `retail-postgres`. CH/Iceberg остались bonus-вариантом потому что `seed_metrics_db.py` читает схему из глобального `DATABASE_URL` — без `using_engine` override CH/Iceberg проекты получат метрики Postgres-таблиц. Это отдельная инфра, out of scope #176.

### `verify_project(pid)`
COUNT(*) по 6 артефактам: metrics, anomaly_scores, changepoints, drift_reports, notifications + forecast models на диске (glob по `safe_project_id__*.joblib`). Все ненулевые = демо готово.

### Makefile + CHECKLIST
- `make demo-prepare` (опционально через `ARGS=`)
- `CHECKLIST.md` шаг 6 обновлён — одна команда вместо четырёх. Сами компоненты остались, `demo-prepare` это sugar поверх них.

## Тесты (8 кейсов)

`tests/test_demo_prepare.py`:
- `_resolve_project_ids` возвращает `{slug: id}`, missing — omitted
- `verify_project` на пустой БД → все нули
- `verify_project` считает metrics + forecast models после подсадки
- Cross-tenant изоляция: project A counters не текут в project B
- `prepare_one` вызывает seed → warmup в правильном порядке с правильным pid
- `main()` орхестрирует по каждому slug, возвращает dict с verify результатами
- `main()` с несуществующим slug → `SystemExit(2)`

## Live smoke

Реальный Postgres + 2 таблицы × 14 дней:

```
Project                     metrics   anomaly   cps  drift  notif  models
----------------------------------------------------------------------
retail-postgres                5138       670     6      7     10       4
```

Все 6 счётчиков ненулевые — acceptance выполнен.

## Acceptance из тикета

- [x] Засеять историю метрик для demo projects (один проект; CH/Iceberg — future)
- [x] Запустить warmup ML для каждого project_id
- [x] Проверить forecast models (forecast_models=4)
- [x] Проверить anomaly scores (anomaly_scores=670)
- [x] Проверить changepoints/drift (cps=6, drift=7)
- [ ] "Проверить /dashboard/history" — endpoint работает, в нём live-фид notifications. Manual smoke в браузере, не автоматизируется в тесте (UI-тест отдельной историей)

## Verification

- **633 passed** (+8 от #176)
- ruff clean
- Live smoke зелёный на реальном Postgres datasete