### PR TITLE
feat(#225): фронтенд-фильтр таблиц на /dashboard

### DIFF
--- a/templates/overview.html
+++ b/templates/overview.html
@@ -78,9 +78,18 @@
   {% endif %}
 
   <section class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-    <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+    <div class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-slate-800">
       <h2 class="text-base font-semibold">Обзор таблиц</h2>
-      <span class="text-xs text-slate-500 dark:text-slate-400">{{ tables|length }} таблиц</span>
+      <div class="flex items-center gap-3">
+        {# #225: клиент-сайд фильтр. Серверной пагинации нет — на 30+ таблиц
+           Ctrl+F-style поиск спасает. JS-обработчик ниже. #}
+        <input type="search"
+               id="table-filter"
+               placeholder="Фильтр по имени таблицы…"
+               aria-label="Фильтр таблиц"
+               class="w-64 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent dark:border-slate-700 dark:bg-slate-950">
+        <span class="text-xs text-slate-500 dark:text-slate-400">{{ tables|length }} таблиц</span>
+      </div>
     </div>
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
@@ -94,10 +103,10 @@
             <th class="px-5 py-3 font-medium"></th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+        <tbody class="divide-y divide-slate-100 dark:divide-slate-800" id="table-rows">
           {% for t in tables %}
             {% set status = t.null_rate|status_class %}
-            <tr class="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+            <tr class="hover:bg-slate-50 dark:hover:bg-slate-800/50" data-table-name="{{ t.table_name }}">
               <td class="px-5 py-3">
                 <a href="/dashboard/schema/{{ t.table_name }}" class="font-medium text-accent hover:underline">{{ t.table_name }}</a>
                 <div class="text-xs text-slate-500 dark:text-slate-400">{{ t.schema }}</div>
@@ -124,6 +133,37 @@
           {% endfor %}
         </tbody>
       </table>
+      {# #225: показывается JS-ом когда все строки скрыты фильтром.
+         Изначально hidden, серверный empty-state остаётся <tr> выше. #}
+      <p id="no-tables-msg" hidden class="px-5 py-8 text-center text-sm text-slate-500 dark:text-slate-400">
+        Таблицы не найдены
+      </p>
     </div>
   </section>
+
+  {% if tables %}
+  <script>
+    // #225: клиент-сайд фильтр по data-table-name. Case-insensitive
+    // substring match. Не вешает обработчик на keydown — input
+    // покрывает и paste, и очистку через × у type=search.
+    (() => {
+      const input = document.getElementById("table-filter");
+      const rows = document.querySelectorAll("#table-rows > tr[data-table-name]");
+      const emptyMsg = document.getElementById("no-tables-msg");
+      if (!input || !rows.length) return;
+
+      input.addEventListener("input", () => {
+        const needle = input.value.trim().toLowerCase();
+        let visible = 0;
+        rows.forEach((row) => {
+          const name = (row.dataset.tableName || "").toLowerCase();
+          const match = needle === "" || name.includes(needle);
+          row.hidden = !match;
+          if (match) visible++;
+        });
+        emptyMsg.hidden = visible !== 0;
+      });
+    })();
+  </script>
+  {% endif %}
 {% endblock %}

--- a/tests/e2e/test_dashboard_filter.py
+++ b/tests/e2e/test_dashboard_filter.py
@@ -1,0 +1,61 @@
+"""E2E: фильтр таблиц на /dashboard (#225).
+
+`live_dashboard` фикстур из conftest сидит две таблицы: `users` и
+`events`. Этого достаточно чтобы проверить:
+
+- input#table-filter присутствует на странице
+- ввод "use" → видим users, не видим events
+- регистронезависимость: ввод "USER" → users всё ещё совпадает
+- очистка → обе строки видны
+- ввод бессмысленной строки → видим #no-tables-msg
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+
+def test_filter_hides_non_matching_rows(live_dashboard: str, page: Page):
+    page.goto(f"{live_dashboard}/dashboard")
+    users_row = page.locator("tr[data-table-name='users']")
+    events_row = page.locator("tr[data-table-name='events']")
+    expect(users_row).to_be_visible()
+    expect(events_row).to_be_visible()
+
+    page.fill("#table-filter", "use")
+    expect(users_row).to_be_visible()
+    expect(events_row).to_be_hidden()
+
+
+def test_filter_is_case_insensitive(live_dashboard: str, page: Page):
+    """Acceptance: «USER» находит «users»."""
+    page.goto(f"{live_dashboard}/dashboard")
+
+    page.fill("#table-filter", "USER")
+    expect(page.locator("tr[data-table-name='users']")).to_be_visible()
+    expect(page.locator("tr[data-table-name='events']")).to_be_hidden()
+
+
+def test_clearing_filter_restores_all_rows(live_dashboard: str, page: Page):
+    page.goto(f"{live_dashboard}/dashboard")
+    page.fill("#table-filter", "USER")
+    expect(page.locator("tr[data-table-name='events']")).to_be_hidden()
+
+    page.fill("#table-filter", "")
+    expect(page.locator("tr[data-table-name='users']")).to_be_visible()
+    expect(page.locator("tr[data-table-name='events']")).to_be_visible()
+
+
+def test_no_matches_shows_empty_state(live_dashboard: str, page: Page):
+    page.goto(f"{live_dashboard}/dashboard")
+    # #no-tables-msg изначально hidden (есть строки).
+    expect(page.locator("#no-tables-msg")).to_be_hidden()
+
+    page.fill("#table-filter", "zzz-no-such-table")
+    expect(page.locator("tr[data-table-name='users']")).to_be_hidden()
+    expect(page.locator("tr[data-table-name='events']")).to_be_hidden()
+    expect(page.locator("#no-tables-msg")).to_be_visible()
+    expect(page.locator("#no-tables-msg")).to_have_text("Таблицы не найдены")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -138,6 +138,27 @@ def test_overview_renders_kpis_and_table_from_storage(client):
     mock_stats.assert_not_called()
 
 
+def test_overview_renders_table_filter_input(client):
+    """#225: на /dashboard есть input#table-filter + data-table-name= в строках."""
+    fake_tables = [
+        {"table_name": "users", "schema": "public"},
+        {"table_name": "orders", "schema": "public"},
+    ]
+    with patch("app.dashboard.db.list_tables", return_value=fake_tables), \
+         patch("app.dashboard.get_latest_metric", return_value=None):
+        resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'id="table-filter"' in body
+    assert 'type="search"' in body
+    assert 'data-table-name="users"' in body
+    assert 'data-table-name="orders"' in body
+    # Placeholder для empty-state (показывается JS-ом когда фильтр не
+    # совпал ни с одной строкой) — должен быть в HTML.
+    assert 'id="no-tables-msg"' in body
+    assert "Таблицы не найдены" in body
+
+
 def test_overview_handles_no_collected_metrics(client):
     """Tables with no stored metrics still render — values show as em-dash placeholders."""
     with patch("app.dashboard.db.list_tables", return_value=[{"table_name": "fresh", "schema": "public"}]), \


### PR DESCRIPTION
Closes #225

На 30+ таблицах overview становится длинным скроллом. Добавляем
live-фильтр над списком таблиц.

## Что делает PR

- `<input type="search" id="table-filter">` над таблицей
- `data-table-name="..."` на каждой строке
- Inline JS: substring-match (case-insensitive) на событие \`input\`,
  не совпавшие → \`row.hidden = true\`
- `<p id="no-tables-msg" hidden>Таблицы не найдены</p>` —
  показывается JS-ом когда ни одна строка не прошла фильтр

Никаких новых роутов, URL-параметров, сортировки и серверной
пагинации — pure frontend, как просит тикет.

## Acceptance

- [x] input#table-filter присутствует в HTML
- [x] Ввод → скрывает не совпавшие строки без перезагрузки
- [x] Case-insensitive (\"USER\" находит \"users\")
- [x] Очистка восстанавливает все строки
- [x] Ноль результатов → текст «Таблицы не найдены»

## Tests

- **1 unit** (`tests/test_dashboard.py::test_overview_renders_table_filter_input`)
  — HTML-level: input#table-filter, type=search, data-table-name на
  строках, id=no-tables-msg, текст «Таблицы не найдены».
- **4 E2E Playwright** (`tests/e2e/test_dashboard_filter.py`) — ввод
  \"use\"/\"USER\"/очистка/нет совпадений.

## Test plan

- [x] 767 unit passed
- [x] 4 E2E passed
- [x] ruff clean