### PR TITLE
feat(#229 #230): write-rights check + полный smoke-check в probe_connection

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -48,6 +48,13 @@ bp = Blueprint("connections", __name__, url_prefix="/projects/<slug>/connections
 # Connection-test budget — caps the wall-clock for the whole probe.
 _TEST_CONNECT_TIMEOUT_S = 5
 
+# #230: сколько таблиц возвращать UI как preview.
+_PROBE_TABLES_PREVIEW = 10
+# #229: сколько таблиц проверять на INSERT-права. Полный скан всей
+# схемы бессмысленно дорог (десятки тыщ таблиц у крупных пользователей);
+# первые 20 — практический компромисс для smoke-check.
+_PROBE_PRIV_CHECK = 20
+
 
 class ConnectionForm(FlaskForm):
     name = StringField(
@@ -443,12 +450,91 @@ def probe_connection(dsn: str) -> dict:
             row = conn.execute(
                 text("SELECT current_database(), version()")
             ).fetchone()
+
+            # #229/#230 smoke-check. Все запросы — SELECT-only, никакой
+            # записи. Schema берётся из dsn-query-param ``schema`` если
+            # передан, иначе settings.MONITORED_SCHEMA — то же значение,
+            # с которым реальный сборщик будет ходить в БД.
+            from app.config import settings as _settings
+            try:
+                target_schema = (
+                    make_url(dsn).query.get("schema")  # SQLAlchemy URL.query
+                    or _settings.MONITORED_SCHEMA
+                )
+            except Exception:
+                target_schema = _settings.MONITORED_SCHEMA
+
+            # #229: USAGE на схему — без него адаптер ничего не увидит.
+            # has_schema_privilege возвращает NULL для несуществующей
+            # схемы → coalesce, чтобы не упасть на None.
+            usage_row = conn.execute(text(
+                "SELECT COALESCE(has_schema_privilege(current_user, "
+                ":schema, 'USAGE'), false)"
+            ), {"schema": target_schema}).fetchone()
+            has_usage = bool(usage_row[0]) if usage_row else False
+
+            if not has_usage:
+                latency_ms = int((time.monotonic() - started) * 1000)
+                return {
+                    "status": "error",
+                    "code": "no_select_permission",
+                    "message": (
+                        f"Нет прав USAGE на схему {target_schema!r}. "
+                        "Дайте read-only роли GRANT USAGE ON SCHEMA "
+                        f"{target_schema} TO <user>."
+                    ),
+                    "latency_ms": latency_ms,
+                }
+
+            # #230: list tables — берём первые
+            # _PROBE_TABLES_PREVIEW для UI-preview, считаем total.
+            tables_rows = conn.execute(text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = :schema "
+                "  AND table_type = 'BASE TABLE' "
+                "ORDER BY table_name"
+            ), {"schema": target_schema}).fetchall()
+            all_tables = [r[0] for r in tables_rows]
+            tables_preview = all_tables[:_PROBE_TABLES_PREVIEW]
+            tables_found = len(all_tables)
+
+            # #229: проверяем INSERT/SELECT на первых _PROBE_PRIV_CHECK
+            # таблицах. has_table_privilege принимает имя как
+            # schema.table (quoted). Если таблиц нет — has_select=False,
+            # has_insert=False, warning не выставляем.
+            has_select = False
+            has_insert = False
+            for tbl in all_tables[:_PROBE_PRIV_CHECK]:
+                qualified = f'"{target_schema}"."{tbl}"'
+                row_p = conn.execute(text(
+                    "SELECT "
+                    "  COALESCE(has_table_privilege(current_user, "
+                    "    :q, 'SELECT'), false), "
+                    "  COALESCE(has_table_privilege(current_user, "
+                    "    :q, 'INSERT'), false)"
+                ), {"q": qualified}).fetchone()
+                if row_p:
+                    if row_p[0]:
+                        has_select = True
+                    if row_p[1]:
+                        has_insert = True
+                if has_insert and has_select:
+                    break  # дальше проверять нечего
+
+            warnings: list[str] = []
+            if has_insert:
+                warnings.append("write_privileges_detected")
+
         latency_ms = int((time.monotonic() - started) * 1000)
         return {
             "status": "ok",
             "database": row[0],
             "version": row[1].split(" on ", 1)[0],  # trim "on x86_64-..."
             "latency_ms": latency_ms,
+            "tables_found": tables_found,
+            "tables_preview": tables_preview,
+            "privileges": {"select": has_select, "insert": has_insert},
+            "warnings": warnings,
         }
     except SQLAlchemyError as exc:
         # Full traceback (with masked DSN — DSNFilter scrubs the password

--- a/templates/connections/list.html
+++ b/templates/connections/list.html
@@ -22,7 +22,7 @@
   <section class="mt-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
     <div class="divide-y divide-slate-100 dark:divide-slate-800">
       {% for c in connections %}
-        <div class="grid grid-cols-12 items-center gap-3 px-5 py-4 text-sm">
+        <div class="grid grid-cols-12 items-center gap-3 px-5 py-4 text-sm" data-conn-id="{{ c.id }}">
           <div class="col-span-4 min-w-0">
             <div class="font-medium">{{ c.name }}</div>
             <div class="truncate font-mono text-xs text-slate-500 dark:text-slate-400">{{ c.dsn_masked }}</div>
@@ -61,6 +61,9 @@
               </button>
             </form>
           </div>
+          {# #230: место под результат «Тест». Inline-блок чтобы не дёргать модалки. #}
+          <div class="col-span-12 hidden js-test-result rounded-md border border-slate-200 bg-slate-50 px-4 py-3 text-xs dark:border-slate-700 dark:bg-slate-950"
+               role="status" aria-live="polite"></div>
         </div>
       {% else %}
         <div class="px-5 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
@@ -72,13 +75,68 @@
   </section>
 
   <script>
-    // POSTs /test, alerts the result. Kept minimal — no toast library,
-    // no spinner: probe resolves in ≤ 5 s and alert() works for screen
-    // readers without extra ARIA wiring.
+    // POSTs /test, рендерит inline-результат под рядом подключения
+    // (#229, #230). Раньше тут был alert() — теперь нужны
+    // structured-данные (privileges, tables_preview, warnings), которые
+    // alert не покажет адекватно. Без toast-библиотек, чтобы держать
+    // зависимости тонкими.
+    const escapeHtml = (s) => String(s).replace(/[&<>"']/g, (c) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    }[c]));
+
+    const renderOk = (data) => {
+      const tables = data.tables_preview || [];
+      const tablesFound = data.tables_found ?? 0;
+      const priv = data.privileges || {};
+      const warnings = data.warnings || [];
+      const previewList = tables.length
+        ? `<ul class="mt-1 list-disc pl-5 font-mono">${tables.map((t) =>
+            `<li>${escapeHtml(t)}</li>`).join("")}</ul>`
+        : `<div class="mt-1 italic text-slate-500">таблиц в схеме не найдено</div>`;
+      const warningBlock = warnings.includes("write_privileges_detected")
+        ? `<div class="mt-2 rounded border border-amber-300 bg-amber-50 px-2 py-1 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+                data-warning="write_privileges_detected">
+             ⚠ DSN имеет INSERT-права. Создайте read-only роль для мониторинга
+             (рекомендация least-privilege).
+           </div>`
+        : "";
+      return `
+        <div class="font-medium text-emerald-700 dark:text-emerald-300">
+          ✓ ${escapeHtml(data.database)} · ${escapeHtml(data.version)} · ${data.latency_ms} мс
+        </div>
+        <div class="mt-2 grid grid-cols-2 gap-3">
+          <div data-section="tables">
+            <div class="text-slate-500 dark:text-slate-400">
+              Найдено таблиц: <span data-tables-found class="font-mono text-slate-800 dark:text-slate-200">${tablesFound}</span>
+            </div>
+            ${previewList}
+          </div>
+          <div data-section="privileges">
+            <div class="text-slate-500 dark:text-slate-400">Права:</div>
+            <ul class="mt-1 font-mono">
+              <li>SELECT: <span data-priv="select">${priv.select ? "✓" : "✗"}</span></li>
+              <li>INSERT: <span data-priv="insert">${priv.insert ? "✓" : "✗"}</span></li>
+            </ul>
+          </div>
+        </div>
+        ${warningBlock}
+      `;
+    };
+
+    const renderError = (data) => `
+      <div class="font-medium text-red-700 dark:text-red-300" data-error-code="${escapeHtml(data.code || "error")}">
+        ✗ ${escapeHtml(data.code || "error")}: ${escapeHtml(data.message || "")}
+      </div>
+    `;
+
     document.querySelectorAll(".js-test-conn").forEach((btn) => {
       btn.addEventListener("click", async () => {
         const url = btn.dataset.testUrl;
         const csrf = btn.dataset.csrf;
+        const row = btn.closest("[data-conn-id]");
+        const panel = row.querySelector(".js-test-result");
+        panel.classList.remove("hidden");
+        panel.innerHTML = `<div class="text-slate-500">Проверяю подключение…</div>`;
         btn.disabled = true;
         const original = btn.textContent;
         btn.textContent = "Проверяю…";
@@ -88,13 +146,9 @@
             headers: { "X-CSRFToken": csrf, "Accept": "application/json" },
           });
           const data = await resp.json();
-          if (data.status === "ok") {
-            alert(`✓ ${data.database} (${data.version})\n${data.latency_ms} мс`);
-          } else {
-            alert(`✗ ${data.code}: ${data.message}`);
-          }
+          panel.innerHTML = data.status === "ok" ? renderOk(data) : renderError(data);
         } catch (err) {
-          alert(`✗ Не удалось выполнить запрос: ${err}`);
+          panel.innerHTML = `<div class="text-red-700 dark:text-red-300">✗ Не удалось выполнить запрос: ${escapeHtml(err.message || err)}</div>`;
         } finally {
           btn.disabled = false;
           btn.textContent = original;

--- a/tests/e2e/test_connection_smoke_ui.py
+++ b/tests/e2e/test_connection_smoke_ui.py
@@ -1,0 +1,211 @@
+"""E2E: smoke-check «Тест подключения» рендерит preview + privileges + warning (#229, #230).
+
+Поднимаем Flask с реальным auth и mock-нутым `probe_connection`:
+драйв через Playwright по пути регистрация → создать проект →
+добавить подключение → нажать «Тест» → убедиться что:
+
+- Видим список найденных таблиц (tables_preview, tables_found) — #230
+- Видим privileges {select, insert} — #230
+- При insert=True видим warning «write_privileges_detected» — #229
+- При no_select_permission видим error block — #229
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from collections.abc import Iterator
+
+import pytest
+from cryptography.fernet import Fernet
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# Контролируется тест-кодом: каждый тест ставит сюда canned dict,
+# probe_connection-mock возвращает копию.
+_PROBE_RESULT: dict = {}
+
+
+def _mock_probe(_dsn: str) -> dict:
+    return dict(_PROBE_RESULT)
+
+
+@pytest.fixture(scope="module")
+def smoke_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    import os
+    os.environ["FERNET_KEY"] = Fernet.generate_key().decode()
+
+    from app import crypto
+    crypto.reset_for_tests()
+
+    metrics_db = tmp_path_factory.mktemp("e2e-smoke") / "metrics.db"
+
+    from app.config import settings
+    settings.MONITOR_DB_URL = f"sqlite:///{metrics_db}"
+
+    from app import connections, metrics_storage
+    metrics_storage._engine = None
+    metrics_storage._initialized = False
+    metrics_storage.get_engine()
+
+    # Подменяем probe_connection ДО boot — route смотрит на модульный
+    # символ `probe_connection` в момент запроса, что нам и нужно.
+    orig_probe = connections.probe_connection
+    connections.probe_connection = _mock_probe
+
+    from app import db
+    originals = {
+        "list_tables": db.list_tables,
+        "table_schema": db.table_schema,
+        "table_stats": db.table_stats,
+        "column_nulls": db.column_nulls,
+        "column_distribution": db.column_distribution,
+    }
+    db.list_tables = lambda schema=None: []
+    db.table_schema = lambda t, schema=None: []
+    db.table_stats = lambda t, schema=None: None
+    db.column_nulls = lambda t, schema=None: []
+    db.column_distribution = lambda t, schema=None, top_n=20: []
+
+    from app.app import create_app
+
+    app = create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+        "RATELIMIT_ENABLED": False,
+    })
+    port = _free_port()
+
+    from werkzeug.serving import make_server
+
+    server = make_server("127.0.0.1", port, app, threaded=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        connections.probe_connection = orig_probe
+        for name, fn in originals.items():
+            setattr(db, name, fn)
+
+
+def _submit_form(page: Page) -> None:
+    """Кликаем submit-кнопку внутри основного <form>.
+
+    Base-template содержит и logout-форму, и project-switcher, тоже с
+    button[type='submit'] — глобальный селектор брал их первыми. Скоупим
+    к ближайшей форме на content-area.
+    """
+    page.locator("main form, .max-w-md form, [class*='content'] form").first.locator(
+        "input[type='submit'], button[type='submit']"
+    ).first.click()
+
+
+def _register(page: Page, base: str, email: str) -> None:
+    page.goto(f"{base}/auth/register")
+    page.fill("input[name='email']", email)
+    page.fill("input[name='password']", "supersecret1")
+    page.fill("input[name='confirm']", "supersecret1")
+    _submit_form(page)
+    page.wait_for_url(lambda url: "/auth/register" not in url, timeout=5_000)
+
+
+def _go_to_connections(page: Page, base: str, slug: str) -> None:
+    page.goto(f"{base}/projects/new")
+    page.fill("input[name='name']", "Smoke Demo")
+    page.fill("input[name='slug']", slug)
+    _submit_form(page)
+    page.wait_for_url(f"{base}/projects/{slug}", timeout=5_000)
+
+
+def _add_connection(page: Page, base: str, slug: str) -> None:
+    page.goto(f"{base}/projects/{slug}/connections/new")
+    page.fill("input[name='name']", "demo-db")
+    page.fill("input[name='dsn']", "postgresql://u:p@h:5432/d")
+    page.fill("input[name='schema_name']", "public")
+    page.fill("input[name='interval_minutes']", "15")
+    _submit_form(page)
+    # После create редирект либо на /dashboard (first-connection
+    # auto-test ok), либо на /connections (auto-test error). Оба
+    # подходят — главное чтобы ушли с /connections/new.
+    page.wait_for_url(
+        lambda url: "/connections/new" not in url, timeout=5_000,
+    )
+
+
+def test_smoke_check_shows_tables_privileges_and_write_warning(
+    smoke_server: str, page: Page,
+):
+    """Главный happy path #229 + #230: видим preview, privileges, warning."""
+    global _PROBE_RESULT
+    _PROBE_RESULT = {
+        "status": "ok",
+        "database": "demo",
+        "version": "PostgreSQL 16.1",
+        "latency_ms": 42,
+        "tables_found": 12,
+        "tables_preview": [f"t{i:02d}" for i in range(10)],
+        "privileges": {"select": True, "insert": True},
+        "warnings": ["write_privileges_detected"],
+    }
+
+    _register(page, smoke_server, "smoke-warn@x.io")
+    _go_to_connections(page, smoke_server, "smoke-warn")
+    _add_connection(page, smoke_server, "smoke-warn")
+
+    # Главная проверка — UI-страница списка подключений.
+    page.goto(f"{smoke_server}/projects/smoke-warn/connections")
+    page.click(".js-test-conn")
+
+    panel = page.locator(".js-test-result").first
+    expect(panel).to_be_visible()
+
+    # tables_found рендерится в [data-tables-found].
+    expect(panel.locator("[data-tables-found]")).to_have_text("12")
+
+    # Хотя бы первая таблица из preview видна.
+    expect(panel.get_by_text("t00", exact=True)).to_be_visible()
+
+    # privileges select/insert — оба ✓.
+    expect(panel.locator("[data-priv='select']")).to_have_text("✓")
+    expect(panel.locator("[data-priv='insert']")).to_have_text("✓")
+
+    # Warning блок.
+    expect(panel.locator("[data-warning='write_privileges_detected']")).to_be_visible()
+
+
+def test_smoke_check_shows_no_select_permission_error(
+    smoke_server: str, page: Page,
+):
+    """Acceptance #229: USAGE=false → UI показывает code/message."""
+    global _PROBE_RESULT
+    _PROBE_RESULT = {
+        "status": "error",
+        "code": "no_select_permission",
+        "message": "Нет прав USAGE на схему 'public'.",
+        "latency_ms": 7,
+    }
+
+    _register(page, smoke_server, "smoke-err@x.io")
+    _go_to_connections(page, smoke_server, "smoke-err")
+    # Для no_select_permission — auto-test при создании connection
+    # вернёт error и редиректит на /connections (не /dashboard).
+    _add_connection(page, smoke_server, "smoke-err")
+
+    page.goto(f"{smoke_server}/projects/smoke-err/connections")
+    page.click(".js-test-conn")
+
+    panel = page.locator(".js-test-result").first
+    expect(panel).to_be_visible()
+    expect(panel.locator("[data-error-code='no_select_permission']")).to_be_visible()

--- a/tests/test_connection_test.py
+++ b/tests/test_connection_test.py
@@ -197,13 +197,20 @@ def test_probe_classifies_exception_text(monkeypatch, err_text, expected_code):
 def test_probe_returns_database_and_version_on_success(monkeypatch):
     monkeypatch.setattr(
         connections, "create_engine",
-        lambda *_a, **_kw: _engine_that_returns_metadata("testdb", "PostgreSQL 16.1 on x86_64-pc-linux-gnu"),
+        lambda *_a, **_kw: _engine_that_returns_metadata(
+            "testdb", "PostgreSQL 16.1 on x86_64-pc-linux-gnu",
+        ),
     )
     result = connections.probe_connection("postgresql://u:p@h/d")
     assert result["status"] == "ok"
     assert result["database"] == "testdb"
     assert result["version"] == "PostgreSQL 16.1"  # trims " on x86_64-..."
     assert isinstance(result["latency_ms"], int)
+    # #229/#230 — новые поля в success-ответе.
+    assert result["tables_found"] == 0
+    assert result["tables_preview"] == []
+    assert result["privileges"] == {"select": False, "insert": False}
+    assert result["warnings"] == []
 
 
 # --- Route-level tests ----------------------------------------------------
@@ -248,12 +255,15 @@ def test_test_route_returns_ok_payload(monkeypatch, client):
     resp = client.post(f"/projects/{slug}/connections/{conn_id}/test")
     assert resp.status_code == 200
     body = resp.get_json()
-    assert body == {
-        "status": "ok",
-        "database": "appdb",
-        "version": "PostgreSQL 16.1",
-        "latency_ms": body["latency_ms"],  # any int
-    }
+    assert body["status"] == "ok"
+    assert body["database"] == "appdb"
+    assert body["version"] == "PostgreSQL 16.1"
+    assert isinstance(body["latency_ms"], int)
+    # #229/#230 — smoke-check поля.
+    assert body["tables_found"] == 0
+    assert body["tables_preview"] == []
+    assert body["privileges"] == {"select": False, "insert": False}
+    assert body["warnings"] == []
 
 
 def test_test_route_returns_422_with_code_on_failure(monkeypatch, client):
@@ -341,20 +351,169 @@ def test_test_route_never_leaks_dsn_in_logs(monkeypatch, client, caplog):
     assert "supersecret" not in full_log
 
 
+# --- Smoke-check: privileges + tables (#229 + #230) -----------------------
+
+
+def test_probe_lists_tables_and_returns_preview(monkeypatch):
+    """list_tables → tables_found=N, tables_preview ограничен 10."""
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_returns_metadata(
+            "db", "PostgreSQL 16",
+            tables=[f"t{i:02d}" for i in range(15)],
+            has_select=True, has_insert=False,
+        ),
+    )
+    result = connections.probe_connection("postgresql://u:p@h/d")
+    assert result["status"] == "ok"
+    assert result["tables_found"] == 15
+    assert result["tables_preview"] == [f"t{i:02d}" for i in range(10)]
+    assert result["privileges"] == {"select": True, "insert": False}
+    assert result["warnings"] == []
+
+
+def test_probe_emits_warning_when_insert_detected(monkeypatch):
+    """has_table_privilege(INSERT)=True хоть на одной → warning."""
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_returns_metadata(
+            "db", "PostgreSQL 16",
+            tables=["users", "events"],
+            has_select=True, has_insert=True,
+        ),
+    )
+    result = connections.probe_connection("postgresql://u:p@h/d")
+    assert result["status"] == "ok"
+    # write_privileges_detected — НЕ блокирует, статус остаётся ok.
+    assert result["warnings"] == ["write_privileges_detected"]
+    assert result["privileges"]["insert"] is True
+
+
+def test_probe_returns_no_select_permission_when_no_usage(monkeypatch):
+    """has_schema_privilege(USAGE)=False → error.no_select_permission.
+
+    Acceptance тикета #229 — без USAGE адаптер не может листать таблицы
+    в схеме, дальше идти бессмысленно.
+    """
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_returns_metadata(
+            "db", "PostgreSQL 16", has_usage=False,
+        ),
+    )
+    result = connections.probe_connection("postgresql://u:p@h/d")
+    assert result["status"] == "error"
+    assert result["code"] == "no_select_permission"
+    # Дальнейших полей быть не должно — short-circuit до list_tables.
+    assert "tables_found" not in result
+
+
+def test_probe_empty_schema_no_privileges_no_warning(monkeypatch):
+    """Пустая схема → privileges.* остаются False (нечего проверить),
+    warnings пустой. Не падать."""
+    monkeypatch.setattr(
+        connections, "create_engine",
+        lambda *_a, **_kw: _engine_that_returns_metadata(
+            "db", "PostgreSQL 16", tables=[],
+        ),
+    )
+    result = connections.probe_connection("postgresql://u:p@h/d")
+    assert result["status"] == "ok"
+    assert result["tables_found"] == 0
+    assert result["privileges"] == {"select": False, "insert": False}
+    assert result["warnings"] == []
+
+
+def test_probe_privilege_check_limited_to_20_tables(monkeypatch):
+    """Probe не должен дрочить has_table_privilege по 10k таблицам —
+    cap _PROBE_PRIV_CHECK=20. Это явное требование тикета #229.
+
+    Мокаем engine с 100 таблицами и считаем execute() calls: ожидаем
+    1 (SELECT 1) + 1 (metadata) + 1 (USAGE) + 1 (list tables) + 20
+    (privileges) = 24. _engine_that_returns_metadata уже резает
+    side_effect под [:20] — проверяем что probe не идёт за пределы.
+    """
+    engine_holder: dict = {}
+
+    def build_engine(*_a, **_kw):
+        eng = _engine_that_returns_metadata(
+            "db", "PostgreSQL 16",
+            tables=[f"t{i}" for i in range(100)],
+            has_select=False, has_insert=False,
+        )
+        engine_holder["engine"] = eng
+        return eng
+
+    monkeypatch.setattr(connections, "create_engine", build_engine)
+    result = connections.probe_connection("postgresql://u:p@h/d")
+    assert result["status"] == "ok"
+    assert result["tables_found"] == 100
+    # При has_select=False (и has_insert=False) — break не сработает,
+    # значит probe пройдёт весь cap.
+    eng = engine_holder["engine"]
+    # engine.connect() возвращает context manager, считаем .execute calls
+    # на conn внутри.
+    conn = eng.connect.side_effect.__self__ if hasattr(  # type: ignore[attr-defined]
+        eng.connect.side_effect, "__self__"
+    ) else None
+    # _engine_that_returns_metadata.side_effect — list ровно той длины,
+    # которая нужна; reaching end-of-list raised бы StopIteration.
+    # Если тест не упал — probe не пытался лезть за 20-й privilege check.
+    assert conn is None or conn  # просто sanity, главная проверка — отсутствие падения
+
+
 # --- Fakes -----------------------------------------------------------------
 
 
-def _engine_that_returns_metadata(database: str, version: str):
-    """Build a Mock engine whose .connect().execute(text(...)).fetchone()
-    returns the metadata row on the second call (SELECT current_database, version()).
+def _engine_that_returns_metadata(
+    database: str,
+    version: str,
+    *,
+    has_usage: bool = True,
+    tables: list[str] | None = None,
+    has_select: bool = True,
+    has_insert: bool = False,
+):
+    """Build a Mock engine for the full Postgres probe (#52 + #229/#230).
+
+    Сценарий шагов в реальном `probe_connection`:
+      1. SELECT 1
+      2. SELECT current_database(), version() — `(database, version)`
+      3. SELECT has_schema_privilege(...)     — `(has_usage,)`
+      4. SELECT table_name FROM information_schema.tables — rows
+      5. Per-table: SELECT has_table_privilege(SELECT), (INSERT) — `(s, i)`
+
+    Side-effect chain собран в этом же порядке. Per-table результат для
+    шага 5 — повторяется для каждой таблицы; цикл в коде break-ит при
+    первом совпадении (select=True && insert=True), поэтому достаточно
+    одного результата если ответы детерминистические.
     """
+    tables = tables if tables is not None else []
     engine = MagicMock(name="engine")
     conn = MagicMock(name="conn")
+
     select1 = MagicMock(name="select1")
+
     metadata = MagicMock(name="metadata")
     metadata.fetchone.return_value = (database, version)
-    # First execute: SELECT 1 — value irrelevant. Second: metadata row.
-    conn.execute.side_effect = [select1, metadata]
+
+    usage = MagicMock(name="usage")
+    usage.fetchone.return_value = (has_usage,)
+
+    tables_rs = MagicMock(name="tables")
+    tables_rs.fetchall.return_value = [(t,) for t in tables]
+
+    priv = MagicMock(name="priv")
+    priv.fetchone.return_value = (has_select, has_insert)
+
+    # Шаги 1–4 фиксированной длины, шаг 5 — `min(len(tables), 20)` раз,
+    # либо ноль если таблиц нет / has_usage=False.
+    side: list = [select1, metadata, usage]
+    if has_usage:
+        side.append(tables_rs)
+        for _ in tables[:20]:
+            side.append(priv)
+    conn.execute.side_effect = side
 
     @contextmanager
     def _connect():


### PR DESCRIPTION
Closes #229
Closes #230

Раньше «Тест подключения» возвращал только `{database, version,
latency_ms}` — пользователь видел «✓ OK» и не знал, сколько таблиц
найдено, есть ли права, не дал ли он admin-DSN. Эти два тикета вместе
закрывают smoke-check.

## Backend

`probe_connection` для Postgres расширен (все шаги SELECT-only):

1. `has_schema_privilege(... 'USAGE')` — false → short-circuit с
   `code: no_select_permission`.
2. `information_schema.tables` → `tables_found: N`, `tables_preview: [...]`
   (до 10).
3. `has_table_privilege('SELECT')` + `'INSERT'` на первых 20 →
   `privileges: {select, insert}`, `warnings:
   [\"write_privileges_detected\"]` если INSERT.

Cap 20 на privilege-check, чтобы не сканить 10k таблиц.

## UI

`alert()` убран → inline-панель `.js-test-result` под рядом подключения
показывает все три части (database/version, найдённые таблицы +
preview, права + warning). Data-атрибуты (`[data-tables-found]`,
`[data-priv=select|insert]`, `[data-warning=...]`, `[data-error-code=...]`) —
стабильный API для E2E selectors.

## Acceptance

#229: warnings=[] для read-only / warnings=[\"write_privileges_detected\"]
при INSERT / no_select_permission без USAGE / SELECT-only / UI
показывает warning.

#230: tables_found / tables_preview / privileges / UI рендерит /
smoke-check не пишет в metrics и не создаёт scheduler jobs / при
недоступном хосте — status:error.

## Tests

- **5 unit** (`tests/test_connection_test.py`, всего 30): preview cap,
  warning при INSERT, no_select_permission, пустая схема, privilege
  check capped 20.
- **2 E2E Playwright** (`tests/e2e/test_connection_smoke_ui.py`):
  happy path (видим tables_found / preview / privileges / warning),
  error path (видим [data-error-code=no_select_permission]).

## Test plan

- [x] 766 unit passed
- [x] 2 E2E passed
- [x] ruff clean