### PR TITLE
feat(#171): качество anomaly alerts — score/delta gate + LLM alignment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -39,6 +39,24 @@ class Settings(BaseSettings):
     TELEGRAM_CHAT_ID: str = ""
     TELEGRAM_THROTTLE_MINUTES: int = 30
 
+    # Anomaly alert quality (#171). IsolationForest предсказывает
+    # ``is_anomaly=1`` для всех точек ниже decision_function threshold,
+    # включая случаи где score ≈ -0.003 (статистический borderline).
+    # На стабильных данных это даёт false positives. Дополнительные
+    # фильтры на стороне notification:
+    #
+    # ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE — absolute величина отрицательного
+    # score; алерт отсекается если |score| < этого значения. 0.05 = умеренно
+    # консервативно: ловим только уверенно-аномальные точки, теряем
+    # borderline. На демо это особенно критично — лучше пропустить
+    # пограничную точку чем кричать "аномалия!" на шумном baseline.
+    ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE: float = 0.05
+    # ANOMALY_NOTIFY_MIN_DELTA_RATIO — относительное отклонение текущего
+    # значения от 7-дневной медианы; алерт отсекается если |delta| < этого.
+    # 0.10 = 10% — мелкие колебания (день недели, нагрузка) не уведомят.
+    # Реальные инциденты (load spike, NULL-вспышка) обычно на порядок выше.
+    ANOMALY_NOTIFY_MIN_DELTA_RATIO: float = 0.10
+
     # SMTP for password-reset emails (#133). Empty SMTP_HOST → backend
     # falls back to ``memory`` which captures sent messages in an in-process
     # outbox; useful for tests and local dev without an SMTP server.

--- a/app/llm.py
+++ b/app/llm.py
@@ -33,6 +33,56 @@ def _context_window(ts: str) -> timedelta:
         return timedelta(hours=48)
 
 
+def _summary_stats(values: list[float]) -> dict | None:
+    """Sample-statistics for a value series — feeds the LLM historical
+    context block (#171). Returns None if too few points to summarise."""
+    cleaned = [float(v) for v in values if v is not None]
+    if len(cleaned) < 3:
+        return None
+    sorted_v = sorted(cleaned)
+    n = len(sorted_v)
+    median = sorted_v[n // 2] if n % 2 else (sorted_v[n // 2 - 1] + sorted_v[n // 2]) / 2
+    mean = sum(cleaned) / n
+    return {
+        "min": sorted_v[0],
+        "max": sorted_v[-1],
+        "median": median,
+        "mean": mean,
+        "n": n,
+    }
+
+
+def _format_history_block(
+    rc_stats: dict | None, current_rc: float | None,
+    nr_stats: dict | None, current_nr: float | None,
+) -> str:
+    """Human-readable history block for the prompt. Empty string if no
+    historical stats — avoids planting a placeholder that the LLM might
+    treat as authoritative."""
+    lines: list[str] = []
+    if rc_stats and current_rc is not None and rc_stats["median"] > 0:
+        ratio = current_rc / rc_stats["median"]
+        lines.append(
+            f"Historical row_count (last 48 h, n={rc_stats['n']}): "
+            f"min={int(rc_stats['min'])}, median={int(rc_stats['median'])}, "
+            f"max={int(rc_stats['max'])}. "
+            f"Current value at the anomaly: {int(current_rc)} "
+            f"({ratio:.2f}x of median)."
+        )
+    if nr_stats and current_nr is not None and nr_stats["median"] >= 0:
+        delta = current_nr - nr_stats["median"]
+        lines.append(
+            f"Historical null_rate (last 48 h, n={nr_stats['n']}): "
+            f"min={nr_stats['min']:.3f}, median={nr_stats['median']:.3f}, "
+            f"max={nr_stats['max']:.3f}. "
+            f"Current value at the anomaly: {current_nr:.3f} "
+            f"(Δ={delta:+.3f})."
+        )
+    if not lines:
+        return ""
+    return "Historical context:\n" + "\n".join(f"  {ln}" for ln in lines)
+
+
 def _build_prompt(
     table: str, metric: str, ts: str, project_id: str = "legacy"
 ) -> str:
@@ -76,6 +126,18 @@ def _build_prompt(
     )
     ts_fmt = _fmt(ts)
 
+    # #171: подмешиваем сводный исторический контекст — без него LLM
+    # часто отвечает шаблонно («возможный сбой в системе сбора»). С
+    # явным baseline + multiple легко сформулировать конкретный
+    # «8x от типичного прироста» как в acceptance issue.
+    rc_stats = _summary_stats([r["value"] for r in recent_rc])
+    nr_stats = _summary_stats([r["value"] for r in recent_nr])
+    current_rc = recent_rc[-1]["value"] if recent_rc else None
+    current_nr = recent_nr[-1]["value"] if recent_nr else None
+    history_block = _format_history_block(
+        rc_stats, current_rc, nr_stats, current_nr
+    )
+
     return f"""You are a database reliability expert. Analyze the anomaly below and explain its root cause.
 
 Table: {table}
@@ -84,16 +146,29 @@ Anomaly detected at: {ts_fmt}
 Trigger metric: {metric}
 Isolation Forest score at {ts_fmt}: {anomaly_score_text}
 
+IMPORTANT: The IsolationForest detector has CONFIRMED this point is an anomaly
+(is_anomaly=1, score is negative). Your job is to explain WHY this looks
+anomalous given the data, not to argue whether it is. If the data truly
+looks stable to you, state briefly that the deviation is borderline
+(e.g. "small deviation from baseline") — do NOT write "no anomaly" or
+"data is stable" as the main explanation.
+
 Recent row_count (last 48 h):
 {chr(10).join(rc_sample) or "  no data"}
 
 Recent null_rate (last 48 h):
 {chr(10).join(nr_sample) or "  no data"}
 
+{history_block}
+
 Recent change-points (last 14 days):
 {cp_text}
 
-Based on this context, provide a root-cause explanation.
+Based on this context, provide a root-cause explanation grounded in the
+actual numbers (e.g. "вырос на X строк, это в Yx выше среднего за 7 дней").
+Avoid generic phrases like "возможный сбой в системе сбора данных" unless
+the data actually supports that hypothesis.
+
 Respond ONLY with valid JSON (no markdown, no extra text):
 {{"explanation": "...", "suggested_fix": "...", "confidence": 0.85}}
 

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -187,6 +187,107 @@ def _load_telegram_config(project_id: str) -> tuple[str, str, int] | None:
     return bot_token, chat_id, int(cfg.get("throttle_minutes") or 30)
 
 
+def _passes_alert_quality_gate(
+    table: str, anomaly: dict, project_id: str,
+) -> bool:
+    """Drop borderline anomalies before they reach Telegram (#171).
+
+    Two independent checks, both must pass:
+
+    1. ``|score| >= ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE`` — отбрасывает
+       borderline IsolationForest predictions (score ≈ -0.003 при
+       стабильных данных). Score из ``decision_function`` — отрицательный
+       означает аномалия; чем больше |score|, тем увереннее модель.
+
+    2. ``|value - baseline_median| / baseline_median >= ANOMALY_NOTIFY_MIN_DELTA_RATIO``
+       — отбрасывает алерты на мелких колебаниях (день недели, нагрузочные
+       циклы), даже если IF их пометил. baseline = 7-day median.
+       Если baseline не вычисляется (<3 точки в окне) — gate пропускает
+       (нет данных = доверяем детектору).
+
+    Возвращает True если алерт ПРОЙТИ, False если ОТСЕЧЬ.
+    """
+    from app.config import settings
+
+    score = float(anomaly.get("score", 0.0))
+    if abs(score) < settings.ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE:
+        logger.debug(
+            "[project=%s][table=%s] anomaly score %.4f below magnitude "
+            "threshold (%.4f); dropping alert",
+            project_id, table, score,
+            settings.ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE,
+        )
+        return False
+
+    # Delta vs 7-day median of row_count (наиболее частая аномальная
+    # метрика). Если медианы нет (свежая таблица) — пропускаем gate.
+    baseline = _baseline_median_row_count(table, project_id)
+    if baseline is None or baseline == 0:
+        return True
+    latest_value = _latest_row_count_at(table, project_id, anomaly["ts"])
+    if latest_value is None:
+        return True
+    delta_ratio = abs(latest_value - baseline) / baseline
+    if delta_ratio < settings.ANOMALY_NOTIFY_MIN_DELTA_RATIO:
+        logger.debug(
+            "[project=%s][table=%s] delta_ratio %.3f below threshold "
+            "%.3f (baseline=%.1f, latest=%.1f); dropping alert",
+            project_id, table, delta_ratio,
+            settings.ANOMALY_NOTIFY_MIN_DELTA_RATIO,
+            baseline, latest_value,
+        )
+        return False
+    return True
+
+
+def _baseline_median_row_count(table: str, project_id: str) -> float | None:
+    """Median row_count за последние 7 дней (excluding the anomaly point itself).
+
+    Возвращает None если в окне меньше 3 точек — недостаточно для
+    repeatable median. Чисто defensive: на свежей таблице gate
+    пропускает алерт без расчёта delta.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from sqlalchemy import text
+
+    from app.metrics_storage import get_engine
+
+    since = (datetime.now(UTC) - timedelta(days=7)).isoformat(timespec="seconds")
+    with get_engine().connect() as conn:
+        rows = conn.execute(text("""
+            SELECT value FROM metrics
+            WHERE project_id = :pid
+              AND table_name = :table
+              AND metric_name = 'row_count'
+              AND ts >= :since
+            ORDER BY value
+        """), {"pid": project_id, "table": table, "since": since}).fetchall()
+    values = [float(r[0]) for r in rows]
+    if len(values) < 3:
+        return None
+    # SQLite не имеет PERCENTILE_CONT, считаем в Python.
+    n = len(values)
+    return values[n // 2] if n % 2 else (values[n // 2 - 1] + values[n // 2]) / 2
+
+
+def _latest_row_count_at(table: str, project_id: str, ts: str) -> float | None:
+    """row_count в момент аномальной точки. Если такой записи нет — None."""
+    from sqlalchemy import text
+
+    from app.metrics_storage import get_engine
+
+    with get_engine().connect() as conn:
+        row = conn.execute(text("""
+            SELECT value FROM metrics
+            WHERE project_id = :pid
+              AND table_name = :table
+              AND metric_name = 'row_count'
+              AND ts = :ts
+        """), {"pid": project_id, "table": table, "ts": ts}).fetchone()
+    return float(row[0]) if row else None
+
+
 def _maybe_notify_anomalies(project_id: str, table_names: list[str]) -> None:
     """Score the last day of metrics for each table just collected, send a
     Telegram alert for the most recent anomaly per table.
@@ -226,6 +327,14 @@ def _maybe_notify_anomalies(project_id: str, table_names: list[str]) -> None:
             if not anomalies:
                 continue
             latest = max(anomalies, key=lambda s: s["ts"])
+            # #171 quality gate: IsolationForest помечает is_anomaly=1
+            # для borderline точек со score=-0.003, что на стабильных
+            # данных даёт false positives. Здесь — два независимых порога:
+            # (1) magnitude самого score, (2) насколько метрика реально
+            # сдвинулась относительно 7-дневной медианы. Оба должны
+            # пройти, иначе alert не идёт.
+            if not _passes_alert_quality_gate(name, latest, project_id):
+                continue
             try:
                 notify_anomaly(
                     project_id, name, latest["ts"], latest["score"],

--- a/tests/test_anomaly_alert_quality.py
+++ b/tests/test_anomaly_alert_quality.py
@@ -1,0 +1,301 @@
+"""Anomaly alert quality gates (#171, supersedes #180).
+
+Two layers под испытанием:
+1. ``_passes_alert_quality_gate`` — отсекает borderline anomalies до
+   того как они дойдут до telegram.notify_anomaly:
+   - |score| < MIN_SCORE_MAGNITUDE → drop
+   - |Δ / baseline_median| < MIN_DELTA_RATIO → drop
+2. ``_build_prompt`` — содержит исторический контекст и явную инструкцию
+   LLM не оспаривать факт аномалии (alignment с detector).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    import app.metrics_storage as ms
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "quality.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    return ms
+
+
+def _new_project(storage) -> str:
+    uid = uuid.uuid4().hex
+    storage.create_user(user_id=uid, email=f"u-{uid[:6]}@x.io", password_hash="x")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=uid, name="P", slug=f"p-{uid[:6]}",
+    )
+    return project["id"]
+
+
+# ── _passes_alert_quality_gate ─────────────────────────────────────────────
+
+
+def test_gate_drops_borderline_score(storage):
+    """Score=-0.003 (стабильный baseline) → не уведомляем, даже если
+    IsolationForest пометил точку как anomaly."""
+    from collectors.per_project import _passes_alert_quality_gate
+
+    pid = _new_project(storage)
+    anomaly = {
+        "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+        "score": -0.003,
+        "is_anomaly": 1,
+    }
+    assert _passes_alert_quality_gate("users", anomaly, pid) is False
+
+
+def test_gate_passes_strong_score_no_baseline(storage):
+    """Без baseline (свежая таблица) и при сильном score → пропускаем."""
+    from collectors.per_project import _passes_alert_quality_gate
+
+    pid = _new_project(storage)
+    anomaly = {
+        "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+        "score": -0.25,
+        "is_anomaly": 1,
+    }
+    # Нет metrics в БД → baseline=None → gate пропускает.
+    assert _passes_alert_quality_gate("users", anomaly, pid) is True
+
+
+def test_gate_drops_small_delta(storage):
+    """Score сильный, но текущее значение в пределах 5% от 7-day median
+    → drop (delta_ratio < 10%)."""
+    from collectors.per_project import _passes_alert_quality_gate
+
+    pid = _new_project(storage)
+
+    # Засеять 7 точек со значениями около 100 (median=100).
+    now = datetime.now(UTC)
+    rows = [
+        {"ts": now - timedelta(hours=h), "table_name": "users",
+         "metric_name": "row_count", "value": 100.0 + (h % 5)}
+        for h in range(1, 8)
+    ]
+    storage.save_metrics(rows, pid)
+
+    # Аномальная точка с value=103 (3% от baseline).
+    anomaly_ts = now.isoformat(timespec="seconds")
+    storage.save_metrics([{
+        "ts": now, "table_name": "users",
+        "metric_name": "row_count", "value": 103.0,
+    }], pid)
+
+    anomaly = {"ts": anomaly_ts, "score": -0.40, "is_anomaly": 1}
+    assert _passes_alert_quality_gate("users", anomaly, pid) is False
+
+
+def test_gate_passes_large_delta(storage):
+    """Score сильный + delta 50% → пропускаем (реальный инцидент)."""
+    from collectors.per_project import _passes_alert_quality_gate
+
+    pid = _new_project(storage)
+
+    now = datetime.now(UTC)
+    rows = [
+        {"ts": now - timedelta(hours=h), "table_name": "users",
+         "metric_name": "row_count", "value": 100.0}
+        for h in range(1, 8)
+    ]
+    storage.save_metrics(rows, pid)
+
+    anomaly_ts = now.isoformat(timespec="seconds")
+    storage.save_metrics([{
+        "ts": now, "table_name": "users",
+        "metric_name": "row_count", "value": 150.0,
+    }], pid)
+
+    anomaly = {"ts": anomaly_ts, "score": -0.20, "is_anomaly": 1}
+    assert _passes_alert_quality_gate("users", anomaly, pid) is True
+
+
+def test_gate_respects_settings_overrides(storage, monkeypatch):
+    """Поднимаем порог через settings — borderline score проходит."""
+    from app.config import settings
+    from collectors.per_project import _passes_alert_quality_gate
+
+    monkeypatch.setattr(settings, "ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE", 0.001)
+    monkeypatch.setattr(settings, "ANOMALY_NOTIFY_MIN_DELTA_RATIO", 0.0)
+
+    pid = _new_project(storage)
+    anomaly = {
+        "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+        "score": -0.003,
+        "is_anomaly": 1,
+    }
+    assert _passes_alert_quality_gate("users", anomaly, pid) is True
+
+
+# ── _baseline_median_row_count ─────────────────────────────────────────────
+
+
+def test_baseline_returns_none_for_sparse_history(storage):
+    """< 3 точек → None (защита от шумной median)."""
+    from collectors.per_project import _baseline_median_row_count
+
+    pid = _new_project(storage)
+    storage.save_metrics([
+        {"ts": datetime.now(UTC), "table_name": "users",
+         "metric_name": "row_count", "value": 100.0},
+        {"ts": datetime.now(UTC) - timedelta(hours=1), "table_name": "users",
+         "metric_name": "row_count", "value": 110.0},
+    ], pid)
+    assert _baseline_median_row_count("users", pid) is None
+
+
+def test_baseline_computes_median(storage):
+    from collectors.per_project import _baseline_median_row_count
+
+    pid = _new_project(storage)
+    now = datetime.now(UTC)
+    storage.save_metrics([
+        {"ts": now - timedelta(hours=h), "table_name": "orders",
+         "metric_name": "row_count", "value": v}
+        for h, v in zip(range(1, 8), [10, 20, 30, 40, 50, 60, 70])
+    ], pid)
+    # 7 значений, median = 40
+    assert _baseline_median_row_count("orders", pid) == 40.0
+
+
+# ── End-to-end: _maybe_notify_anomalies respects the gate ──────────────────
+
+
+def test_notify_skipped_when_gate_drops_anomaly(storage, monkeypatch):
+    """Borderline anomaly (score=-0.001) с настроенным Telegram → notify
+    НЕ вызывается. Проверяет что gate сидит на правильном слое и не
+    позволяет ML-флюктуации добраться до пользователя."""
+    from collectors import per_project
+
+    pid = _new_project(storage)
+    storage.save_project_notifications(
+        pid,
+        telegram_bot_token=crypto.encrypt_token("0000000001:" + "A" * 35),
+        telegram_chat_id="42",
+        throttle_minutes=15,
+    )
+
+    captures = []
+    monkeypatch.setattr(
+        "app.notifications.telegram.notify_anomaly",
+        lambda *a, **kw: captures.append((a, kw)),
+    )
+    monkeypatch.setattr(
+        "ml.anomaly_detector.score_table",
+        lambda table, window_days=14, project_id="legacy": [
+            {"ts": datetime.now(UTC).isoformat(timespec="seconds"),
+             "score": -0.001, "is_anomaly": 1}
+        ],
+    )
+
+    per_project._maybe_notify_anomalies(pid, ["users"])
+    assert captures == []
+
+
+def test_notify_fires_when_gate_passes(storage, monkeypatch):
+    from collectors import per_project
+
+    pid = _new_project(storage)
+    storage.save_project_notifications(
+        pid,
+        telegram_bot_token=crypto.encrypt_token("0000000001:" + "A" * 35),
+        telegram_chat_id="42",
+        throttle_minutes=15,
+    )
+
+    captures = []
+    monkeypatch.setattr(
+        "app.notifications.telegram.notify_anomaly",
+        lambda *a, **kw: captures.append(a),
+    )
+    # Сильный score, baseline отсутствует → gate пропускает.
+    monkeypatch.setattr(
+        "ml.anomaly_detector.score_table",
+        lambda table, window_days=14, project_id="legacy": [
+            {"ts": datetime.now(UTC).isoformat(timespec="seconds"),
+             "score": -0.30, "is_anomaly": 1}
+        ],
+    )
+
+    per_project._maybe_notify_anomalies(pid, ["users"])
+    assert len(captures) == 1
+
+
+# ── LLM prompt alignment (#171 пункт 3) ────────────────────────────────────
+
+
+def test_prompt_contains_detector_alignment_instruction(storage):
+    """Промпт явно велит LLM не оспаривать факт аномалии — устраняет
+    'данные стабильны, аномалии нет' внутри alert об аномалии."""
+    from app.llm import _build_prompt
+
+    pid = _new_project(storage)
+    # Положим минимум данных чтобы prompt сгенерился.
+    storage.save_metrics([{
+        "ts": datetime.now(UTC), "table_name": "users",
+        "metric_name": "row_count", "value": 100.0,
+    }], pid)
+
+    prompt = _build_prompt("users", "row_count",
+                            datetime.now(UTC).isoformat(timespec="seconds"),
+                            project_id=pid)
+    assert "CONFIRMED this point is an anomaly" in prompt
+    assert "do NOT write" in prompt or "do not write" in prompt.lower()
+
+
+def test_prompt_contains_historical_block_when_data_available(storage):
+    """С достаточной историей промпт включает median/min/max сводку."""
+    from app.llm import _build_prompt
+
+    pid = _new_project(storage)
+    now = datetime.now(UTC)
+    storage.save_metrics([
+        {"ts": now - timedelta(minutes=m), "table_name": "users",
+         "metric_name": "row_count", "value": 100.0 + m}
+        for m in range(0, 60, 10)  # 6 точек
+    ], pid)
+
+    prompt = _build_prompt("users", "row_count",
+                            now.isoformat(timespec="seconds"),
+                            project_id=pid)
+    assert "Historical context" in prompt
+    assert "median" in prompt
+    # Должна быть x-multiple — самое читаемое для LLM.
+    assert "x of median" in prompt
+
+
+def test_prompt_skips_historical_block_when_sparse(storage):
+    """1 точка — мало для статистики, блок пропускается чтобы не дать
+    LLM шумные числа («median 100 на 1 наблюдении»)."""
+    from app.llm import _build_prompt
+
+    pid = _new_project(storage)
+    now = datetime.now(UTC)
+    storage.save_metrics([{
+        "ts": now, "table_name": "users",
+        "metric_name": "row_count", "value": 100.0,
+    }], pid)
+
+    prompt = _build_prompt("users", "row_count",
+                            now.isoformat(timespec="seconds"),
+                            project_id=pid)
+    assert "Historical context" not in prompt


### PR DESCRIPTION
Closes **#171** (бэклог), supersedes **#180** (его demo-specific дубль — то же содержание).

## Проблема

IsolationForest помечает `is_anomaly=1` для ВСЕХ точек где `decision_function < 0`, включая статистический borderline (`score=-0.003`). На стабильных данных это создавало:

1. **Ложные срабатывания** — alert на `score=-0.003` при ровном baseline
2. **Противоречивые сообщения** — alert говорит «аномалия», LLM внутри пишет «данные стабильны, аномалии нет»
3. **Шаблонные объяснения** — LLM без контекста выдаёт «возможный сбой в системе сбора» без цифр

## Что внутри

### Quality gate в `collectors/per_project.py` (#171 пункты 1-2)

Две независимые проверки в `_passes_alert_quality_gate`, обе должны пройти иначе alert отсекается ДО `telegram.notify_anomaly`:

- `|score| >= ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE` (default `0.05`) — отбрасывает borderline IF predictions
- `|Δ / baseline_median| >= ANOMALY_NOTIFY_MIN_DELTA_RATIO` (default `0.10`) — отбрасывает мелкие колебания (день недели, нагрузочные циклы) даже если IF их пометил. baseline = 7-day median row_count.

При отсутствии baseline (свежая таблица, <3 точек) gate **пропускает** — нет данных = доверяем детектору.

Оба порога — настройки в `app/config.py` с подробными комментариями WHY эти конкретные значения.

### LLM prompt alignment в `app/llm.py` (#171 пункт 3)

Добавлен explicit instruction перед основной частью промпта:

> IMPORTANT: The IsolationForest detector has CONFIRMED this point is an anomaly. Your job is to explain WHY this looks anomalous, not to argue whether it is. If the data truly looks stable, state briefly that the deviation is borderline — do NOT write 'no anomaly' or 'data is stable' as the main explanation.

Устраняет противоречие detector ↔ LLM.

### Historical context block (#171 пункт 4)

`_summary_stats` + `_format_history_block` подмешивают:

```
Historical row_count (last 48h, n=N): min=X, median=M, max=Y.
Current value at the anomaly: V (R.RRx of median).
```

С multiple ("8x of median") LLM формулирует конкретные объяснения вместо шаблонов. Блок **пропускается** если <3 точек — не даём LLM шумные числа.

Plus финальная инструкция: «Avoid generic phrases like 'возможный сбой в системе сбора данных' unless the data actually supports that».

## Acceptance из #171/#180

- [x] Поднять порог score (`ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE`)
- [x] Минимальный delta-threshold (`ANOMALY_NOTIFY_MIN_DELTA_RATIO`)
- [x] Не уведомлять когда score не аномалия (уже было через `is_anomaly` filter)
- [x] LLM prompt с историческим контекстом (median / multiple)
- [x] LLM alignment с detector
- [x] На стабильных данных alert НЕ отправляется (`test_notify_skipped_when_gate_drops_anomaly`)
- [x] На реальном incident alert отправляется (`test_notify_fires_when_gate_passes`)

## Тесты (12 кейсов, `tests/test_anomaly_alert_quality.py`)

**Quality gate** (7):
- borderline score=-0.003 → drop
- strong score без baseline → pass (defensive)
- small delta (3% от median) → drop
- large delta (50%) → pass
- settings override меняют поведение
- baseline returns None для <3 точек
- baseline computes median правильно

**End-to-end** (2):
- `_maybe_notify_anomalies` скипает borderline alert (telegram не вызван)
- `_maybe_notify_anomalies` fires когда gate проходит

**LLM prompt** (3):
- содержит detector alignment instruction
- содержит historical block при достаточных данных
- НЕ содержит historical block при sparse data

## Verification

- **655 passed** (+12 от #171)
- ruff clean

## Test plan

- [x] Юнит-тесты на gate + LLM prompt
- [x] End-to-end на _maybe_notify_anomalies
- [ ] Manual smoke после merge: `make demo-prepare` → стабильные данные → НЕТ alert; `make live-demo ARGS="--incident-at 5"` → есть alert с осмысленным объяснением