### PR TITLE
feat(#172): shared project access — project_members с ролями + CLI + seed

### DIFF
--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -371,6 +371,32 @@ def _migrate_existing_schema(engine: Engine) -> None:
 
     _migrate_project_scoped_ml_tables(engine)
 
+    # #172: backfill project_members for projects that existed before
+    # shared-access landed. Every legacy project's user_id becomes the
+    # owner row. Idempotent: subsequent boots find the row already there
+    # and skip. Runs AFTER the schema CREATE so the table exists.
+    if _table_exists(engine, "projects") and _table_exists(engine, "project_members"):
+        with engine.begin() as conn:
+            existing = conn.execute(text("""
+                SELECT p.id, p.user_id FROM projects p
+                LEFT JOIN project_members m
+                  ON m.project_id = p.id AND m.user_id = p.user_id
+                WHERE m.project_id IS NULL
+            """)).fetchall()
+            if existing:
+                now_iso = _iso(datetime.now(UTC))
+                conn.execute(
+                    text("""
+                        INSERT INTO project_members
+                            (project_id, user_id, role, joined_at)
+                        VALUES (:pid, :uid, 'owner', :ts)
+                    """),
+                    [{"pid": pid, "uid": uid, "ts": now_iso} for pid, uid in existing],
+                )
+                logger.info(
+                    "Backfilled %d owner row(s) into project_members", len(existing),
+                )
+
 
 def _is_optional_timescale_stmt(stmt: str) -> bool:
     normalized = " ".join(stmt.lower().split())
@@ -1818,9 +1844,12 @@ class ProjectSlugTaken(Exception):
 
 
 def create_project(project_id: str, user_id: str, name: str, slug: str) -> dict:
-    """Insert a new project. Raises ProjectSlugTaken on UNIQUE violation.
+    """Insert a new project + auto-add owner row to project_members (#172).
 
-    Slug must already be normalised (lower-cased, URL-safe) by the caller.
+    Raises ProjectSlugTaken on UNIQUE violation. Slug must already be
+    normalised (lower-cased, URL-safe) by the caller. Both inserts run in
+    one transaction — if the owner-row write fails, the project itself is
+    rolled back.
     """
     # Pre-check keeps ProjectSlugTaken trustworthy if future schema adds
     # other UNIQUEs (see same pattern in create_user). Race window is benign:
@@ -1832,13 +1861,20 @@ def create_project(project_id: str, user_id: str, name: str, slug: str) -> dict:
         "id": project_id, "user_id": user_id,
         "name": name, "slug": slug, "created_at": now,
     }
-    stmt = text(
-        "INSERT INTO projects (id, user_id, name, slug, created_at) "
-        "VALUES (:id, :user_id, :name, :slug, :created_at)"
-    )
     try:
         with get_engine().begin() as conn:
-            conn.execute(stmt, payload)
+            conn.execute(text(
+                "INSERT INTO projects (id, user_id, name, slug, created_at) "
+                "VALUES (:id, :user_id, :name, :slug, :created_at)"
+            ), payload)
+            # #172: автор → owner row в project_members. Один INSERT в той
+            # же транзакции. Без него new project не появится в
+            # list_projects_for_user (она walks membership, не owners).
+            conn.execute(text(
+                "INSERT INTO project_members "
+                "(project_id, user_id, role, joined_at) "
+                "VALUES (:pid, :uid, 'owner', :ts)"
+            ), {"pid": project_id, "uid": user_id, "ts": now})
     except IntegrityError:
         if get_project_by_slug(user_id, slug) is not None:
             raise ProjectSlugTaken(slug) from None
@@ -1859,36 +1895,157 @@ def _row_to_project(row) -> dict | None:
 
 
 def get_project_by_slug(user_id: str, slug: str) -> dict | None:
-    """Scoped to user — never returns another user's project even on slug match."""
-    stmt = text(
-        "SELECT id, user_id, name, slug, created_at FROM projects "
-        "WHERE user_id = :user_id AND slug = :slug"
-    )
+    """Scoped to user — returns owned OR shared project matching the slug (#172).
+
+    Slugs unique per OWNER, поэтому при коллизии "user_id владелец И user_id
+    member of another's project with same slug" возвращаем owned-вариант
+    (приоритет). Если у юзера такого собственного нет, проверяем shared.
+    """
+    # Шаг 1: owned shortcut.
     with get_engine().connect() as conn:
-        row = conn.execute(stmt, {"user_id": user_id, "slug": slug}).fetchone()
+        row = conn.execute(text(
+            "SELECT id, user_id, name, slug, created_at FROM projects "
+            "WHERE user_id = :user_id AND slug = :slug"
+        ), {"user_id": user_id, "slug": slug}).fetchone()
+        if row is not None:
+            return _row_to_project(row)
+        # Шаг 2: shared lookup via project_members.
+        row = conn.execute(text(
+            "SELECT p.id, p.user_id, p.name, p.slug, p.created_at "
+            "FROM projects p "
+            "INNER JOIN project_members m ON m.project_id = p.id "
+            "WHERE m.user_id = :user_id AND p.slug = :slug "
+            "LIMIT 1"
+        ), {"user_id": user_id, "slug": slug}).fetchone()
     return _row_to_project(row)
 
 
 def get_project_by_id(user_id: str, project_id: str) -> dict | None:
-    """Scoped to user. Returns None if the project belongs to someone else
-    even when the id is correct — defence against horizontal escalation."""
-    stmt = text(
-        "SELECT id, user_id, name, slug, created_at FROM projects "
-        "WHERE id = :id AND user_id = :user_id"
-    )
+    """Membership-scoped (#172): returns the project iff user_id is owner
+    OR a member. Defends against horizontal escalation — random project_id
+    guesses still don't leak data."""
     with get_engine().connect() as conn:
-        row = conn.execute(stmt, {"id": project_id, "user_id": user_id}).fetchone()
+        row = conn.execute(text(
+            "SELECT p.id, p.user_id, p.name, p.slug, p.created_at "
+            "FROM projects p "
+            "LEFT JOIN project_members m "
+            "  ON m.project_id = p.id AND m.user_id = :user_id "
+            "WHERE p.id = :id AND (p.user_id = :user_id OR m.user_id IS NOT NULL)"
+        ), {"id": project_id, "user_id": user_id}).fetchone()
     return _row_to_project(row)
 
 
 def list_projects_for_user(user_id: str) -> list[dict]:
-    stmt = text(
-        "SELECT id, user_id, name, slug, created_at FROM projects "
-        "WHERE user_id = :user_id ORDER BY created_at"
-    )
+    """Returns owned + shared projects (#172).
+
+    UNION over (owner WHERE user_id) и (member via project_members) с
+    DISTINCT по project_id чтобы owner-row (есть как в projects.user_id,
+    так и в project_members.user_id='owner') не дублировался.
+
+    Поле ``role`` — что у юзера в проекте: 'owner' для своего, иначе
+    значение из project_members. UI потом покажет бейджик роли.
+    """
     with get_engine().connect() as conn:
-        rows = conn.execute(stmt, {"user_id": user_id}).fetchall()
-    return [_row_to_project(r) for r in rows]
+        rows = conn.execute(text("""
+            SELECT p.id, p.user_id, p.name, p.slug, p.created_at,
+                   COALESCE(m.role, 'owner') AS role
+            FROM projects p
+            INNER JOIN project_members m
+              ON m.project_id = p.id AND m.user_id = :user_id
+            ORDER BY p.created_at
+        """), {"user_id": user_id}).fetchall()
+    return [
+        {**(_row_to_project(r) or {}), "role": r[5]}
+        for r in rows
+    ]
+
+
+# --- Project membership (#172) ---------------------------------------------
+
+
+_MEMBER_ROLES = ("owner", "editor", "viewer")
+
+
+class InvalidMemberRole(Exception):
+    """Raised when add_project_member gets a role outside the allowed set."""
+
+
+def add_project_member(
+    project_id: str, user_id: str, role: str = "viewer",
+) -> dict:
+    """Upsert a (project, user, role) row in project_members.
+
+    Идемпотентна — повторный вызов с тем же role вернёт существующую
+    запись без ошибки. Смена роли через тот же вызов c новым role —
+    UPSERT update path. Owner-row создаётся только через create_project,
+    защищаем что нельзя downgrade owner-а через этот вход.
+    """
+    if role not in _MEMBER_ROLES:
+        raise InvalidMemberRole(f"role must be one of {_MEMBER_ROLES}, got {role!r}")
+    now = _iso(datetime.now(UTC))
+    # Не позволяем перезаписать owner-row через этот entry — иначе
+    # remove_project_member([role='owner']) можно отменить, чтобы юзер
+    # перестал быть owner-ом. Защита: проверяем существующий role перед
+    # upsert и отказываемся менять existing owner.
+    existing = get_member_role(project_id, user_id)
+    if existing == "owner" and role != "owner":
+        raise InvalidMemberRole("cannot downgrade owner via add_project_member")
+    stmt = text(_upsert_sql(
+        "project_members",
+        ["project_id", "user_id", "role", "joined_at"],
+        conflict_columns=["project_id", "user_id"],
+    ))
+    with get_engine().begin() as conn:
+        conn.execute(stmt, {
+            "project_id": project_id, "user_id": user_id,
+            "role": role, "joined_at": now,
+        })
+    return {"project_id": project_id, "user_id": user_id, "role": role,
+            "joined_at": now}
+
+
+def remove_project_member(project_id: str, user_id: str) -> bool:
+    """Remove a non-owner member. Owner cannot be removed — он удаляется
+    вместе с проектом через delete_project. Returns True if a row was
+    removed (idempotent: False if нет такой membership)."""
+    if get_member_role(project_id, user_id) == "owner":
+        raise InvalidMemberRole("cannot remove project owner")
+    with get_engine().begin() as conn:
+        result = conn.execute(text(
+            "DELETE FROM project_members "
+            "WHERE project_id = :pid AND user_id = :uid"
+        ), {"pid": project_id, "uid": user_id})
+    return (result.rowcount or 0) > 0
+
+
+def get_member_role(project_id: str, user_id: str) -> str | None:
+    """Return the user's role on the project, or None if no membership.
+    Используется на всех access-проверках вместо ownership."""
+    with get_engine().connect() as conn:
+        row = conn.execute(text(
+            "SELECT role FROM project_members "
+            "WHERE project_id = :pid AND user_id = :uid"
+        ), {"pid": project_id, "uid": user_id}).fetchone()
+    return row[0] if row else None
+
+
+def list_project_members(project_id: str) -> list[dict]:
+    """All members of a project with their roles + email/joined timestamp."""
+    with get_engine().connect() as conn:
+        rows = conn.execute(text("""
+            SELECT pm.user_id, u.email, pm.role, pm.joined_at
+            FROM project_members pm
+            INNER JOIN users u ON u.id = pm.user_id
+            WHERE pm.project_id = :pid
+            ORDER BY pm.joined_at
+        """), {"pid": project_id}).fetchall()
+    return [
+        {
+            "user_id": r[0], "email": r[1],
+            "role": r[2], "joined_at": _normalize_ts(r[3]),
+        }
+        for r in rows
+    ]
 
 
 def delete_project(user_id: str, project_id: str) -> bool:

--- a/app/projects.py
+++ b/app/projects.py
@@ -105,8 +105,16 @@ def new_project():
 
 
 def _require_owned_project(slug: str) -> dict:
-    """Lookup-or-404 scoped to the current user. Centralises the ownership
-    check so every route gets it right by default."""
+    """Lookup-or-404 scoped to the current user. Centralises the access
+    check so every route gets it right by default.
+
+    Despite the historical name (kept to avoid touching dozens of imports),
+    this now allows BOTH owned AND shared projects (#172) — the underlying
+    ``get_project_by_slug`` walks ``project_members`` so any user with a
+    membership row passes. Owner-only mutations (e.g. delete project) must
+    additionally call ``metrics_storage.get_member_role`` and check for
+    ``'owner'`` themselves.
+    """
     project = metrics_storage.get_project_by_slug(current_user.id, slug)
     if project is None:
         abort(404)
@@ -135,6 +143,12 @@ def detail(slug: str):
 @login_required
 def delete(slug: str):
     project = _require_owned_project(slug)
+    # #172: только owner может удалить проект. Editor/viewer member видят
+    # проект (через _require_owned_project), но кнопка должна быть скрыта
+    # на UI; этот защитный 403 — belt-and-braces против прямого POST.
+    role = metrics_storage.get_member_role(project["id"], current_user.id)
+    if role != "owner":
+        abort(403)
     metrics_storage.delete_project(current_user.id, project["id"])
     # If we just deleted the current project, fall back to the first
     # remaining one (or clear the slot — list view will pick again).

--- a/scripts/add_project_member.py
+++ b/scripts/add_project_member.py
@@ -1,0 +1,81 @@
+"""CLI to add a user to a project as a member (#172).
+
+Usage:
+    python -m scripts.add_project_member \
+        --owner demo@dbmonitor.app \
+        --slug retail-postgres \
+        --email demo2@dbmonitor.app \
+        --role editor
+
+Resolves the project by (owner-email, slug) — слаги уникальны per-owner,
+поэтому нужны оба. Если юзер уже состоит в проекте — UPSERT
+обновит его role.
+
+Owner row создаётся автоматически в ``create_project``; этот скрипт —
+только для editor / viewer membership.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from app.metrics_storage import (
+    InvalidMemberRole,
+    add_project_member,
+    get_project_by_slug,
+    get_user_by_email,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--owner", required=True,
+        help="Email владельца проекта (чтобы резолвить slug per-owner)",
+    )
+    parser.add_argument(
+        "--slug", required=True,
+        help="Slug проекта в namespace владельца",
+    )
+    parser.add_argument(
+        "--email", required=True,
+        help="Email пользователя, которого добавляем как члена",
+    )
+    parser.add_argument(
+        "--role", default="editor", choices=("editor", "viewer"),
+        help="Роль (owner создаётся через create_project, не здесь)",
+    )
+    args = parser.parse_args()
+
+    owner = get_user_by_email(args.owner.strip().lower())
+    if owner is None:
+        print(f"FATAL: owner user not found: {args.owner}", file=sys.stderr)
+        return 2
+    project = get_project_by_slug(owner["id"], args.slug)
+    if project is None:
+        print(
+            f"FATAL: project '{args.slug}' not found under owner {args.owner}",
+            file=sys.stderr,
+        )
+        return 2
+    member = get_user_by_email(args.email.strip().lower())
+    if member is None:
+        print(f"FATAL: target user not found: {args.email}", file=sys.stderr)
+        return 2
+
+    try:
+        row = add_project_member(project["id"], member["id"], role=args.role)
+    except InvalidMemberRole as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        f"Added {args.email} to project '{args.slug}' as {row['role']} "
+        f"(project_id={project['id']}, user_id={member['id']})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -184,6 +184,30 @@ CREATE TABLE IF NOT EXISTS projects (
     CHECK (slug = LOWER(slug))
 );
 
+-- Project membership (#172). Допускает несколько юзеров на один проект
+-- с указанием роли. Owner — автор, создаётся автоматически при
+-- create_project. Editor/viewer добавляются вручную через
+-- add_project_member.
+--
+-- Composite PK (project_id, user_id): один пользователь — одна роль
+-- на проект. Чтобы перевести из viewer в editor, делаем UPSERT.
+-- FK CASCADE на projects: удаление проекта чистит membership.
+-- FK CASCADE на users: удаление аккаунта чистит membership.
+CREATE TABLE IF NOT EXISTS project_members (
+    project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role        TEXT NOT NULL CHECK (role IN ('owner', 'editor', 'viewer')),
+    joined_at   TEXT NOT NULL,
+    PRIMARY KEY (project_id, user_id)
+);
+
+-- Поиск "какие проекты доступны юзеру" — основной запрос на каждой
+-- странице (header switcher, /projects/). Композитный PK выше
+-- начинается с project_id, поэтому WHERE user_id=? делает full scan
+-- без отдельного индекса.
+CREATE INDEX IF NOT EXISTS idx_project_members_user
+    ON project_members (user_id);
+
 -- DB connections (#51). Каждый коннект принадлежит проекту (FK с CASCADE).
 -- dsn_encrypted — Fernet ciphertext, BLOB, plaintext НИКОГДА не хранится.
 -- interval_minutes — частота сбора метрик per-connection, 5..1440 минут.

--- a/scripts/seed_demo_workspace.py
+++ b/scripts/seed_demo_workspace.py
@@ -23,6 +23,7 @@ from werkzeug.security import generate_password_hash
 
 from app import crypto, metrics_storage
 from app.config import settings
+from app.metrics_storage import add_project_member
 
 DEFAULT_PASSWORD = "demo12345"
 DEFAULT_CLICKHOUSE_DSN = "clickhouse+native://default@localhost:19000/demo"
@@ -146,6 +147,9 @@ def build_project_specs(
     ]
 
 
+SHARED_DEMO_EMAIL = "guest@dbmonitor.app"
+
+
 def seed_demo_workspace(
     *,
     password: str = DEFAULT_PASSWORD,
@@ -161,7 +165,9 @@ def seed_demo_workspace(
     projects: dict[str, dict] = {}
     connections: dict[str, dict] = {}
 
-    for email in ("demo@dbmonitor.app", "lake@dbmonitor.app"):
+    # #172: SHARED_DEMO_EMAIL добавляется как viewer в retail-postgres.
+    # Демонстрирует "User B видит проект User A в своём списке" из acceptance.
+    for email in ("demo@dbmonitor.app", "lake@dbmonitor.app", SHARED_DEMO_EMAIL):
         users[email] = ensure_user(
             email,
             password,
@@ -178,6 +184,18 @@ def seed_demo_workspace(
         connection = ensure_connection(project["id"], spec.connection)
         projects[spec.slug] = project
         connections[spec.slug] = connection
+
+    # #172: guest@dbmonitor.app — viewer на retail-postgres (проект demo@).
+    # Идемпотентно: add_project_member через UPSERT — повторный вызов
+    # просто оставляет существующий role.
+    try:
+        retail = projects["retail-postgres"]
+        guest_user = users[SHARED_DEMO_EMAIL]
+        add_project_member(retail["id"], guest_user["id"], role="viewer")
+    except KeyError:
+        # На случай если build_project_specs убрал retail-postgres из spec'а
+        # — silently skip, не блокируем seed остальных проектов.
+        pass
 
     return {
         "password": password,

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -164,6 +164,17 @@ CREATE TABLE IF NOT EXISTS projects (
     CHECK (slug = LOWER(slug))
 );
 
+CREATE TABLE IF NOT EXISTS project_members (
+    project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role        TEXT NOT NULL CHECK (role IN ('owner', 'editor', 'viewer')),
+    joined_at   TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (project_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_members_user
+    ON project_members (user_id);
+
 CREATE TABLE IF NOT EXISTS connections (
     id               TEXT NOT NULL PRIMARY KEY,
     project_id       TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,

--- a/tests/test_shared_project_access.py
+++ b/tests/test_shared_project_access.py
@@ -1,0 +1,393 @@
+"""Shared project access tests (#172).
+
+Covers acceptance:
+- User A creates project → owner row автоматом в project_members
+- User B added via add_project_member → видит проект в своём списке
+- User B видит project detail и connections
+- User C без membership получает 404
+- Owner row защищён: нельзя удалить через remove_project_member
+- Non-owner не может удалить проект (route 403)
+- Backfill миграция вставляет owner row для legacy projects
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    import app.metrics_storage as ms
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "shared.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    return ms
+
+
+def _user(storage, email: str) -> str:
+    uid = uuid.uuid4().hex
+    storage.create_user(user_id=uid, email=email, password_hash="x")
+    return uid
+
+
+# ── create_project auto-adds owner row ─────────────────────────────────────
+
+
+def test_create_project_inserts_owner_membership(storage):
+    user_id = _user(storage, "owner@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=user_id,
+        name="P", slug="my-project",
+    )
+    assert storage.get_member_role(project["id"], user_id) == "owner"
+
+
+def test_list_projects_for_user_includes_self_owned(storage):
+    user_id = _user(storage, "owner@example.com")
+    storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=user_id,
+        name="P", slug="my-project",
+    )
+    projects = storage.list_projects_for_user(user_id)
+    assert len(projects) == 1
+    assert projects[0]["slug"] == "my-project"
+    assert projects[0]["role"] == "owner"
+
+
+# ── add_project_member + shared listing ────────────────────────────────────
+
+
+def test_add_member_makes_project_visible_to_target(storage):
+    """User A создает → User B added → User B видит проект в списке."""
+    a_id = _user(storage, "a@example.com")
+    b_id = _user(storage, "b@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id,
+        name="Retail", slug="retail",
+    )
+    storage.add_project_member(project["id"], b_id, role="viewer")
+
+    b_projects = storage.list_projects_for_user(b_id)
+    assert len(b_projects) == 1
+    assert b_projects[0]["slug"] == "retail"
+    assert b_projects[0]["role"] == "viewer"
+
+
+def test_user_without_membership_does_not_see_project(storage):
+    """User C без membership → пустой list, 404 на slug lookup."""
+    a_id = _user(storage, "a@example.com")
+    c_id = _user(storage, "c@example.com")
+    storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id,
+        name="Retail", slug="retail",
+    )
+
+    assert storage.list_projects_for_user(c_id) == []
+    assert storage.get_project_by_slug(c_id, "retail") is None
+
+
+def test_get_project_by_slug_finds_shared_project(storage):
+    """Shared lookup: User B нашёл проект A по slug несмотря на то что
+    у B этого slug в собственных проектах нет."""
+    a_id = _user(storage, "a@example.com")
+    b_id = _user(storage, "b@example.com")
+    a_project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id,
+        name="Shared", slug="shared-slug",
+    )
+    storage.add_project_member(a_project["id"], b_id, role="editor")
+
+    found = storage.get_project_by_slug(b_id, "shared-slug")
+    assert found is not None
+    assert found["id"] == a_project["id"]
+
+
+def test_get_project_by_slug_prefers_owned_when_collision(storage):
+    """User B owns 'default' AND was added to A's 'default' — owned wins."""
+    a_id = _user(storage, "a@example.com")
+    b_id = _user(storage, "b@example.com")
+    a_project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id,
+        name="A's default", slug="default",
+    )
+    b_project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=b_id,
+        name="B's default", slug="default",
+    )
+    storage.add_project_member(a_project["id"], b_id, role="viewer")
+
+    # B looks up 'default' → должен получить свой, не A's.
+    found = storage.get_project_by_slug(b_id, "default")
+    assert found is not None
+    assert found["id"] == b_project["id"]
+
+
+def test_get_project_by_id_membership_aware(storage):
+    """get_project_by_id (user, pid) проходит для shared, отказывает для outsider."""
+    a_id = _user(storage, "a@example.com")
+    b_id = _user(storage, "b@example.com")
+    c_id = _user(storage, "c@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id,
+        name="Shared", slug="shared",
+    )
+    storage.add_project_member(project["id"], b_id, role="editor")
+
+    assert storage.get_project_by_id(a_id, project["id"]) is not None
+    assert storage.get_project_by_id(b_id, project["id"]) is not None
+    assert storage.get_project_by_id(c_id, project["id"]) is None
+
+
+# ── role validation + safety guards ────────────────────────────────────────
+
+
+def test_add_member_rejects_invalid_role(storage):
+    user_id = _user(storage, "owner@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=user_id,
+        name="P", slug="p",
+    )
+    target = _user(storage, "target@example.com")
+    with pytest.raises(storage.InvalidMemberRole):
+        storage.add_project_member(project["id"], target, role="admin")
+
+
+def test_add_member_cannot_downgrade_owner(storage):
+    """Owner row защищён: попытка перевести owner → editor отклоняется."""
+    a_id = _user(storage, "owner@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id, name="P", slug="p",
+    )
+    with pytest.raises(storage.InvalidMemberRole):
+        storage.add_project_member(project["id"], a_id, role="editor")
+
+
+def test_remove_member_cannot_remove_owner(storage):
+    a_id = _user(storage, "owner@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id, name="P", slug="p",
+    )
+    with pytest.raises(storage.InvalidMemberRole):
+        storage.remove_project_member(project["id"], a_id)
+
+
+def test_remove_member_returns_false_if_absent(storage):
+    """Идемпотентность remove: повторный/несуществующий → False, не Error."""
+    a_id = _user(storage, "owner@example.com")
+    other = _user(storage, "other@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id, name="P", slug="p",
+    )
+    assert storage.remove_project_member(project["id"], other) is False
+
+
+def test_add_member_upserts_role_change(storage):
+    """Повторный add с другим role → UPSERT обновляет role."""
+    a_id = _user(storage, "owner@example.com")
+    b_id = _user(storage, "b@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id, name="P", slug="p",
+    )
+    storage.add_project_member(project["id"], b_id, role="viewer")
+    assert storage.get_member_role(project["id"], b_id) == "viewer"
+    storage.add_project_member(project["id"], b_id, role="editor")
+    assert storage.get_member_role(project["id"], b_id) == "editor"
+
+
+def test_list_project_members_returns_owner_and_members(storage):
+    """list_project_members показывает всех с ролями + email."""
+    a_id = _user(storage, "owner@example.com")
+    b_id = _user(storage, "editor@example.com")
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=a_id, name="P", slug="p",
+    )
+    storage.add_project_member(project["id"], b_id, role="editor")
+    members = storage.list_project_members(project["id"])
+    assert len(members) == 2
+    by_role = {m["role"]: m["email"] for m in members}
+    assert by_role == {"owner": "owner@example.com", "editor": "editor@example.com"}
+
+
+# ── Migration backfill для legacy projects ─────────────────────────────────
+
+
+def test_migration_backfills_owner_row_for_legacy_projects(tmp_path, monkeypatch):
+    """Legacy projects (без project_members ряда) после миграции должны
+    получить owner-row автоматически. Симулируем: создаём проект, удаляем
+    owner-row, реинициализируем engine — повторный _apply_schema должен
+    восстановить."""
+    from sqlalchemy import text
+
+    import app.metrics_storage as ms
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "legacy.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+
+    uid = uuid.uuid4().hex
+    ms.create_user(user_id=uid, email=f"u-{uid[:6]}@x.io", password_hash="x")
+    project = ms.create_project(
+        project_id=uuid.uuid4().hex, user_id=uid,
+        name="Legacy", slug="legacy",
+    )
+
+    # Симулируем legacy state: удалить owner-row напрямую.
+    with ms.get_engine().begin() as conn:
+        conn.execute(text(
+            "DELETE FROM project_members WHERE project_id = :pid"
+        ), {"pid": project["id"]})
+    assert ms.get_member_role(project["id"], uid) is None
+
+    # Force re-init → _apply_schema → _migrate_existing_schema → backfill.
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    ms.get_engine()  # triggers _apply_schema
+
+    assert ms.get_member_role(project["id"], uid) == "owner"
+
+
+# ── Route-level: User C получает 404, non-owner — 403 на delete ────────────
+
+
+@pytest.fixture
+def app_(tmp_path, monkeypatch):
+    import app.metrics_storage as ms
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "route.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    return create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+
+
+def _register(client, email):
+    client.post("/auth/register", data={
+        "email": email, "password": "supersecret1", "confirm": "supersecret1",
+    })
+
+
+def _login(client, email):
+    client.post("/auth/login", data={
+        "email": email, "password": "supersecret1",
+    })
+
+
+def test_outsider_gets_404_on_someone_elses_project(app_):
+    """User C логинится, лезет в проект A → 404."""
+    c_a = app_.test_client()
+    _register(c_a, "a@example.com")  # creates default project
+    # Logout A, login C.
+    c_a.post("/auth/logout")
+    _register(c_a, "c@example.com")
+    # C is now logged in. A's project slug is 'default' (auto-created).
+    # But C also has their own 'default'. To force testing outsider path,
+    # use a unique slug — create one as A first.
+    c_a.post("/auth/logout")
+    _login(c_a, "a@example.com")
+    # Create custom slug as A.
+    c_a.post("/projects/new", data={"name": "Secret A", "slug": "secret-a"})
+    c_a.post("/auth/logout")
+
+    # Login as C, try to access A's project.
+    _login(c_a, "c@example.com")
+    resp = c_a.get("/projects/secret-a")
+    assert resp.status_code == 404
+
+
+def test_member_can_view_shared_project(app_):
+    """User A creates → adds User B → B logs in → видит проект на /projects/."""
+    from app.metrics_storage import (
+        add_project_member,
+        get_project_by_slug,
+        get_user_by_email,
+    )
+    c = app_.test_client()
+    _register(c, "a@example.com")
+    c.post("/projects/new", data={"name": "Shared A", "slug": "shared-a"})
+    c.post("/auth/logout")
+    _register(c, "b@example.com")
+    c.post("/auth/logout")
+    # Add B as member of A's project.
+    a = get_user_by_email("a@example.com")
+    b = get_user_by_email("b@example.com")
+    project = get_project_by_slug(a["id"], "shared-a")
+    add_project_member(project["id"], b["id"], role="viewer")
+
+    # Login as B and check.
+    _login(c, "b@example.com")
+    list_resp = c.get("/projects/")
+    assert list_resp.status_code == 200
+    assert "Shared A" in list_resp.get_data(as_text=True)
+
+    detail_resp = c.get("/projects/shared-a")
+    assert detail_resp.status_code == 200
+    assert "Shared A" in detail_resp.get_data(as_text=True)
+
+
+def test_non_owner_cannot_delete_project_via_route(app_):
+    """Editor member видит проект, но POST /delete → 403 (не 404, чтобы
+    дать понятную ошибку owner-only действия — отличается от 'not found')."""
+    from app.metrics_storage import (
+        add_project_member,
+        get_project_by_slug,
+        get_user_by_email,
+    )
+    c = app_.test_client()
+    _register(c, "a@example.com")
+    c.post("/projects/new", data={"name": "Owned A", "slug": "owned-a"})
+    c.post("/auth/logout")
+    _register(c, "b@example.com")
+    c.post("/auth/logout")
+    a = get_user_by_email("a@example.com")
+    b = get_user_by_email("b@example.com")
+    project = get_project_by_slug(a["id"], "owned-a")
+    add_project_member(project["id"], b["id"], role="editor")
+
+    _login(c, "b@example.com")
+    resp = c.post("/projects/owned-a/delete", follow_redirects=False)
+    assert resp.status_code == 403
+
+    # Sanity: проект всё ещё существует у A.
+    assert get_project_by_slug(a["id"], "owned-a") is not None
+
+
+def test_owner_can_still_delete_project(app_):
+    """Owner-flow не должен сломаться от #172."""
+    from app.metrics_storage import (
+        get_project_by_slug,
+        get_user_by_email,
+    )
+    c = app_.test_client()
+    _register(c, "a@example.com")
+    c.post("/projects/new", data={"name": "Owned A", "slug": "owned-a"})
+    resp = c.post("/projects/owned-a/delete", follow_redirects=False)
+    assert resp.status_code == 302  # redirect to /projects/
+
+    a = get_user_by_email("a@example.com")
+    assert get_project_by_slug(a["id"], "owned-a") is None


### PR DESCRIPTION
Closes #172. User A добавляет User B в свой проект, B видит его в списке + dashboard. User C получает 404. Owner-only удаление защищено 403.

## Скоуп

### Schema
`project_members(project_id, user_id, role, joined_at)` — composite PK, CASCADE FK, CHECK на роль ('owner','editor','viewer'). Index по `user_id` для основного запроса "какие проекты у юзера".

### Migration backfill
`_migrate_existing_schema` вставляет owner-row для legacy проектов без membership. Идемпотентна. Без неё `list_projects_for_user` вернул бы пустоту для существующих юзеров.

### Storage CRUD
- `create_project` атомарно создаёт owner-row
- `get_project_by_slug` — owned shortcut, fallback на shared. Owned приоритет при коллизии slug
- `get_project_by_id` membership-aware
- `list_projects_for_user` → owned + shared с полем `role`
- `add_project_member` — UPSERT с CHECK + guard от downgrade owner
- `remove_project_member` — guard от удаления owner
- `get_member_role`, `list_project_members`

### Routes
- `_require_owned_project` оставлен по имени (historical), теперь membership-aware. Docstring обновлён.
- `projects.delete` — 403 если `role != 'owner'`

### CLI
`scripts/add_project_member.py`:
```
python -m scripts.add_project_member \
  --owner demo@dbmonitor.app --slug retail-postgres \
  --email guest@dbmonitor.app --role viewer
```

### Demo seed
`seed_demo_workspace` добавляет `guest@dbmonitor.app` как viewer на retail-postgres. После `make demo-prepare` на сцене сразу можно показать "вот другой юзер видит тот же проект".

## Acceptance из тикета

- [x] Модель `project_members`
- [x] Owner row при create_project
- [x] Роли owner/editor/viewer (CHECK constraint)
- [x] Ownership checks → membership access
- [x] `list_projects_for_user`: owned + shared
- [x] Demo seed: второй юзер на shared project
- [x] Ограничены опасные действия по роли (delete = owner-only)
- [x] User A создаёт; User B добавлен; User B видит; User C → 404
- [x] Тесты на доступ и изоляцию

## Не входит (future tickets)

- Полноценная RBAC (editor vs viewer specific perms) — пока owner-only только для delete
- UI page `/projects/<slug>/members` для управления участниками — пока через CLI

## Тесты (18 кейсов)

**Storage** (12): create-owner-row, list-roles, shared-lookup, slug collision priority, get_project_by_id membership-aware, invalid role rejected, downgrade owner rejected, remove-owner rejected, remove idempotent, UPSERT role change, list_project_members, migration backfill.

**Routes** (4): outsider 404, member sees /projects/ + detail, editor delete 403, owner delete 302.

## Verification

- **682 passed** (+18)
- ruff clean

## Test plan

- [x] Юнит на access logic
- [x] Routes на 404/403/200 paths
- [x] Migration backfill через force re-init
- [ ] Manual smoke после merge: `make demo-prepare` → `/auth/login guest@dbmonitor.app / demo12345` → должен видеть retail-postgres в списке проектов с бейджем "viewer"