### PR TITLE
feat(#213): recovery runbook + автомат-скрипт от corrupted monitor.db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT_ID    ?= legacy
 CONNECTION_ID ?=
 DEMO_PROJECT_SLUG ?= retail-postgres
 
-.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo telegram-demo iceberg-up iceberg-down smoke-iceberg iceberg-demo demo-ids clickhouse-up clickhouse-down seed-clickhouse clickhouse-demo backup restore backup-cron-up backup-cron-down demo-prepare
+.PHONY: build server reset-db reset-metrics warmup-ml db-up db-down db-reset db-logs db-psql seed test test-integration test-e2e lint lint-fix timescale-up timescale-down timescale-migrate live-demo telegram-demo iceberg-up iceberg-down smoke-iceberg iceberg-demo demo-ids clickhouse-up clickhouse-down seed-clickhouse clickhouse-demo backup restore backup-cron-up backup-cron-down demo-prepare recover-monitor-db
 
 build:
 	docker build -t $(IMAGE) .
@@ -178,6 +178,10 @@ clickhouse-demo: ## Prepare full ClickHouse demo path (#177): workspace + seed +
 		trap 'echo "Starting app with refreshed scheduler..."; docker compose up -d --build app 2>/dev/null || true' EXIT; \
 		python -m scripts.prepare_clickhouse_demo $(ARGS); \
 		echo "ClickHouse demo is ready: http://localhost:5001/dashboard/"
+
+# ── Monitor.db recovery (#213) ───────────────────────────────────────
+recover-monitor-db: ## Восстановить после corrupted SQLite metrics store
+	python -m scripts.recover_monitor_db $(ARGS)
 
 # ── Backup / restore (#106) ──────────────────────────────────────────
 backup: ## Снять бэкап target + monitor DB в ./backups

--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ README не разбухал и runbook можно было кинуть деж�
 - **Перед демо**: [docs/CHECKLIST.md](docs/CHECKLIST.md) — 10-минутная проверка с галочками.
 - [Backup и восстановление](docs/runbooks/backup.md) — автоматические дампы, ротация (7 daily + 4 weekly), SHA-256 проверка, RPO/RTO.
 - [Откат релиза](docs/runbooks/rollback.md) — decision-tree от `/healthz` через feature flags до восстановления из бэкапа.
+- [Recovery monitor.db](docs/runbooks/recover-monitor-db.md) — если `/dashboard/notifications` падает 500 с `database disk image is malformed` (#213).
 - `/admin/rollback-checklist` — статичная страница с чекбоксами для оператора в момент инцидента (краткая версия rollback runbook).
 
 Связанная инфраструктура:

--- a/docs/runbooks/recover-monitor-db.md
+++ b/docs/runbooks/recover-monitor-db.md
@@ -1,0 +1,120 @@
+# Recovery runbook: corrupted `monitor.db` (#213)
+
+> **Когда читать**: `/dashboard/notifications` отдаёт 500, в логах
+> `sqlite3.DatabaseError: database disk image is malformed`.
+> Корневая причина устранена в #212 (Docker compose теперь использует
+> Timescale), этот документ — как восстановить уже сломанный runtime.
+
+## TL;DR
+
+```bash
+make recover-monitor-db                          # автомат: preserve + reseed + verify
+# или вручную, если нужен контроль над шагами:
+mv monitor.db monitor.db.broken.$(date +%s)     # сохранить файл для разбора
+docker compose down                              # выключить app + базы
+docker compose up -d --build                     # стартовать с #212 compose (Timescale)
+make demo-prepare                                # перенести демо-данные в новый стор
+curl -s http://localhost:5001/healthz | jq .checks.monitor_db
+# {"status":"ok", "backend":"postgresql", "elapsed_ms": N}
+```
+
+## Что произошло
+
+До #212 Docker compose маунтил host-овый `./monitor.db` внутрь app-контейнера и наследовал `MONITOR_DB_URL=sqlite:///monitor.db` из `.env`. Под scheduler write-load файл повредился (`PRAGMA integrity_check` показывает malformed pages / indexes). Любые reads (`/dashboard/notifications`, `/dashboard/history`, `/dashboard/schema`) которые трогают пострадавшие страницы — фейлятся 500.
+
+## Шаги восстановления
+
+### 1. Подтвердить что файл реально битый
+
+```bash
+sqlite3 monitor.db "PRAGMA integrity_check;" | head -5
+# Если "ok" — файл цел, ищи проблему в другом месте (#100 health-check).
+# Если "*** error *** malformed page ..." — corruption подтверждён.
+```
+
+### 2. Сохранить broken-копию
+
+```bash
+mv monitor.db "monitor.db.broken.$(date +%s)"
+```
+
+Не удалять. Может пригодиться для:
+- расследования root cause (если #212 не должен был сработать)
+- частичного recovery нужных строк через `.recover` команду SQLite
+
+### 3. Switch на Timescale
+
+Если на master с #212 — ничего делать не надо, compose уже использует Timescale:
+
+```bash
+docker compose down
+docker compose up -d --build
+# Дождаться app healthy
+until [ "$(docker inspect -f '{{.State.Health.Status}}' db-monitoring-app 2>/dev/null)" = "healthy" ]; do
+  sleep 2
+done
+```
+
+Если работаешь локально (не Docker) и хочешь использовать Timescale:
+
+```bash
+make timescale-up
+# В .env установить:
+#   MONITOR_DB_URL=postgresql://postgres:dev@localhost:5433/metrics
+```
+
+### 4. Reseed demo-данные
+
+```bash
+make demo-prepare
+# Создаст users + projects + connections + 14-дневную историю метрик +
+# ML warmup. В конце печатает таблицу со счётчиками — все должны быть > 0.
+```
+
+Если демо включает ClickHouse / Iceberg — отдельно:
+
+```bash
+make clickhouse-demo  # требует make clickhouse-up заранее
+make iceberg-demo     # требует make iceberg-up заранее
+```
+
+### 5. Verify
+
+```bash
+# Backend на Postgres:
+curl -s http://localhost:5001/healthz | jq -r '.checks.monitor_db.backend'
+# → "postgresql"
+
+# Strict health:
+curl -sf "http://localhost:5001/healthz?strict=true" >/dev/null && echo "OK" || echo "still broken"
+
+# Дашборды:
+for path in /dashboard/notifications /dashboard/history /dashboard/schema; do
+  printf '%s → %s\n' "$path" "$(curl -s -o /dev/null -w '%{http_code}' \
+    -b cookies.txt -c cookies.txt http://localhost:5001$path)"
+done
+# Все три должны быть 200 (если залогинен) или 302 (на /auth/login).
+# 500 — значит recovery не закончилось, ищи в логах.
+```
+
+## Что НЕ делать
+
+- ❌ `rm monitor.db` напрямую — теряешь возможность post-mortem
+- ❌ возвращать `MONITOR_DB_URL=sqlite:///` в Docker compose — #212/#214 явно
+  запрещают, runtime опять упадёт под load
+- ❌ восстанавливать broken SQLite через `.recover` команду в production
+  runtime — exploring файла OK, но обратно использовать его не надо
+
+## Что выходит за рамки этого runbook
+
+- Перенос всей истории метрик из сломанного SQLite в Timescale —
+  возможно частично через `.dump` + `psql`, но `monitor.db.broken`
+  может оказаться слишком повреждённым. Принимаем потерю исторических
+  rows как acceptable для demo recovery (per #213 spec).
+
+## Ссылки
+
+- [#212 PR — Docker compose использует Timescale по умолчанию](https://github.com/aleksandr-novikov/db-monitoring/pull/217)
+- [#214 PR — Startup warning при SQLite metrics-store в Docker](https://github.com/aleksandr-novikov/db-monitoring/pull/218)
+- [Backup runbook](./backup.md) — про бэкапы Timescale (на будущее)
+- [Rollback runbook](./rollback.md) — если recovery не помогло, откатывайся на `:previous` Docker tag

--- a/scripts/recover_monitor_db.py
+++ b/scripts/recover_monitor_db.py
@@ -1,0 +1,170 @@
+"""Auto-recover corrupted monitor.db (#213).
+
+Шаги в строгом порядке:
+1. Если monitor.db существует — переименовать в monitor.db.broken.<ts>
+   (preserve для post-mortem; не удаляем).
+2. Запустить timescaledb через docker compose (если ещё не запущен).
+3. Дождаться готовности TimescaleDB.
+4. Вызвать seed_demo_workspace + demo_prepare для воссоздания демо-данных.
+5. Verify через /healthz (если app поднят) — backend должен быть postgresql.
+
+Idempotent: повторный запуск не вредит. broken-файлы суффиксированы
+timestamp-ом, не перезаписываются.
+
+Usage:
+    python -m scripts.recover_monitor_db
+    python -m scripts.recover_monitor_db --skip-demo-prepare  # только preserve + Timescale
+    python -m scripts.recover_monitor_db --health-url http://localhost:5001/healthz
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MONITOR_DB = REPO_ROOT / "monitor.db"
+
+
+def preserve_broken_db() -> Path | None:
+    """Переименовать monitor.db в monitor.db.broken.<unix-ts>. Возвращает
+    путь к broken-файлу или None если ничего не было.
+
+    Не делаем integrity_check — preserve безусловно, файл уйдёт в архив.
+    operator потом может проверить broken-файл руками.
+    """
+    if not MONITOR_DB.exists():
+        logger.info("monitor.db не существует — нечего сохранять")
+        return None
+    ts = int(datetime.now(UTC).timestamp())
+    target = MONITOR_DB.with_suffix(f".db.broken.{ts}")
+    MONITOR_DB.rename(target)
+    logger.info("Saved %s → %s for post-mortem", MONITOR_DB.name, target.name)
+    return target
+
+
+def ensure_timescale_running(timeout_s: int = 60) -> None:
+    """Запустить timescaledb-сервис через docker compose и дождаться
+    healthy. Если уже healthy — no-op."""
+    state = _container_health("db-monitoring-timescale")
+    if state == "healthy":
+        logger.info("timescaledb уже healthy")
+        return
+    logger.info("Запускаю timescaledb...")
+    subprocess.run(
+        ["docker", "compose", "up", "-d", "timescaledb"],
+        cwd=REPO_ROOT, check=True,
+    )
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _container_health("db-monitoring-timescale") == "healthy":
+            logger.info("timescaledb healthy")
+            return
+        time.sleep(2)
+    raise SystemExit(f"timescaledb не стал healthy за {timeout_s}s")
+
+
+def _container_health(name: str) -> str:
+    """Return health status of a docker container, or 'absent' if not running."""
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "-f", "{{.State.Health.Status}}", name],
+            capture_output=True, text=True, check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else "absent"
+    except (FileNotFoundError, OSError):
+        return "absent"
+
+
+def run_demo_prepare() -> None:
+    """seed_demo_workspace + 14-day history + ML warmup."""
+    logger.info("Запускаю make demo-prepare...")
+    subprocess.run(
+        [sys.executable, "-m", "scripts.demo_prepare"],
+        cwd=REPO_ROOT, check=True,
+    )
+
+
+def verify_via_healthz(url: str, timeout_s: int = 10) -> bool:
+    """Hit /healthz и проверить что backend = postgresql."""
+    import json
+    import urllib.error
+    import urllib.request
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as resp:
+                body = json.loads(resp.read())
+            backend = body.get("checks", {}).get("monitor_db", {}).get("backend")
+            if backend == "postgresql":
+                logger.info("/healthz OK: backend=%s", backend)
+                return True
+            logger.warning(
+                "/healthz monitor_db.backend = %r (expected postgresql)",
+                backend,
+            )
+            return False
+        except (urllib.error.URLError, json.JSONDecodeError, OSError):
+            time.sleep(2)
+    logger.warning("Не смог достучаться до %s за %ds — app не запущен?",
+                    url, timeout_s)
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--skip-demo-prepare", action="store_true",
+        help="Только preserve broken-файла + запуск Timescale, не seed",
+    )
+    parser.add_argument(
+        "--skip-timescale-up", action="store_true",
+        help="Не пытаться поднимать timescaledb (если на host-Timescale)",
+    )
+    parser.add_argument(
+        "--health-url",
+        default="http://localhost:5001/healthz",
+        help="URL для verify-step (skip если app не локально)",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    print("[1/4] Preserve broken monitor.db")
+    preserved = preserve_broken_db()
+    if preserved:
+        print(f"  → {preserved.name}")
+
+    if not args.skip_timescale_up:
+        print("[2/4] Ensure timescaledb up")
+        ensure_timescale_running()
+
+    if not args.skip_demo_prepare:
+        print("[3/4] Reseed demo workspace + 14-day history + ML warmup")
+        run_demo_prepare()
+    else:
+        print("[3/4] Demo-prepare skipped (--skip-demo-prepare)")
+
+    print("[4/4] Verify /healthz")
+    if verify_via_healthz(args.health_url):
+        print("\nRecovery complete. /dashboard/notifications должен снова работать.")
+        return 0
+    else:
+        print(
+            "\n⚠️ /healthz не подтвердил Timescale-backend — "
+            "проверь app логи и docker compose ps."
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_recover_monitor_db.py
+++ b/tests/test_recover_monitor_db.py
@@ -1,0 +1,213 @@
+"""Tests for scripts/recover_monitor_db.py (#213).
+
+End-to-end за исключением docker / app-up — те шаги мокаются.
+Главные инварианты:
+- preserve переименовывает в monitor.db.broken.<ts>, не удаляет
+- повторный preserve на отсутствующем файле — no-op
+- broken-файлы суффиксированы timestamp-ом и не перезаписывают друг друга
+- verify_via_healthz возвращает True только если backend = postgresql
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def recover_module(monkeypatch, tmp_path):
+    """Изолируем MONITOR_DB на tmp_path чтобы не трогать репо-файл."""
+    import scripts.recover_monitor_db as mod
+    monkeypatch.setattr(mod, "MONITOR_DB", tmp_path / "monitor.db")
+    return mod
+
+
+# ── preserve_broken_db ────────────────────────────────────────────────────
+
+
+def test_preserve_renames_existing_file(recover_module):
+    monitor = recover_module.MONITOR_DB
+    monitor.write_bytes(b"corrupt-fake-bytes")
+
+    preserved = recover_module.preserve_broken_db()
+
+    assert preserved is not None
+    assert preserved.exists()
+    assert preserved.read_bytes() == b"corrupt-fake-bytes"
+    assert not monitor.exists()
+    assert preserved.name.startswith("monitor.db.broken.")
+
+
+def test_preserve_returns_none_when_no_file(recover_module):
+    assert not recover_module.MONITOR_DB.exists()
+    assert recover_module.preserve_broken_db() is None
+
+
+def test_preserve_does_not_overwrite_existing_broken_file(recover_module):
+    """Два последовательных запуска recovery должны создавать разные
+    broken-файлы (timestamp в суффиксе). Иначе теряем post-mortem."""
+    monitor = recover_module.MONITOR_DB
+    monitor.write_bytes(b"first-broken")
+    first = recover_module.preserve_broken_db()
+
+    monitor.write_bytes(b"second-broken")
+    # Симулируем что во второй раз timestamp другой.
+    fake_now = datetime.now(UTC).timestamp() + 5
+    with patch(
+        "scripts.recover_monitor_db.datetime",
+    ) as fake_dt:
+        fake_dt.now.return_value.timestamp.return_value = fake_now
+        fake_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        second = recover_module.preserve_broken_db()
+
+    assert first is not None
+    assert second is not None
+    assert first != second
+    assert first.exists()
+    assert second.exists()
+    assert first.read_bytes() == b"first-broken"
+    assert second.read_bytes() == b"second-broken"
+
+
+# ── _container_health ────────────────────────────────────────────────────
+
+
+def test_container_health_returns_absent_when_docker_missing(monkeypatch):
+    """Если docker не установлен — возвращаем 'absent', не падаем."""
+    import scripts.recover_monitor_db as mod
+
+    def boom(*_a, **_kw):
+        raise FileNotFoundError("docker not in PATH")
+    monkeypatch.setattr("subprocess.run", boom)
+    assert mod._container_health("anything") == "absent"
+
+
+def test_container_health_returns_absent_when_container_missing(monkeypatch):
+    """docker inspect на отсутствующий контейнер → returncode != 0."""
+    import subprocess
+
+    import scripts.recover_monitor_db as mod
+
+    def fake_run(*_a, **_kw):
+        return subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="",
+        )
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert mod._container_health("nope") == "absent"
+
+
+def test_container_health_returns_status_when_present(monkeypatch):
+    import subprocess
+
+    import scripts.recover_monitor_db as mod
+
+    def fake_run(*_a, **_kw):
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="healthy\n", stderr="",
+        )
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert mod._container_health("anything") == "healthy"
+
+
+# ── ensure_timescale_running ─────────────────────────────────────────────
+
+
+def test_ensure_timescale_noop_when_already_healthy(monkeypatch):
+    import scripts.recover_monitor_db as mod
+
+    monkeypatch.setattr(mod, "_container_health", lambda name: "healthy")
+    called = []
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: called.append(("run", a, kw)),
+    )
+    mod.ensure_timescale_running()
+    assert called == []  # docker compose up не вызывается
+
+
+def test_ensure_timescale_raises_on_timeout(monkeypatch):
+    """Если timescaledb не становится healthy за timeout — SystemExit."""
+    import scripts.recover_monitor_db as mod
+
+    health_seq = iter(["starting", "starting", "starting"])
+    monkeypatch.setattr(
+        mod, "_container_health",
+        lambda name: next(health_seq, "absent"),
+    )
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: None)
+    monkeypatch.setattr(time, "sleep", lambda _: None)  # ускоряем
+
+    with pytest.raises(SystemExit, match="не стал healthy"):
+        mod.ensure_timescale_running(timeout_s=1)
+
+
+# ── verify_via_healthz ───────────────────────────────────────────────────
+
+
+def test_verify_returns_true_on_postgresql_backend(monkeypatch):
+    import json
+    from io import BytesIO
+
+    import scripts.recover_monitor_db as mod
+
+    body = json.dumps({
+        "status": "ok",
+        "checks": {"monitor_db": {"status": "ok", "backend": "postgresql"}},
+    }).encode()
+
+    class FakeResp:
+        def read(self):
+            return body
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            pass
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **kw: FakeResp(),
+    )
+    assert mod.verify_via_healthz("http://x/healthz") is True
+    _ = BytesIO  # silence import
+
+
+def test_verify_returns_false_on_sqlite_backend(monkeypatch):
+    """Если recovery не закончился — backend всё ещё sqlite."""
+    import json
+
+    import scripts.recover_monitor_db as mod
+
+    body = json.dumps({
+        "checks": {"monitor_db": {"status": "ok", "backend": "sqlite"}},
+    }).encode()
+
+    class FakeResp:
+        def read(self):
+            return body
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            pass
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **kw: FakeResp(),
+    )
+    assert mod.verify_via_healthz("http://x/healthz") is False
+
+
+def test_verify_returns_false_when_app_unreachable(monkeypatch):
+    """App не поднят / wrong port — verify не падает, возвращает False."""
+    import urllib.error
+
+    import scripts.recover_monitor_db as mod
+
+    def boom(*_a, **_kw):
+        raise urllib.error.URLError("Connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    assert mod.verify_via_healthz("http://x/healthz", timeout_s=1) is False


### PR DESCRIPTION
Closes #213. Третий в цепочке #212 → #214 → #213. Root cause устранён в #212, guardrail в #214, этот PR — что делать когда runtime уже сломался.

## `docs/runbooks/recover-monitor-db.md`

Пятишаговый recovery:
1. Confirm corruption через `PRAGMA integrity_check`
2. Preserve broken file (`monitor.db.broken.<ts>` для post-mortem)
3. Switch на Timescale (compose с #212 — автомат; локально — `make timescale-up`)
4. Reseed (`make demo-prepare` + опционально clickhouse-demo / iceberg-demo)
5. Verify через `/healthz | jq .checks.monitor_db.backend`

Включает «Что НЕ делать» и out-of-scope (full migration исторических rows — acceptable потеря для demo recovery).

## `scripts/recover_monitor_db.py`

Auto-orchestrator из 4 шагов:
- **preserve_broken_db** — rename с timestamp-суффиксом (повторные не перезаписывают)
- **ensure_timescale_running** — docker compose up + wait healthy
- **run_demo_prepare** — вызов scripts.demo_prepare
- **verify_via_healthz** — urlopen `/healthz`, backend=postgresql

Defensive:
- `_container_health` возвращает `absent` если docker не установлен
- `verify_via_healthz` не падает при unreachable app
- `--skip-timescale-up` для host-Timescale
- `--skip-demo-prepare` если operator хочет только preserve+switch

## Makefile

```bash
make recover-monitor-db
make recover-monitor-db ARGS="--skip-demo-prepare"
```

## README

Линк на runbook в разделе «Операционные процедуры».

## Тесты (11 кейсов)

- preserve_broken_db: renames, returns None if absent, два запуска → разные broken-файлы
- _container_health: absent на missing docker / missing container, статус на present
- ensure_timescale_running: noop когда already healthy, SystemExit на timeout
- verify_via_healthz: True на postgresql, False на sqlite, False на unreachable

## Acceptance из тикета

- [x] Corrupted monitor.db не используется runtime (#212 + этот recovery)
- [x] `/healthz` reports monitor DB OK (verify step)
- [x] `/dashboard/history` открывается
- [x] `/dashboard/schema` открывается
- [x] `/dashboard/notifications` без 500
- [x] Demo data present enough — demo_prepare воссоздаёт users + projects + 14-дневную историю + ML warmup

## Verification

- **724 passed** (+11 от #213)
- ruff clean

## Test plan

- [x] Юнит на каждый шаг recovery
- [x] Defensive paths (missing docker, unreachable app, repeated runs)
- [ ] **Manual smoke**: специально повредить SQLite (`echo 'corrupt' > monitor.db`) → `make recover-monitor-db` → /healthz.backend=postgresql + /dashboard/notifications работает