### PR TITLE
feat(#214): guardrail + docs для unsafe SQLite metrics store

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,17 +328,34 @@ make test-e2e                      # = pytest -m e2e -v
 
 ## Хранилище метрик
 
-Метрики коллектора (`row_count`, `null_rate`, schema-snapshots, anomaly scores, change-points, …) хранятся в отдельной БД, выбираемой через `MONITOR_DB_URL`:
+Метрики коллектора (`row_count`, `null_rate`, schema-snapshots, anomaly scores, change-points, notifications, project_members) хранятся в отдельной БД, выбираемой через `MONITOR_DB_URL`.
 
-- **SQLite** (по умолчанию, `sqlite:///monitor.db`) — нулевая настройка для разработки и MVP. Хватает на 14-дневную историю при 4–10 таблицах.
-- **PostgreSQL + TimescaleDB** (опционально, #40) — для длинных историй и масштаба. `metrics` становится hypertable, retention идёт через `drop_chunks` вместо row-by-row DELETE.
+> ⚠️ **Не путать с `DATABASE_URL`** — это **мониторируемая** БД пользователя. `MONITOR_DB_URL` — **внутренняя** БД самого продукта.
+
+### Какой backend и когда
+
+| Окружение | Backend | Почему |
+|---|---|---|
+| **Локальный non-Docker dev** | SQLite (`sqlite:///monitor.db`) | Нулевая настройка, один процесс — ничего не повредится. Хватает на 14-дневную историю при 4–10 таблицах. |
+| **Docker compose / демо / прод** | **TimescaleDB (Postgres)** | Под scheduler write-нагрузкой (per-project ticks + ML retrain + schema drift + notifications) SQLite файл повреждается — `database disk image is malformed`. `/dashboard/notifications` падает 500 на сцене (#212/#213/#214). |
+
+Docker compose теперь принудительно оверайдит `MONITOR_DB_URL` на Timescale через `app.environment`, и `.env` с SQLite значением больше не может тихо это откатить.
+
+### Как проверить (`/healthz.backend`)
 
 ```bash
-# Поднять Timescale-контейнер (порт 5433, профиль `timescale`)
-make timescale-up
+curl -s http://localhost:5001/healthz | jq '.checks.monitor_db.backend'
+# "postgresql" → Timescale, "sqlite" → SQLite
+```
 
-# Указать новый DSN в .env:
-#   MONITOR_DB_URL=postgresql://postgres:dev@localhost:5433/metrics
+На демо это первая команда в [pre-demo checklist](docs/CHECKLIST.md#4a--metrics-store-backend). Если на Docker-стейдже видишь `sqlite` — ищи в логах startup warning `MONITOR_DB_URL is SQLite (...) in production-like runtime`.
+
+### Setup для Timescale
+
+```bash
+# Docker compose стартует timescaledb автоматически (с #212).
+# Для standalone-запуска (миграция без app):
+make timescale-up
 
 # Перенести историю SQLite → Timescale
 make timescale-migrate                              # = scripts.migrate_metrics_to_timescale

--- a/app/app.py
+++ b/app/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 
@@ -84,12 +85,55 @@ def _maybe_install_proxy_fix(app: Flask) -> None:
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
 
+def _warn_unsafe_sqlite_metrics_store() -> None:
+    """Log a LOUD warning if MONITOR_DB_URL=sqlite:/// в production-like
+    runtime (#214). Не fail-fast — это бы блокировало смешанные сценарии
+    (CI, мини-демо без compose), но JSON-логи кричат WARNING на
+    каждом старте чтобы оператор не пропустил.
+
+    Heuristic для "production-like runtime":
+      - SQLite scheme в MONITOR_DB_URL, AND
+      - либо FLASK_ENV != development, либо процесс выглядит как
+        запущенный в Docker (/.dockerenv exists)
+
+    В чистом локальном dev (FLASK_ENV=development без /.dockerenv) —
+    silently OK, это и есть intended usage SQLite.
+    """
+    import os
+    from urllib.parse import urlparse
+
+    url = settings.MONITOR_DB_URL.strip()
+    try:
+        scheme = urlparse(url).scheme
+    except (ValueError, AttributeError):
+        return
+    if not scheme.startswith("sqlite"):
+        return
+
+    is_docker = os.path.exists("/.dockerenv")
+    is_dev = (settings.FLASK_ENV or "").lower() == "development"
+    if is_dev and not is_docker:
+        return  # intended local-dev path
+
+    logging.getLogger("app.startup").warning(
+        "MONITOR_DB_URL is SQLite (%s) in production-like runtime "
+        "(FLASK_ENV=%s, in_docker=%s). SQLite metrics store corrupts under "
+        "scheduler write load and breaks /dashboard/notifications. "
+        "Switch to Postgres/Timescale — see .env.example MONITOR_DB_URL "
+        "block + docs README 'Metrics store backend' section.",
+        url, settings.FLASK_ENV, is_docker,
+    )
+
+
 def create_app(config: dict | None = None):
     # Order matters: configure formatters/handlers BEFORE the DSN-scrub
     # filter so the scrubber gets attached to the JSON/text handler we
     # actually use. _ensure_dsn_logging_filter is idempotent per process.
     configure_logging(settings.LOG_FORMAT, level=settings.LOG_LEVEL)
     _ensure_dsn_logging_filter()
+    # #214: warn ДО Sentry init, чтобы первая ошибка от corrupted SQLite
+    # уже шла в Sentry с этим warning'ом сверху breadcrumb-стека.
+    _warn_unsafe_sqlite_metrics_store()
     # Sentry init (#103) — no-op when SENTRY_DSN is empty. Must run
     # before Flask() so FlaskIntegration can patch the right symbols.
     init_sentry()

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -89,6 +89,23 @@ curl -sf "http://localhost:5001/healthz?strict=true" | jq .
 `?strict=true` важен — без него `n/a` (нет подключения к target DB) не
 триггерит 503.
 
+### 4a · Metrics-store backend
+
+⚠️ Самый частый pre-demo факап: scheduler роняет corrupted SQLite
+и `/dashboard/notifications` падает 500 на сцене.
+
+```bash
+curl -s http://localhost:5001/healthz | jq -r '.checks.monitor_db.backend'
+```
+
+✅ Должно быть `postgresql` (Docker compose / прод). Если `sqlite` —
+сразу проверь:
+
+- `docker compose ps timescaledb` → state=Up
+- `env | grep MONITOR_DB_URL` внутри контейнера: должна быть `postgresql://`
+- Логи стартапа `docker compose logs app | grep MONITOR_DB_URL is SQLite`
+  — если есть, .env с SQLite override-ит compose `environment` (#212/#214)
+
 ---
 
 ## 4b · Prometheus `/metrics` endpoint

--- a/tests/test_sqlite_metrics_guardrail.py
+++ b/tests/test_sqlite_metrics_guardrail.py
@@ -1,0 +1,103 @@
+"""Tests for the unsafe-SQLite-metrics-store warning (#214).
+
+Acceptance: `_warn_unsafe_sqlite_metrics_store` LOGS a WARNING when
+MONITOR_DB_URL = sqlite:/// in production-like runtime (Docker container
+OR FLASK_ENV != development). In intended local-dev path (FLASK_ENV =
+development AND not in Docker) — silent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+def _has_warning(caplog, snippet: str) -> bool:
+    """True if any caplog record at WARNING contains the substring."""
+    return any(
+        r.levelno >= logging.WARNING and snippet in r.getMessage()
+        for r in caplog.records
+    )
+
+
+@pytest.fixture
+def warn_fn():
+    """Late-import the warning function under test — keeps import cheap."""
+    from app.app import _warn_unsafe_sqlite_metrics_store
+    return _warn_unsafe_sqlite_metrics_store
+
+
+def test_sqlite_in_production_runtime_logs_warning(warn_fn, monkeypatch, caplog):
+    """FLASK_ENV != development AND SQLite → WARNING."""
+    from app.config import settings
+    monkeypatch.setattr(settings, "MONITOR_DB_URL", "sqlite:///monitor.db")
+    monkeypatch.setattr(settings, "FLASK_ENV", "production")
+    with caplog.at_level(logging.WARNING):
+        warn_fn()
+    assert _has_warning(caplog, "MONITOR_DB_URL is SQLite")
+
+
+def test_sqlite_in_docker_container_logs_warning(
+    warn_fn, monkeypatch, caplog, tmp_path,
+):
+    """/.dockerenv present + SQLite + FLASK_ENV=development → WARNING.
+    Сценарий: dev-режим в Docker — всё равно опасно. Мокаем os.path.exists
+    чтобы симулировать наличие /.dockerenv."""
+    import os as os_mod
+
+    from app.config import settings
+    monkeypatch.setattr(settings, "MONITOR_DB_URL", "sqlite:///monitor.db")
+    monkeypatch.setattr(settings, "FLASK_ENV", "development")
+    real_exists = os_mod.path.exists
+    monkeypatch.setattr(
+        "os.path.exists",
+        lambda p: True if p == "/.dockerenv" else real_exists(p),
+    )
+    with caplog.at_level(logging.WARNING):
+        warn_fn()
+    assert _has_warning(caplog, "MONITOR_DB_URL is SQLite")
+
+
+def test_sqlite_in_local_dev_is_silent(warn_fn, monkeypatch, caplog):
+    """FLASK_ENV=development AND no /.dockerenv → silent (intended usage)."""
+    import os as os_mod
+
+    from app.config import settings
+    monkeypatch.setattr(settings, "MONITOR_DB_URL", "sqlite:///monitor.db")
+    monkeypatch.setattr(settings, "FLASK_ENV", "development")
+    real_exists = os_mod.path.exists
+    monkeypatch.setattr(
+        "os.path.exists",
+        lambda p: False if p == "/.dockerenv" else real_exists(p),
+    )
+    with caplog.at_level(logging.WARNING):
+        warn_fn()
+    assert not _has_warning(caplog, "MONITOR_DB_URL is SQLite")
+
+
+def test_postgres_in_any_environment_is_silent(warn_fn, monkeypatch, caplog):
+    """Postgres backend → silent regardless of FLASK_ENV / Docker."""
+    from app.config import settings
+    monkeypatch.setattr(
+        settings, "MONITOR_DB_URL",
+        "postgresql://postgres:dev@timescaledb:5432/metrics",
+    )
+    monkeypatch.setattr(settings, "FLASK_ENV", "production")
+    with caplog.at_level(logging.WARNING):
+        warn_fn()
+    assert not _has_warning(caplog, "MONITOR_DB_URL is SQLite")
+
+
+def test_warning_includes_actionable_pointer(warn_fn, monkeypatch, caplog):
+    """Message должен указывать куда смотреть — иначе operator не починит."""
+    from app.config import settings
+    monkeypatch.setattr(settings, "MONITOR_DB_URL", "sqlite:///monitor.db")
+    monkeypatch.setattr(settings, "FLASK_ENV", "production")
+    with caplog.at_level(logging.WARNING):
+        warn_fn()
+    msg = " ".join(
+        r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+    )
+    assert "Postgres/Timescale" in msg
+    assert ".env.example" in msg or "README" in msg


### PR DESCRIPTION
Closes #214. После #212 Docker уже не использует SQLite по умолчанию, но это defense-in-depth: если кто-то вернёт опасную конфигурацию случайно (изменит compose, удалит override), оператор увидит warning до того как demo упадёт.

## 1. Startup warning в `app.app`

`_warn_unsafe_sqlite_metrics_store()` вызывается из `create_app` сразу после `configure_logging`. Heuristic для «production-like runtime»:

- `MONITOR_DB_URL` начинается с `sqlite://`, **AND**
- `FLASK_ENV != development`, **OR** `/.dockerenv` существует (мы внутри Docker)

В этом случае — **LOUD WARNING** в JSON-логах с actionable pointer на `.env.example` + README.

В чистом local-dev (FLASK_ENV=development, не Docker) — silent, SQLite там intended usage.

**Не fail-fast** (исключение блокировало бы CI / мини-демо), но WARNING поднимется в Sentry автоматически (#103) → Slack/email operator-у.

## 2. `/healthz.checks.monitor_db.backend`

Из #212 — оставляем. Документируем что это первая команда в pre-demo checklist.

## 3. `CHECKLIST.md` шаг 4a · Metrics-store backend

Между 4 (health-check) и 4b (Prometheus) вставлен короткий шаг:

```bash
curl -s /healthz | jq -r '.checks.monitor_db.backend'
# должен быть "postgresql"; если "sqlite" — диагностические команды
```

## 4. README раздел «Хранилище метрик» переписан

- Чёткая таблица «когда SQLite vs когда Timescale»
- Не путать `MONITOR_DB_URL` с `DATABASE_URL` (callout)
- Как проверить backend через `/healthz`
- Ссылка на CHECKLIST для pre-demo проверки

## Acceptance из тикета

- [x] Unsafe Docker/demo SQLite configuration **visible перед** corrupted DB state (startup warning + /healthz.backend)
- [x] Docs объясняют `DATABASE_URL` vs `MONITOR_DB_URL` (README callout)
- [x] Docs ссылаются на #40 / Timescale (README раздел Setup)
- [x] Pre-demo checklist includes a check for monitor DB backend (4a)

## Тесты (5 кейсов, `tests/test_sqlite_metrics_guardrail.py`)

- SQLite + FLASK_ENV=production → WARNING
- SQLite + `/.dockerenv` (даже FLASK_ENV=development) → WARNING
- SQLite + FLASK_ENV=development + не Docker → silent
- Postgres backend → silent в любом окружении
- Сообщение содержит actionable pointer (Postgres/Timescale + ссылка на .env.example/README)

## Verification

- **713 passed** (+5 от #214)
- ruff clean

## Test plan

- [x] Юнит на heuristic для всех 4 комбинаций (production+sqlite, docker+sqlite, dev+sqlite, postgres)
- [x] Acceptance message content
- [ ] **Manual smoke**: запустить локально с `FLASK_ENV=production make server` + `MONITOR_DB_URL=sqlite:/// в env` → в логах увидеть WARNING. Запустить с Postgres → silent