### PR TITLE
fix(#205): добавить название проекта в Telegram-уведомление schema_drift

### DIFF
--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -218,7 +218,12 @@ def notify_schema_drift(
         lines.append(line)
 
     project_label = _project_label(project_id)
-    text = f"\U0001f4cb [{table}] Дрейф схемы:\nПроект: {project_label}\n" + "\n".join(lines)
+    text = (
+        f"\U0001f4cb Дрейф схемы:\n"
+        f"Проект: {project_label}\n"
+        f"Таблица: {table}\n"
+        + "\n".join(lines)
+    )
     ok, error = send_message(text, bot_token=bot_token, chat_id=chat_id)
     _record(project_id=project_id, event_type="schema_drift", message=text,
             ok=ok, error=error, chat_id=chat_id, table=table)

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -217,7 +217,8 @@ def notify_schema_drift(
             line += f" ({col_type})"
         lines.append(line)
 
-    text = f"\U0001f4cb [{table}] Дрейф схемы:\n" + "\n".join(lines)
+    project_label = _project_label(project_id)
+    text = f"\U0001f4cb [{table}] Дрейф схемы:\nПроект: {project_label}\n" + "\n".join(lines)
     ok, error = send_message(text, bot_token=bot_token, chat_id=chat_id)
     _record(project_id=project_id, event_type="schema_drift", message=text,
             ok=ok, error=error, chat_id=chat_id, table=table)


### PR DESCRIPTION
## Описание

`notify_schema_drift()` не включал название проекта в тело Telegram-сообщения, хотя `notify_anomaly()` и `notify_changepoint()` его содержат. На демо per-project уведомлений (#197) было невозможно отличить какому проекту принадлежит уведомление.

**Было:**
```
📋 [orders] Дрейф схемы:
  • column_added — test_197 (text)
```

**Стало:**
```
📋 [orders] Дрейф схемы:
Проект: Retail Postgres (retail-postgres)
  • column_added — test_197 (text)
```

Использует уже существующий хелпер `_project_label(project_id)` — как в `notify_anomaly()`.

## Тип изменения

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы