### PR TITLE
fix(#215): stabilize demo runtime on Timescale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage.xml
 htmlcov/
 tests/e2e/_artifacts/
 .env.local
+docker-compose.override.yml

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -210,7 +210,7 @@ def _ml_last_runs(project_id: str) -> dict[str, str | None]:
     from app.metrics_storage import get_engine
     from ml.forecast import MODELS_DIR
 
-    out: dict[str, str | None] = {
+    out: dict[str, str | datetime | None] = {
         "isolation_forest": None,
         "prophet": None,
         "pelt": None,
@@ -246,9 +246,11 @@ def _ml_last_runs(project_id: str) -> dict[str, str | None]:
     return {k: _fmt_ts(v) for k, v in out.items()}
 
 
-def _fmt_ts(value: str | None) -> str | None:
+def _fmt_ts(value: str | datetime | None) -> str | None:
     if not value:
         return None
+    if isinstance(value, datetime):
+        value = value.isoformat()
     return value.replace("T", " ")[:16] + " UTC"
 
 

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -1384,11 +1384,20 @@ def get_project_notifications(project_id: str) -> dict | None:
         return None
     return {
         "project_id": row[0],
-        "telegram_bot_token": row[1],
+        "telegram_bot_token": _normalize_binary_or_none(row[1]),
         "telegram_chat_id": row[2],
         "throttle_minutes": int(row[3]),
         "updated_at": str(row[4]) if row[4] else None,
     }
+
+
+def _normalize_binary_or_none(value) -> bytes | None:
+    """Normalize DB binary values across SQLite and Postgres drivers."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value
+    return bytes(value)
 
 
 def save_project_notifications(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -5,7 +6,7 @@ from cryptography.fernet import Fernet
 
 from app import crypto
 from app.app import _fmt_iso_in_text, create_app
-from app.dashboard import status_class
+from app.dashboard import _fmt_ts, status_class
 
 
 @pytest.fixture(autouse=True)
@@ -84,6 +85,13 @@ def test_status_class_buckets():
     assert status_class(0.29) == "warn"
     assert status_class(0.30) == "crit"
     assert status_class(0.95) == "crit"
+
+
+def test_fmt_ts_accepts_datetime_from_postgres():
+    value = datetime(2026, 6, 6, 12, 34, 56, tzinfo=UTC)
+
+    assert _fmt_ts(value) == "2026-06-06 12:34 UTC"
+    assert _fmt_ts(value.isoformat()) == "2026-06-06 12:34 UTC"
 
 
 def test_root_renders_landing_for_anonymous(client):

--- a/tests/test_project_notifications.py
+++ b/tests/test_project_notifications.py
@@ -89,6 +89,36 @@ def test_save_then_get_round_trip(storage):
         _FAKE_TG_TOKEN
 
 
+def test_get_project_notifications_normalizes_postgres_memoryview(storage, monkeypatch):
+    token = crypto.encrypt_token(_FAKE_TG_TOKEN)
+
+    class _Result:
+        def fetchone(self):
+            return ("pid", memoryview(token), "987654321", 15, "2026-06-06T00:00:00+00:00")
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+        def execute(self, _stmt, params):
+            assert params == {"pid": "pid"}
+            return _Result()
+
+    class _Engine:
+        def connect(self):
+            return _Conn()
+
+    monkeypatch.setattr(storage, "get_engine", lambda: _Engine())
+
+    row = storage.get_project_notifications("pid")
+
+    assert isinstance(row["telegram_bot_token"], bytes)
+    assert crypto.decrypt_token(row["telegram_bot_token"]) == _FAKE_TG_TOKEN
+
+
 def test_save_is_upsert(storage):
     pid = _seed_project(storage)
     tok1 = crypto.encrypt_token(_FAKE_TG_TOKEN)


### PR DESCRIPTION
Closes #215
Part of #175

## Что изменено

- Нормализован формат timestamp в dashboard ML last runs: Timescale/Postgres возвращает `datetime`, SQLite возвращает строку.
- Нормализован `telegram_bot_token` из Postgres `memoryview` в `bytes`, чтобы Telegram settings не падали при расшифровке Fernet token.
- Добавлены regression-тесты для обоих Postgres/Timescale type handling кейсов.
- Добавлен `docker-compose.override.yml` в `.gitignore`, чтобы локальный demo-runtime override не попал в репозиторий.

## Проверка

- `py_compile` по измененным Python-файлам
- Docker `app` пересобран
- Smoke-check: `lake@dbmonitor.app / demo12345` → `/dashboard/` возвращает 200
- Smoke-check: `/projects/iceberg/settings/notifications` возвращает 200 после сохраненного Telegram token

## Примечание

Операционная подготовка demo-runtime выполнена локально: Timescale metrics store, Retail/Iceberg/ClickHouse seed, Telegram settings. В PR входят только кодовые фиксы и `.gitignore`.