### PR TITLE
docs: port-conflict 5432 precheck + admin-routes login note (smoke findings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ DSN уже прописан в `.env.example`:
 DATABASE_URL=postgresql://postgres:dev@localhost:5432/monitor
 ```
 
+> ⚠️ **Port-conflict на macOS / Linux с локальным Postgres**: если у тебя
+> уже стоит `brew install postgresql` или нативный пакет, твой Postgres
+> слушает 5432 первее Docker. `psql -h localhost -p 5432 -U postgres -l`
+> покажет твою локальную базу, не Docker-овскую `monitor`. Признак —
+> приложение падает с `database "monitor" does not exist`. Решение:
+> остановить локальный (`brew services stop postgresql@<version>`)
+> ИЛИ перенастроить Docker на другой порт через `compose.override.yml`.
+
 **Производительность сидинга** (350k строк, full demo: `--users 50000 --products 1000 --orders 100000 --events 200000`):
 
 | Окружение                  | Время    |

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -48,6 +48,20 @@ python -c "from app.sentry import init_sentry; print('sentry:', init_sentry())"
 
 > Этот шаг **уничтожает** локальные volumes. Не запускай если в БД что-то нужное.
 
+**Port-conflict precheck** (важно на macOS / любом ноуте с локальным
+Postgres): docker compose маппит `5432:5432`. Если на хосте уже слушает
+свой postgres (например, `brew install postgresql`), он перебивает Docker
+по `localhost:5432` и app получает database "monitor" does not exist.
+
+```bash
+lsof -ti :5432 | xargs -r ps -p | head
+# Если видишь СВОЙ postgres (не db-monitoring-pg) — останови:
+#   brew services stop postgresql@<version>
+# Или временно: pg_ctl -D /usr/local/var/postgres stop
+```
+
+Запуск:
+
 ```bash
 docker compose down -v
 docker compose up -d --build
@@ -58,7 +72,8 @@ done
 echo " ✓ app healthy"
 ```
 
-✅ Контейнер `db-monitoring-app` в state `healthy`.
+✅ Контейнер `db-monitoring-app` в state `healthy`. Если получаешь
+`database "monitor" does not exist` — проверь port-conflict выше.
 
 ---
 
@@ -215,5 +230,5 @@ docker stats --no-stream --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsa
 - [Rollback runbook](./runbooks/rollback.md) — если что-то всё-таки упало
 - [Backup runbook](./runbooks/backup.md) — перед демо хорошо иметь свежий бэкап
 - [Релизы и Docker tags](../README.md#релизы-и-откат-docker-tags) — что такое `demo-stable`
-- `/admin/feature-flags` — что под флагами (можно быстро выключить если фича ломает демо)
-- `/admin/rollback-checklist` — компактная версия rollback runbook на странице
+- `/admin/feature-flags` — что под флагами (требует login; можно быстро выключить если фича ломает демо)
+- `/admin/rollback-checklist` — компактная версия rollback runbook на странице (тоже под login)


### PR DESCRIPTION
Manual smoke end-to-end по `make demo-prepare` поймал два real-world edge case'а — документирую без code changes.

## 1. Port-conflict 5432 (новое)

**Симптом**: app падает с `database "monitor" does not exist` после `docker compose up`.

**Причина**: на macOS с `brew install postgresql` свой Postgres слушает 5432 первее Docker compose mapping. Connection через `localhost:5432` идёт в локальный, где `monitor` database не существует. Docker контейнер запущен и здоров — просто никто к нему не подключается.

Воспроизвёл локально и подтвердил через `lsof -ti :5432`.

**Добавлено**:
- `docs/CHECKLIST.md` шаг 3: precheck с `lsof -ti :5432` + команды `brew services stop postgresql@<version>`
- `README.md` раздел «Локальный Postgres»: callout с диагностикой и решением

## 2. `/admin/*` под login

**Не баг — feature**: `app.app::_require_login_for_html` gate-ит `/admin/*` через before_request hook. Это intent (admin-tooling для operator-а с аккаунтом, не для анонимного scrape), но не было задокументировано в CHECKLIST.

**Добавлено**: пометка "требует login" к ссылкам на `/admin/feature-flags` и `/admin/rollback-checklist` в CHECKLIST.

## Что ещё smoke подтвердил

Без изменений (документирую для истории):

- `/healthz` → `status: ok` + `version: <git SHA>` (#100 + #105)
- `/metrics` → три ключевых TYPE-counter (#101)
- `make demo-prepare` → metrics=21126, anomaly_scores=1340, changepoints=14, drift_reports=45, notifications=10, forecast_models=8 — все ненулевые
- anon `/dashboard` → 302 (#137)
- Per-project scheduler регистрирует 3 collection jobs из demo workspace (#54 + #176)

## Verification

- **682 passed** (no regressions — чистый doc fix)
- ruff clean

## Test plan

- [x] Воспроизведён port-conflict локально
- [x] Команда `lsof -ti :5432` показывает PID конкретного процесса (не Docker), `brew services stop` его убивает
- [x] После остановки локального Postgres + перезапуска docker compose — соединение к `monitor` проходит