### PR TITLE
feat(#202): добавить ClickHouse demo проект в telegram_demo DEFAULT_PROJECTS

### DIFF
--- a/scripts/telegram_demo.py
+++ b/scripts/telegram_demo.py
@@ -49,6 +49,20 @@ DEFAULT_PROJECTS = (
         metric="row_count",
         score=-0.37,
     ),
+    # #202: ClickHouse demo проект. seed_demo_workspace создаёт его как
+    # events-clickhouse под demo@dbmonitor.app — issue упоминает slug
+    # 'clickhouse-demo' / 'clickhouse@dbmonitor.app', но на master реально
+    # events-clickhouse / demo@. На сцене показывает что per-project alert
+    # работает для всех трёх бэкендов (Postgres + Iceberg + ClickHouse)
+    # одинаково. ``events`` — самая bursty CH-таблица; score выше
+    # ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE из #171, проходит quality gate.
+    DemoTelegramProject(
+        email="demo@dbmonitor.app",
+        slug="events-clickhouse",
+        table="events",
+        metric="row_count",
+        score=-0.35,
+    ),
 )
 
 

--- a/tests/test_telegram_demo.py
+++ b/tests/test_telegram_demo.py
@@ -1,0 +1,140 @@
+"""Tests for scripts/telegram_demo.py (#182 + #202).
+
+#202 specifically: ensure the ClickHouse demo project (``events-clickhouse``)
+is included in ``DEFAULT_PROJECTS`` so ``configure`` saves Telegram
+settings for all three demo bases (Postgres + Iceberg + ClickHouse).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    import app.metrics_storage as ms
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "tgdemo.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    return ms
+
+
+def _seed_demo_projects(storage) -> dict[str, str]:
+    """Минимальная имитация seed_demo_workspace для трёх demo-проектов
+    из DEFAULT_PROJECTS. Возвращает {slug: project_id}."""
+    specs = [
+        ("demo@dbmonitor.app", "retail-postgres", "Retail Postgres"),
+        ("lake@dbmonitor.app", "iceberg-lakehouse", "Iceberg Lakehouse"),
+        ("demo@dbmonitor.app", "events-clickhouse", "Events ClickHouse"),
+    ]
+    # Уникальные юзеры по email (demo@ один для двух проектов).
+    user_by_email: dict[str, str] = {}
+    project_ids: dict[str, str] = {}
+    for email, slug, name in specs:
+        if email not in user_by_email:
+            uid = uuid.uuid4().hex
+            storage.create_user(user_id=uid, email=email, password_hash="x")
+            user_by_email[email] = uid
+        project = storage.create_project(
+            project_id=uuid.uuid4().hex,
+            user_id=user_by_email[email],
+            name=name,
+            slug=slug,
+        )
+        project_ids[slug] = project["id"]
+    return project_ids
+
+
+# ── DEFAULT_PROJECTS shape ────────────────────────────────────────────────
+
+
+def test_default_projects_includes_all_three_backends():
+    """Acceptance из #202: configure должен сохранять конфиг для всех
+    трёх demo-бэкендов — Postgres, Iceberg, ClickHouse."""
+    from scripts.telegram_demo import DEFAULT_PROJECTS
+
+    slugs = {p.slug for p in DEFAULT_PROJECTS}
+    assert "retail-postgres" in slugs
+    assert "iceberg-lakehouse" in slugs
+    assert "events-clickhouse" in slugs, (
+        "ClickHouse demo project (events-clickhouse) missing from "
+        "DEFAULT_PROJECTS — добавьте через DemoTelegramProject"
+    )
+
+
+def test_clickhouse_spec_has_strong_enough_score_for_quality_gate():
+    """#171 quality gate отбрасывает алерты с |score| < 0.05. Demo-spec
+    должен быть выше — иначе на сцене alert не уйдёт."""
+    from app.config import settings
+    from scripts.telegram_demo import DEFAULT_PROJECTS
+
+    ch = next(p for p in DEFAULT_PROJECTS if p.slug == "events-clickhouse")
+    assert abs(ch.score) >= settings.ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE
+
+
+# ── configure end-to-end with three projects ─────────────────────────────
+
+
+def test_configure_saves_notifications_for_all_default_projects(
+    storage, monkeypatch,
+):
+    """End-to-end: configure(DEFAULT_PROJECTS) → у каждого из трёх demo
+    проектов есть row в project_notifications с расшифрованным токеном."""
+    from app.config import settings as cfg
+    from scripts.telegram_demo import DEFAULT_PROJECTS, configure
+
+    monkeypatch.setattr(cfg, "TELEGRAM_BOT_TOKEN",
+                        "0000000001:" + "A" * 35)
+    monkeypatch.setattr(cfg, "TELEGRAM_CHAT_ID", "42")
+
+    pids = _seed_demo_projects(storage)
+    configure(DEFAULT_PROJECTS, throttle_minutes=15)
+
+    for slug in ("retail-postgres", "iceberg-lakehouse", "events-clickhouse"):
+        row = storage.get_project_notifications(pids[slug])
+        assert row is not None, f"missing config for {slug}"
+        assert row["telegram_chat_id"] == "42"
+        decrypted = crypto.decrypt_token(row["telegram_bot_token"])
+        assert decrypted.startswith("0000000001:")
+
+
+def test_configure_missing_clickhouse_project_raises(storage, monkeypatch):
+    """Если seed_demo_workspace не создал events-clickhouse,
+    _resolve_project поднимает SystemExit с понятным сообщением.
+    Защита от тихих skip-ов."""
+    from app.config import settings as cfg
+    from scripts.telegram_demo import DEFAULT_PROJECTS, configure
+
+    monkeypatch.setattr(cfg, "TELEGRAM_BOT_TOKEN",
+                        "0000000001:" + "A" * 35)
+    monkeypatch.setattr(cfg, "TELEGRAM_CHAT_ID", "42")
+
+    # Создаём только два первых проекта; events-clickhouse — нет.
+    uid = uuid.uuid4().hex
+    storage.create_user(user_id=uid, email="demo@dbmonitor.app",
+                        password_hash="x")
+    storage.create_project(project_id=uuid.uuid4().hex, user_id=uid,
+                            name="P1", slug="retail-postgres")
+    lake_uid = uuid.uuid4().hex
+    storage.create_user(user_id=lake_uid, email="lake@dbmonitor.app",
+                        password_hash="x")
+    storage.create_project(project_id=uuid.uuid4().hex, user_id=lake_uid,
+                            name="P2", slug="iceberg-lakehouse")
+
+    with pytest.raises(SystemExit) as exc_info:
+        configure(DEFAULT_PROJECTS, throttle_minutes=15)
+    assert "events-clickhouse" in str(exc_info.value)


### PR DESCRIPTION
Closes #202.

ClickHouse demo выпадал из per-project Telegram pipeline — `configure` сохранял конфиг только для `retail-postgres` и `iceberg-lakehouse`, в результате `make telegram-demo ARGS=alert` не показывал CH-проект на сцене.

## Уточнение к issue

Тикет упоминает slug `clickhouse-demo` / email `clickhouse@dbmonitor.app`, но в `seed_demo_workspace` на master реально создаётся **`events-clickhouse` под `demo@dbmonitor.app`**. Использую actual master state.

## Что внутри

`DEFAULT_PROJECTS` пополнен третьим `DemoTelegramProject`:

```python
DemoTelegramProject(
    email="demo@dbmonitor.app",
    slug="events-clickhouse",
    table="events",     # самая bursty CH-таблица
    metric="row_count",
    score=-0.35,         # выше ANOMALY_NOTIFY_MIN_SCORE_MAGNITUDE (0.05) из #171
),
```

`score=-0.35` важен — иначе quality gate из #171 молча отбросил бы alert на сцене.

## Тесты (4 новых, `tests/test_telegram_demo.py`)

У Оксаны не было тестов на `telegram_demo.py` — добавляю новый файл:

1. **`test_default_projects_includes_all_three_backends`** — pin acceptance из #202: все три бэкенда (Postgres + Iceberg + ClickHouse) в `DEFAULT_PROJECTS`
2. **`test_clickhouse_spec_has_strong_enough_score_for_quality_gate`** — защита от регрессии где score=-0.003 и quality gate его молча отбрасывает
3. **`test_configure_saves_notifications_for_all_default_projects`** — end-to-end: после `configure` у всех трёх проектов валидный `project_notifications` row с расшифровываемым bot_token
4. **`test_configure_missing_clickhouse_project_raises`** — защита от тихих skip-ов: если `seed_demo_workspace` не отработал и `events-clickhouse` отсутствует, `configure` делает `SystemExit` с понятным сообщением

## Acceptance из тикета

- [x] Добавить ClickHouse в `DEFAULT_PROJECTS` в `scripts/telegram_demo.py`
- [x] `make telegram-demo ARGS=configure` сохранит Telegram-конфиг для всех трёх demo-проектов (test_configure_saves_notifications_for_all_default_projects)
- [ ] "`detect_changepoints()` итерирует ClickHouse наравне с остальными" — это про `list_project_ids_with_telegram()` из #197 (Оксанин WIP). Закроется автоматически когда её PR смерджится: её функция итерирует `project_notifications` table, в которую теперь сохраняется CH-конфиг.

## Verification

- **686 passed** (+4)
- ruff clean

## Test plan

- [x] Юнит на DEFAULT_PROJECTS shape + quality-gate score
- [x] End-to-end configure → project_notifications
- [x] Negative path: missing project → SystemExit
- [ ] Manual smoke после merge: `make demo-prepare` + `make clickhouse-demo` + `make telegram-demo ARGS=configure` → в Telegram приходит сообщение от Events ClickHouse проекта