### PR TITLE
fix(#208): добавить название проекта в Telegram-уведомление changepoint

### DIFF
--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -253,8 +253,12 @@ def notify_changepoint(
     else:
         change_str = f"{int(value_before):,} → {int(value_after):,}"
 
+    project_label = _project_label(project_id)
     text = (
-        f"\U0001f4c8 [{table}] Change-point: {metric} {change_str} ({ts[:10]})"
+        f"\U0001f4c8 Change-point:\n"
+        f"Проект: {project_label}\n"
+        f"Таблица: {table}\n"
+        f"{metric}: {change_str} ({ts[:10]})"
     )
     ok, error = send_message(text, bot_token=bot_token, chat_id=chat_id)
     _record(project_id=project_id, event_type="changepoint", message=text,


### PR DESCRIPTION
Closes #208

## Описание

`notify_changepoint()` не включал название проекта в сообщение. На демо per-project уведомлений (#197) было невозможно понять от какого проекта пришёл changepoint.

**Было:**
```
📈 [sessions] Change-point: row_count 977,451 → 1,242,816 (2026-05-28)
```

**Стало:**
```
📈 Change-point:
Проект: Iceberg Lakehouse (iceberg-lakehouse)
Таблица: sessions
row_count: 977,451 → 1,242,816 (2026-05-28)
```

Формат приведён в соответствие с `notify_schema_drift()` (#205).

## Тип изменения

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы