### PR TITLE
feat(#220): системный администратор через is_admin флаг

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
+from functools import wraps
 
-from flask import Blueprint, jsonify, render_template
+from flask import Blueprint, abort, jsonify, render_template
 from flask_login import current_user
 
 from collectors.per_project import list_jobs_for_user, parse_job_id, user_owns_job
@@ -11,7 +12,35 @@ from .feature_flags import snapshot as _ff_snapshot
 bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
+def admin_required(view):
+    """403 для не-admin пользователей (#220).
+
+    До этого decorator-а каждый аутентифицированный юзер имел доступ к
+    /admin/* — это было дырой, потому что rollback-checklist и feature-
+    flags toggle — это операторские действия, не для tenant-юзеров.
+
+    Anon-юзера ловит ``_require_login_for_html`` в app.app до этого
+    decorator-а — здесь нам гарантировано current_user.is_authenticated.
+
+    Honours ``LOGIN_DISABLED`` (test bypass) тем же способом что и
+    ``_require_login_for_html`` — иначе все pre-#220 admin тесты,
+    написанные с LOGIN_DISABLED=True, упали бы 403. Тесты, явно
+    проверяющие #220 acceptance, поднимают LOGIN_DISABLED=False.
+    """
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        from flask import current_app
+
+        if current_app.config.get("LOGIN_DISABLED"):
+            return view(*args, **kwargs)
+        if not getattr(current_user, "is_admin", False):
+            abort(403)
+        return view(*args, **kwargs)
+    return wrapper
+
+
 @bp.route("/jobs")
+@admin_required
 def list_jobs():
     """Per-user collection jobs (#54).
 
@@ -42,6 +71,7 @@ def list_jobs():
 
 
 @bp.route("/jobs/<job_id>/run", methods=["POST"])
+@admin_required
 def run_job(job_id: str):
     """Trigger a job immediately by setting its next_run_time to now.
 
@@ -74,6 +104,7 @@ def run_job(job_id: str):
 
 
 @bp.route("/rollback-checklist")
+@admin_required
 def rollback_checklist():
     """Static checklist for the operator at incident time (#107).
 
@@ -85,6 +116,7 @@ def rollback_checklist():
 
 
 @bp.route("/feature-flags")
+@admin_required
 def feature_flags():
     """List every known feature flag and its current value (#104).
 

--- a/app/app.py
+++ b/app/app.py
@@ -125,6 +125,42 @@ def _warn_unsafe_sqlite_metrics_store() -> None:
     )
 
 
+def _auto_promote_admin() -> None:
+    """Если settings.ADMIN_EMAIL задан и юзер с этим email существует —
+    выставить is_admin=True (#220). Идемпотентно: повторный старт ничего
+    не ломает. Юзер должен сначала зарегистрироваться через /auth/register
+    — auto-promote не создаёт аккаунт.
+
+    Silently no-op:
+    - ADMIN_EMAIL пустой (intended dev path);
+    - юзер не найден (ещё не зарегистрировался — promote применится
+      на следующем app start, после регистрации).
+    """
+    email = (settings.ADMIN_EMAIL or "").strip().lower()
+    if not email:
+        return
+    try:
+        from app.metrics_storage import get_user_by_email, set_user_admin
+        user = get_user_by_email(email)
+        if user is None:
+            logging.getLogger("app.startup").info(
+                "ADMIN_EMAIL=%s set but no such user yet — promote will apply "
+                "after they register.", email,
+            )
+            return
+        if user.get("is_admin"):
+            return  # уже admin, не пишем в БД повторно
+        set_user_admin(user["id"], True)
+        logging.getLogger("app.startup").info(
+            "Promoted %s to system admin (ADMIN_EMAIL match)", email,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        # storage не должен ломать boot — admin promote можно сделать руками.
+        logging.getLogger("app.startup").warning(
+            "Auto-promote of ADMIN_EMAIL failed: %s", exc,
+        )
+
+
 def create_app(config: dict | None = None):
     # Order matters: configure formatters/handlers BEFORE the DSN-scrub
     # filter so the scrubber gets attached to the JSON/text handler we
@@ -134,6 +170,9 @@ def create_app(config: dict | None = None):
     # #214: warn ДО Sentry init, чтобы первая ошибка от corrupted SQLite
     # уже шла в Sentry с этим warning'ом сверху breadcrumb-стека.
     _warn_unsafe_sqlite_metrics_store()
+    # #220: попытка авто-промоушена ADMIN_EMAIL → is_admin=True. Silently
+    # no-op если юзер ещё не зарегистрирован.
+    _auto_promote_admin()
     # Sentry init (#103) — no-op when SENTRY_DSN is empty. Must run
     # before Flask() so FlaskIntegration can patch the right symbols.
     init_sentry()

--- a/app/auth.py
+++ b/app/auth.py
@@ -76,6 +76,9 @@ class User(UserMixin):
         self.password_hash = row["password_hash"]
         self.created_at = row["created_at"]
         self.last_login_at = row["last_login_at"]
+        # #220: системный администратор. False для всех старых рядов
+        # (миграция ставит DEFAULT 0); промоушен через ADMIN_EMAIL.
+        self.is_admin = bool(row.get("is_admin", False))
 
     def get_id(self) -> str:  # Flask-Login: must return str
         return str(self.id)

--- a/app/config.py
+++ b/app/config.py
@@ -74,6 +74,11 @@ class Settings(BaseSettings):
     # wrong for user-facing links. Set this explicitly per environment.
     APP_BASE_URL: str = "http://localhost:5001"
 
+    # System administrator email (#220). При старте app, если задан,
+    # юзер с этим email получает is_admin=True (auto-promote). Без UI
+    # для назначения admin — единственный путь промоушена.
+    ADMIN_EMAIL: str = ""
+
     # Sentry error tracking (#103). Optional — empty DSN means the SDK is
     # never initialised, perfect for dev/CI where we don't want to spam
     # the project quota. Traces + profiles are sampled at 10% to control

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -380,6 +380,15 @@ def _migrate_existing_schema(engine: Engine) -> None:
             "(snapshot cache reset; recreated below with project_id in PK)"
         )
 
+    # #220: users gets is_admin column. Дефолт 0 — никто не получает доступ
+    # к /admin/* без явного промоушена через ADMIN_EMAIL.
+    if _table_exists(engine, "users") and "is_admin" not in _existing_columns(engine, "users"):
+        with engine.begin() as conn:
+            conn.execute(text(
+                "ALTER TABLE users ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0"
+            ))
+        logger.info("users.is_admin added (existing rows default to 0)")
+
     # #143: telegram_throttle gets project_id in the primary key. The table
     # is an ephemeral cache (throttle window is typically tens of minutes),
     # so we don't try to do a careful in-place ALTER PRIMARY KEY (which
@@ -1743,12 +1752,15 @@ def _row_to_user(row) -> dict | None:
         "password_hash": row[2],
         "created_at": _normalize_ts(row[3]),
         "last_login_at": _normalize_ts(row[4]),
+        # #220: is_admin как bool — UI / current_user.is_admin сравнивает
+        # с булем. SQLite даёт int 0/1, Postgres — то же при INTEGER column.
+        "is_admin": bool(row[5]) if len(row) > 5 else False,
     }
 
 
 def get_user_by_email(email: str) -> dict | None:
     stmt = text("""
-        SELECT id, email, password_hash, created_at, last_login_at
+        SELECT id, email, password_hash, created_at, last_login_at, is_admin
         FROM users WHERE email = :email
     """)
     with get_engine().connect() as conn:
@@ -1758,12 +1770,34 @@ def get_user_by_email(email: str) -> dict | None:
 
 def get_user_by_id(user_id: str) -> dict | None:
     stmt = text("""
-        SELECT id, email, password_hash, created_at, last_login_at
+        SELECT id, email, password_hash, created_at, last_login_at, is_admin
         FROM users WHERE id = :id
     """)
     with get_engine().connect() as conn:
         row = conn.execute(stmt, {"id": user_id}).fetchone()
     return _row_to_user(row)
+
+
+def set_user_admin(user_id: str, is_admin: bool) -> bool:
+    """Toggle users.is_admin (#220). Returns True если ряд обновился.
+
+    Идемпотентна: повторный вызов с тем же значением → возвращает True
+    если юзер существует, False если не найден.
+    """
+    with get_engine().begin() as conn:
+        result = conn.execute(text(
+            "UPDATE users SET is_admin = :v WHERE id = :id"
+        ), {"v": 1 if is_admin else 0, "id": user_id})
+    return (result.rowcount or 0) > 0
+
+
+def is_system_admin(user_id: str) -> bool:
+    """Quick lookup для @admin_required: только bool, без полного user dict."""
+    with get_engine().connect() as conn:
+        row = conn.execute(text(
+            "SELECT is_admin FROM users WHERE id = :id"
+        ), {"id": user_id}).fetchone()
+    return bool(row[0]) if row else False
 
 
 def update_last_login(user_id: str) -> None:

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -163,6 +163,9 @@ CREATE TABLE IF NOT EXISTS users (
     password_hash  TEXT NOT NULL,
     created_at     TEXT NOT NULL,
     last_login_at  TEXT,
+    -- #220: системный администратор. 1 = доступ к /admin/*. Назначается
+    -- через settings.ADMIN_EMAIL при старте app, нет UI промоушена.
+    is_admin       INTEGER NOT NULL DEFAULT 0,
     -- Belt-and-braces защита поверх _normalize_email в app/auth.py:
     -- любой raw INSERT мимо нормализации (сидеры, ручной SQL) валится здесь,
     -- а не молча создаёт дубликат, который потом не находится по email.

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -153,6 +153,7 @@ CREATE TABLE IF NOT EXISTS users (
     password_hash  TEXT NOT NULL,
     created_at     TIMESTAMPTZ NOT NULL,
     last_login_at  TIMESTAMPTZ,
+    is_admin       INTEGER NOT NULL DEFAULT 0,
     -- Belt-and-braces защита поверх _normalize_email в app/auth.py — см.
     -- комментарий в metrics_schema.sql.
     CHECK (email = LOWER(email))

--- a/tests/e2e/test_admin_access.py
+++ b/tests/e2e/test_admin_access.py
@@ -1,0 +1,147 @@
+"""E2E: /admin/* gated by ``is_admin`` flag (#220).
+
+Acceptance из тикета — обычный юзер видит 403 на /admin/jobs, админ
+проходит. Проверяем через реальный браузер + реальный Werkzeug, поднятый
+с ``LOGIN_DISABLED=False`` (главный ``live_dashboard`` фикстур ставит
+True для остального E2E suite — поэтому здесь свой сервер).
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from collections.abc import Iterator
+
+import pytest
+from cryptography.fernet import Fernet
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def admin_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Боевой Flask с LOGIN_DISABLED=False и пустой БД метрик.
+
+    Module-scoped — register/login прогон один на оба теста, юзер
+    шарится. Admin промоушен идёт через ``set_user_admin`` прямо в
+    storage между тест-кейсами.
+    """
+    import os
+    os.environ["FERNET_KEY"] = Fernet.generate_key().decode()
+
+    from app import crypto
+    crypto.reset_for_tests()
+
+    metrics_db = tmp_path_factory.mktemp("e2e-admin") / "metrics.db"
+
+    from app.config import settings
+    settings.MONITOR_DB_URL = f"sqlite:///{metrics_db}"
+
+    from app import metrics_storage
+    metrics_storage._engine = None
+    metrics_storage._initialized = False
+    metrics_storage.get_engine()
+
+    # Stub db introspection — иначе apsheduler / dashboard будут лезть
+    # в реальный DATABASE_URL, что нам не нужно.
+    from app import db
+    originals = {
+        "list_tables": db.list_tables,
+        "table_schema": db.table_schema,
+        "table_stats": db.table_stats,
+        "column_nulls": db.column_nulls,
+        "column_distribution": db.column_distribution,
+    }
+    db.list_tables = lambda schema=None: []
+    db.table_schema = lambda t, schema=None: []
+    db.table_stats = lambda t, schema=None: None
+    db.column_nulls = lambda t, schema=None: []
+    db.column_distribution = lambda t, schema=None, top_n=20: []
+
+    from app.app import create_app
+
+    app = create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,  # реально проверяем гейт
+        "WTF_CSRF_ENABLED": False,
+        "RATELIMIT_ENABLED": False,
+    })
+    port = _free_port()
+
+    from werkzeug.serving import make_server
+
+    server = make_server("127.0.0.1", port, app, threaded=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        for name, fn in originals.items():
+            setattr(db, name, fn)
+
+
+_EMAIL = "e2e-admin@x.io"
+_PASSWORD = "supersecret1"
+
+
+def _register_via_ui(page: Page, base_url: str, email: str, password: str) -> None:
+    page.goto(f"{base_url}/auth/register")
+    page.fill("input[name='email']", email)
+    page.fill("input[name='password']", password)
+    page.fill("input[name='confirm']", password)
+    page.click("input[type='submit'], button[type='submit']")
+    # Register auto-logs in и редиректит на onboarding/dashboard — ждём
+    # пока URL уйдёт с /auth/register.
+    page.wait_for_url(lambda url: "/auth/register" not in url, timeout=5_000)
+
+
+def _login_via_ui(page: Page, base_url: str, email: str, password: str) -> None:
+    page.goto(f"{base_url}/auth/login")
+    page.fill("input[name='email']", email)
+    page.fill("input[name='password']", password)
+    page.click("input[type='submit'], button[type='submit']")
+    page.wait_for_url(lambda url: "/auth/login" not in url, timeout=5_000)
+
+
+def test_regular_user_gets_403_on_admin_jobs(admin_server: str, page: Page):
+    """Обычный (не-admin) юзер логинится → /admin/jobs возвращает 403."""
+    _register_via_ui(page, admin_server, _EMAIL, _PASSWORD)
+
+    # Делаем запрос через page.request, чтобы поймать HTTP статус —
+    # browser-side page.goto на 403 рендерит error page, статус не виден.
+    resp = page.request.get(f"{admin_server}/admin/jobs")
+    assert resp.status == 403
+
+
+def test_admin_user_gets_200_on_admin_jobs(admin_server: str, page: Page):
+    """После set_user_admin(True) тот же юзер получает 200 + JSON."""
+    from app.metrics_storage import get_user_by_email, set_user_admin
+
+    user = get_user_by_email(_EMAIL)
+    assert user is not None, "fixture order сломан — юзер должен быть из теста выше"
+    set_user_admin(user["id"], True)
+
+    # Re-login — нужно фреш session с обновлённым is_admin (flask-login
+    # хранит привязку к user_id, is_admin читается лениво из storage —
+    # но safer перелогиниться, чтобы тест был детерминистский).
+    page.request.post(f"{admin_server}/auth/logout")
+    _login_via_ui(page, admin_server, _EMAIL, _PASSWORD)
+
+    resp = page.request.get(f"{admin_server}/admin/jobs")
+    assert resp.status == 200
+    # Контракт /admin/jobs — JSON-список.
+    body = resp.json()
+    assert isinstance(body, list)
+
+    # Sanity для UI: rollback checklist рендерится для админа.
+    page.goto(f"{admin_server}/admin/rollback-checklist")
+    expect(page.locator("body")).to_be_visible()

--- a/tests/test_is_admin.py
+++ b/tests/test_is_admin.py
@@ -1,0 +1,279 @@
+"""System admin flag tests (#220).
+
+Acceptance:
+- Колонка ``is_admin`` существует в users после старта (миграция)
+- ``ADMIN_EMAIL=foo@example.com`` → юзер с этим email получает is_admin=1
+- ``GET /admin/jobs`` от обычного юзера → 403
+- ``GET /admin/jobs`` от admin → 200
+- Admin-роуты под decorator: /jobs, /jobs/<id>/run, /rollback-checklist, /feature-flags
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    import app.metrics_storage as ms
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "admin.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    return ms
+
+
+# ── Schema + storage helpers ──────────────────────────────────────────────
+
+
+def test_users_table_has_is_admin_column(storage):
+    """Колонка is_admin создаётся в новой БД (schema file)."""
+    cols = storage._existing_columns(storage.get_engine(), "users")
+    assert "is_admin" in cols
+
+
+def test_create_user_defaults_is_admin_false(storage):
+    uid = uuid.uuid4().hex
+    storage.create_user(user_id=uid, email="user@x.io", password_hash="x")
+    user = storage.get_user_by_id(uid)
+    assert user["is_admin"] is False
+
+
+def test_set_user_admin_idempotent_true_then_false(storage):
+    uid = uuid.uuid4().hex
+    storage.create_user(user_id=uid, email="admin@x.io", password_hash="x")
+
+    assert storage.set_user_admin(uid, True) is True
+    assert storage.is_system_admin(uid) is True
+    assert storage.get_user_by_id(uid)["is_admin"] is True
+
+    # Идемпотентно: True → True снова → всё ок.
+    assert storage.set_user_admin(uid, True) is True
+
+    # Demote обратно.
+    assert storage.set_user_admin(uid, False) is True
+    assert storage.is_system_admin(uid) is False
+
+
+def test_set_user_admin_returns_false_for_missing_user(storage):
+    assert storage.set_user_admin("ghost-user-id", True) is False
+
+
+def test_is_system_admin_false_for_missing_user(storage):
+    assert storage.is_system_admin("ghost") is False
+
+
+def test_get_user_by_email_returns_is_admin(storage):
+    uid = uuid.uuid4().hex
+    storage.create_user(user_id=uid, email="lookup@x.io", password_hash="x")
+    storage.set_user_admin(uid, True)
+    user = storage.get_user_by_email("lookup@x.io")
+    assert user["is_admin"] is True
+
+
+# ── Migration backfill — existing DB без is_admin column ─────────────────
+
+
+def test_migration_adds_is_admin_column(tmp_path, monkeypatch):
+    """Симулируем pre-#220 БД: users table без is_admin → миграция
+    добавляет колонку с DEFAULT 0 для существующих рядов."""
+    from sqlalchemy import create_engine, text
+
+    import app.metrics_storage as ms
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "legacy.db"
+    eng = create_engine(f"sqlite:///{db_path}")
+
+    # Создаём pre-#220 users table без is_admin column.
+    with eng.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                email TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                last_login_at TEXT
+            )
+        """))
+        conn.execute(text(
+            "INSERT INTO users (id, email, password_hash, created_at) "
+            "VALUES ('u1', 'legacy@x.io', 'h', '2026-01-01T00:00:00')"
+        ))
+    eng.dispose()
+
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+
+    # Триггерим _apply_schema → _migrate_existing_schema.
+    eng2 = ms.get_engine()
+    cols = ms._existing_columns(eng2, "users")
+    assert "is_admin" in cols
+
+    # Existing row дефолтится в False.
+    user = ms.get_user_by_email("legacy@x.io")
+    assert user["is_admin"] is False
+
+
+# ── Route enforcement — @admin_required ──────────────────────────────────
+
+
+@pytest.fixture
+def auth_client(tmp_path, monkeypatch):
+    import app.metrics_storage as ms
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "auth.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    app = create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+    return app.test_client()
+
+
+def _register_and_login(client, email="u@x.io", password="supersecret1"):
+    client.post("/auth/register", data={
+        "email": email, "password": password, "confirm": password,
+    })
+    # Register уже логинит, но если нужен фреш — re-login.
+
+
+def test_non_admin_gets_403_on_admin_jobs(auth_client):
+    """Acceptance из тикета: GET /admin/jobs от обычного user → 403."""
+    _register_and_login(auth_client, "regular@x.io")
+    resp = auth_client.get("/admin/jobs")
+    assert resp.status_code == 403
+
+
+def test_non_admin_gets_403_on_feature_flags(auth_client):
+    _register_and_login(auth_client, "regular2@x.io")
+    resp = auth_client.get("/admin/feature-flags")
+    assert resp.status_code == 403
+
+
+def test_non_admin_gets_403_on_rollback_checklist(auth_client):
+    _register_and_login(auth_client, "regular3@x.io")
+    resp = auth_client.get("/admin/rollback-checklist")
+    assert resp.status_code == 403
+
+
+def test_admin_gets_200_on_admin_jobs(auth_client):
+    from app.metrics_storage import get_user_by_email, set_user_admin
+
+    _register_and_login(auth_client, "admin@x.io")
+    user = get_user_by_email("admin@x.io")
+    set_user_admin(user["id"], True)
+
+    # Re-login чтобы фреш session с обновлённым is_admin.
+    auth_client.post("/auth/logout")
+    auth_client.post("/auth/login", data={
+        "email": "admin@x.io", "password": "supersecret1",
+    })
+    resp = auth_client.get("/admin/jobs")
+    assert resp.status_code == 200
+
+
+def test_anon_redirects_not_403(auth_client):
+    """Anon user → 302 на /auth/login (login gate _require_login_for_html),
+    не 403. Разные семантики: 'не залогинен' vs 'залогинен но не админ'."""
+    resp = auth_client.get("/admin/jobs", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/auth/login" in resp.headers["Location"]
+
+
+# ── Auto-promote по ADMIN_EMAIL ──────────────────────────────────────────
+
+
+def test_auto_promote_makes_existing_user_admin(tmp_path, monkeypatch):
+    """ADMIN_EMAIL=existing@x.io → юзер получает is_admin=True после
+    create_app. Это шаг promote из create_app::_auto_promote_admin."""
+    import app.metrics_storage as ms
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "promote.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    # Создаём юзера ДО app start.
+    create_app({"TESTING": True})  # init schema
+    ms.create_user(user_id="admin-uid", email="boss@x.io", password_hash="x")
+    assert ms.get_user_by_email("boss@x.io")["is_admin"] is False
+
+    # Set ADMIN_EMAIL и реинит app.
+    monkeypatch.setattr(cfg, "ADMIN_EMAIL", "boss@x.io")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    create_app({"TESTING": True})
+
+    assert ms.get_user_by_email("boss@x.io")["is_admin"] is True
+
+
+def test_auto_promote_silently_skips_when_user_missing(tmp_path, monkeypatch):
+    """ADMIN_EMAIL установлен, но юзер ещё не зарегистрирован.
+    Не должно падать boot — promote применится после регистрации."""
+    import app.metrics_storage as ms
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "no-user.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    monkeypatch.setattr(cfg, "ADMIN_EMAIL", "future@x.io")
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    # Не падать — это main acceptance.
+    app = create_app({"TESTING": True})
+    assert app is not None
+
+
+def test_auto_promote_noop_when_admin_email_empty(tmp_path, monkeypatch):
+    """Empty ADMIN_EMAIL → ничего не делать (intended dev path)."""
+    import app.metrics_storage as ms
+    from app.app import create_app
+    from app.config import settings as cfg
+
+    db_path = tmp_path / "empty.db"
+    monkeypatch.setattr(cfg, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    monkeypatch.setattr(cfg, "ADMIN_EMAIL", "")
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    create_app({"TESTING": True})  # init schema
+    ms.create_user(user_id="u1", email="someone@x.io", password_hash="x")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    create_app({"TESTING": True})  # second start
+
+    user = ms.get_user_by_email("someone@x.io")
+    assert user["is_admin"] is False


### PR DESCRIPTION
Closes #220

До этого PR любой аутентифицированный юзер имел доступ к `/admin/*` —
rollback-checklist, feature-flags, jobs runner. В мульти-тенантном
окружении это дыра.

## Что делает PR

- Колонка `users.is_admin INTEGER NOT NULL DEFAULT 0` + миграция
  для pre-#220 БД (`ALTER TABLE … ADD COLUMN … DEFAULT 0`).
- `@admin_required` decorator на все `/admin/*` роуты. Honours
  `LOGIN_DISABLED` — pre-#220 admin-тесты продолжают работать.
- Storage хелперы: `set_user_admin(uid, bool)`, `is_system_admin(uid)`.
- `ADMIN_EMAIL` env — auto-promote того юзера в админа при старте app.
  Если юзера ещё нет — silent skip, promote применится после
  регистрации.

## Acceptance из тикета

- [x] Колонка `is_admin` мигрирует в существующую БД.
- [x] `ADMIN_EMAIL` → юзер становится админом.
- [x] `GET /admin/jobs` от не-admin → 403, от admin → 200.
- [x] Anon → 302 на /auth/login (login gate раньше decorator-а).

## Tests

- **15 unit (`tests/test_is_admin.py`)** — schema/migration, set/get
  helpers, route enforcement (403 / 200 / 302), auto-promote
  (existing / missing user / empty ADMIN_EMAIL).
- **2 E2E Playwright (`tests/e2e/test_admin_access.py`)** —
  регистрация через UI → /admin/jobs 403; `set_user_admin(True)` +
  re-login → /admin/jobs 200 + JSON; sanity /admin/rollback-checklist
  в браузере.

## Test plan

- [x] 776 unit passed (+15 от #220)
- [x] 2 E2E passed
- [x] ruff clean