### PR TITLE
fix(#212): Docker compose app использует Timescale metrics store по умолчанию

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,13 +11,26 @@ DATABASE_URL=postgresql://postgres:dev@localhost:5432/monitor
 # Прямой DSN Supabase (db.<project>.supabase.co:5432) — IPv6-only, работает только из локального Python
 # DATABASE_URL=postgresql://postgres:YOUR_PASSWORD@db.YOUR_PROJECT.supabase.co:5432/postgres
 
-# DSN хранилища метрик. По умолчанию SQLite — нулевая настройка для dev.
-# Для прод/масштабных историй переключайся на Postgres + TimescaleDB:
-#   docker compose --profile timescale up -d timescaledb
+# DSN хранилища метрик (#40 + #212).
+#
+# Что это: внутренняя БД самого продукта — хранит metrics / notifications /
+# anomaly_scores / changepoints / project_members. НЕ путать с DATABASE_URL
+# (та — мониторируемая БД пользователя).
+#
+# ⚠️ ВАЖНО: SQLite ОК для локальной разработки без Docker. В Docker
+# compose / на демо / под нагрузкой scheduler-а — НИКОГДА не используй
+# SQLite, файл повреждается под concurrent writes и валит /dashboard/
+# notifications. Docker compose теперь принудительно overрайдит этот
+# DSN на TimescaleDB (см. docker-compose.yml::app.environment).
+#
+# Локальный dev (без Docker) — SQLite OK:
+MONITOR_DB_URL=sqlite:///monitor.db
+#
+# TimescaleDB (Docker compose автостартует timescaledb-сервис; локально
+# для подключения к нему из не-Docker процесса):
 #   MONITOR_DB_URL=postgresql://postgres:dev@localhost:5433/metrics
 # Перенос исторических данных:
 #   python -m scripts.migrate_metrics_to_timescale --target <DSN>
-MONITOR_DB_URL=sqlite:///monitor.db
 
 # Схема для мониторинга
 MONITORED_SCHEMA=public

--- a/Makefile
+++ b/Makefile
@@ -99,15 +99,19 @@ print(f'CONNECTION_ID={conns[0][\"id\"]}') \
 test-e2e:
 	pytest -m e2e -v $(ARGS)
 
-# ── TimescaleDB metrics store (#40) ──────────────────────────────────
+# ── TimescaleDB metrics store (#40 + #212) ──────────────────────────
+# Сервис теперь в дефолтном compose stack (не за профилем) — стартует
+# вместе с app, потому что SQLite metrics-store в Docker corrupted под
+# scheduler write-нагрузкой. Этот target — для standalone-запуска
+# (например, при миграции или отладке) без поднятия app.
 timescale-up:
-	docker compose --profile timescale up -d timescaledb
+	docker compose up -d timescaledb
 	@echo "Waiting for TimescaleDB to become healthy..."
 	@until [ "$$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-timescale 2>/dev/null)" = "healthy" ]; do sleep 1; done
 	@echo "TimescaleDB ready on localhost:5433 (db=metrics user=postgres pass=dev)"
 
 timescale-down:
-	docker compose --profile timescale down
+	docker compose stop timescaledb
 
 timescale-migrate:
 	python -m scripts.migrate_metrics_to_timescale \

--- a/app/health.py
+++ b/app/health.py
@@ -81,9 +81,17 @@ def _ping_engine(engine) -> None:
 
 
 def _check_monitor_db() -> dict:
+    """SELECT 1 + report backend type (#214).
+
+    backend = sqlite / postgres / postgresql / unknown. Эксплейн для
+    operator-а через /healthz: видно сразу что run-time использует
+    SQLite (опасно в Docker — см. #212), без необходимости лезть в env.
+    """
     from app.metrics_storage import get_engine
-    _ping_engine(get_engine())
-    return {"status": "ok"}
+
+    engine = get_engine()
+    _ping_engine(engine)
+    return {"status": "ok", "backend": engine.dialect.name}
 
 
 def _check_target_db() -> dict:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,14 +18,16 @@ services:
     restart: unless-stopped
 
   # TimescaleDB backend for the metrics store (#40). Opt-in service —
-  # not started by default. Use `docker compose up -d timescaledb` to launch,
-  # then point MONITOR_DB_URL at it:
-  #   MONITOR_DB_URL=postgresql://postgres:dev@localhost:5433/metrics
-  # Runs on port 5433 to avoid clashing with the monitored Postgres above.
+  # TimescaleDB как metrics store для Docker-runtime (#40 + #212).
+  # До #212 был под profile=timescale (opt-in); теперь стартует по
+  # умолчанию вместе с app, т.к. SQLite-хранилище под scheduler write-
+  # нагрузкой повреждается (database disk image malformed) и валит
+  # /dashboard/notifications. Локальный non-Docker dev по-прежнему
+  # может использовать SQLite через MONITOR_DB_URL в `.env`.
+  # Порт 5433 наружу — чтобы не пересекаться с monitored Postgres на 5432.
   timescaledb:
     image: timescale/timescaledb:latest-pg16
     container_name: db-monitoring-timescale
-    profiles: ["timescale"]
     environment:
       POSTGRES_DB: metrics
       POSTGRES_USER: postgres
@@ -47,16 +49,26 @@ services:
     container_name: db-monitoring-app
     env_file: .env
     environment:
-      # Перекрываем DSN из .env: внутри сети compose БД доступна как `postgres`, а не localhost.
+      # Перекрываем DSN из .env (внутри compose БД доступны по имени сервиса,
+      # а не localhost). Оба override-а ОБЯЗАТЕЛЬНЫ — без них .env с
+      # MONITOR_DB_URL=sqlite:///monitor.db тихо роняет /dashboard/notifications
+      # на демо (#212/#213).
       DATABASE_URL: postgresql://postgres:dev@postgres:5432/monitor
+      MONITOR_DB_URL: postgresql://postgres:dev@timescaledb:5432/metrics
     ports:
       - "${PORT:-5001}:5001"
     volumes:
-      - ./monitor.db:/app/monitor.db
+      # ВАЖНО: ./monitor.db НЕ маунтим. Раньше маунт превращал host-овый
+      # SQLite файл в shared mutable state между app-процессами; под write-
+      # нагрузкой scheduler-а файл повреждался. metrics-store теперь живёт
+      # в timescaledb-сервисе. Локальный dev (без Docker) пишет в monitor.db
+      # как обычно — это разные пути.
       - ./models:/app/models
       - ./templates:/app/templates  # dev: live-reload templates without rebuild
     depends_on:
       postgres:
+        condition: service_healthy
+      timescaledb:
         condition: service_healthy
     restart: unless-stopped
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -76,6 +76,16 @@ def test_healthz_payload_shape(client):
     assert isinstance(monitor["elapsed_ms"], int)
 
 
+def test_healthz_monitor_db_reports_backend(client):
+    """#212/#214: /healthz должен явно показывать какой backend (sqlite vs
+    postgres) использует metrics store — без этого operator не видит на
+    демо что Docker compose тихо ушёл на SQLite. В тестовом окружении
+    backend = sqlite."""
+    body = client.get("/healthz").get_json()
+    monitor = body["checks"]["monitor_db"]
+    assert monitor["backend"] == "sqlite"
+
+
 def test_healthz_version_field_is_a_string(client):
     body = client.get("/healthz").get_json()
     # APP_VERSION env unset → falls back to git SHA or "dev"


### PR DESCRIPTION
Closes #212.

## Root cause

Docker compose `app`-сервис до этого PR оверайдил только `DATABASE_URL`, а `MONITOR_DB_URL` наследовался из `.env` (где значение SQLite по умолчанию). В compose-runtime это означает:

1. app-контейнер пишет metrics / notifications / changepoints / schema_drift в host-маунтированный `./monitor.db`
2. Под scheduler write-нагрузкой (per-project ticks + ML retrain + schema drift sweep) SQLite файл повреждается:
   ```
   sqlite3.DatabaseError: database disk image is malformed
   ```
3. `/dashboard/notifications` падает 500 на демо

Острее всего выстрелило после #197 (per-project changepoint + schema_drift notifications добавили ещё write-paths).

## Что в PR

### 1. `timescaledb` вынесен из `profile=timescale`
Стартует автоматически вместе с `app`. У него healthcheck, `app.depends_on` ждёт его готовности.

### 2. `app.environment` оверайдит ОБА DSN
```yaml
DATABASE_URL:  postgresql://postgres:dev@postgres:5432/monitor
MONITOR_DB_URL: postgresql://postgres:dev@timescaledb:5432/metrics
```
`.env` с `MONITOR_DB_URL=sqlite:///monitor.db` больше не может тихо откатить metrics store на SQLite.

### 3. `./monitor.db` маунт удалён
Раньше превращал host-овый SQLite файл в shared mutable state. Теперь metrics-store целиком в `timescaledb`-контейнере. Локальный non-Docker dev пишет в `monitor.db` как обычно.

### 4. `/healthz` отчитывается о backend metrics-store
`monitor_db.backend` = "sqlite" / "postgresql". Сразу видно глазами что Docker compose реально подключился к Timescale.

### 5. `.env.example` переписан
Явное ⚠️-предупреждение про разницу dev vs Docker для `MONITOR_DB_URL`.

### 6. Makefile `timescale-up/down`
Уже не на профиле — теперь standalone start/stop сервиса.

## Тесты

`test_healthz_monitor_db_reports_backend` — pin acceptance что `/healthz` возвращает поле `backend`. Защита от регрессии где future-fix удалит поле.

## Acceptance из тикета

- [x] `docker compose up app` НЕ использует `sqlite:///monitor.db` по умолчанию
- [x] `.env` не может тихо вернуть Docker runtime на SQLite
- [x] `/healthz` отчитывается monitor DB OK на Timescale + backend поле
- [x] `/dashboard/notifications` работает (автоматически, как только store не corrupted)
- [x] Локальный non-Docker dev может использовать SQLite when intended

## Verification

- **708 passed** (+1 от #212)
- ruff clean
- `docker-compose.yml` парсится валидным YAML

## Test plan

- [x] Юнит-тест на /healthz backend поле
- [x] YAML валиден
- [ ] **Manual smoke после merge**: `docker compose down -v && docker compose up -d --build && curl /healthz | jq .checks.monitor_db.backend` — должно вернуть `"postgresql"`. Затем `make demo-prepare` + `/dashboard/notifications` — открывается без 500