### PR TITLE
fix(#223): предупреждать о ненастроенном SMTP для reset-писем

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,20 @@ LOG_LEVEL=INFO
 # Режим Flask
 FLASK_ENV=development
 
+# --- SMTP password reset emails (#223) ------------------------------------
+#
+# SMTP нужен, чтобы пользователи реально получали письма сброса пароля.
+# Если SMTP_HOST пустой, приложение не падает: письмо сохраняется только
+# в in-memory app.email.outbox для локальной разработки и тестов.
+# В production SMTP_HOST должен быть заполнен.
+#
+# SMTP_HOST=smtp.gmail.com
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASSWORD=
+# SMTP_FROM=noreply@yourdomain.com
+# SMTP_USE_TLS=true
+
 # --- Production hardening (#56) -------------------------------------------
 #
 # Rate limit storage (Flask-Limiter). По умолчанию in-memory — корректно

--- a/app/auth.py
+++ b/app/auth.py
@@ -265,6 +265,11 @@ def forgot_password():
         email = _normalize_email(form.email.data)
         row = metrics_storage.get_user_by_email(email)
         if row is not None:
+            if not settings.smtp_configured:
+                logger.warning(
+                    "forgot-password: SMTP not configured; reset email "
+                    "captured in memory backend"
+                )
             # Invalidate any active tokens first — only the latest email
             # should resolve. Then mint + persist + send.
             metrics_storage.invalidate_password_reset_tokens(row["id"])

--- a/app/config.py
+++ b/app/config.py
@@ -67,6 +67,10 @@ class Settings(BaseSettings):
     SMTP_FROM: str = "no-reply@dbmonitor.local"
     SMTP_USE_TLS: bool = True
 
+    @property
+    def smtp_configured(self) -> bool:
+        return bool((self.SMTP_HOST or "").strip())
+
     # Absolute base URL the app is served from — used to build links in
     # outgoing emails (reset-password link, future invite links, etc).
     # Reading request.host inside the route would pick up internal

--- a/app/email.py
+++ b/app/email.py
@@ -47,15 +47,15 @@ _outbox_lock = threading.Lock()
 
 
 def _smtp_enabled() -> bool:
-    return bool(settings.SMTP_HOST)
+    return settings.smtp_configured
 
 
 def _send_smtp(to: str, subject: str, body: str) -> bool:
     """Send via stdlib smtplib. Returns True on success, False on failure.
 
     Failures are logged but never re-raised — the caller (/forgot-password)
-    must always respond 200 OK so attackers can't enumerate registered
-    emails via timing or status-code differences.
+    must keep the same HTTP response for known/unknown emails so attackers
+    can't enumerate registered emails via timing or status-code differences.
     """
     msg = EmailMessage()
     msg["From"] = settings.SMTP_FROM
@@ -77,7 +77,7 @@ def _send_smtp(to: str, subject: str, body: str) -> bool:
                 smtp.send_message(msg)
         return True
     except (OSError, smtplib.SMTPException) as exc:
-        logger.warning("SMTP send to %s failed: %s", to, exc)
+        logger.warning("SMTP send failed: %s", exc)
         return False
 
 
@@ -91,7 +91,9 @@ def send_email(to: str, subject: str, body: str) -> bool:
         return _send_smtp(to, subject, body)
     with _outbox_lock:
         outbox.append(SentMessage(to=to, subject=subject, body=body))
-    logger.info("[memory backend] queued email to %s subj=%r", to, subject)
+    logger.warning(
+        "SMTP not configured; using memory email backend; email NOT delivered"
+    )
     return True
 
 

--- a/app/health.py
+++ b/app/health.py
@@ -113,6 +113,12 @@ def _check_ratelimit_storage(storage_uri: str) -> dict:
     return {"status": "ok"}
 
 
+def _check_smtp() -> dict:
+    from app.config import settings
+
+    return {"status": "n/a", "configured": settings.smtp_configured}
+
+
 # --- Probe runner with hard timeout ---------------------------------------
 
 
@@ -158,14 +164,19 @@ def build_health_payload(*, strict: bool, ratelimit_storage_uri: str) -> tuple[d
         "ratelimit_storage": _run_check(
             "ratelimit_storage", _check_ratelimit_storage, ratelimit_storage_uri,
         ),
+        "smtp": _check_smtp(),
     }
     # Defensive: if some future check is added that runs over the total
     # budget, we still return SOMETHING rather than hanging.
     if (time.monotonic() - started) > _TOTAL_BUDGET_S:
         logger.error("healthz: total budget exceeded — investigate")
 
-    any_down = any(c["status"] == "down" for c in checks.values())
-    any_na = any(c["status"] == "n/a" for c in checks.values())
+    critical_checks = {
+        name: check for name, check in checks.items()
+        if name != "smtp"
+    }
+    any_down = any(c["status"] == "down" for c in critical_checks.values())
+    any_na = any(c["status"] == "n/a" for c in critical_checks.values())
 
     if any_down or (strict and any_na):
         overall = "degraded"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -144,6 +144,63 @@ def test_healthz_returns_200_with_na_default(client):
     assert body["checks"]["ratelimit_storage"]["status"] == "n/a"
 
 
+def test_healthz_smtp_not_configured(client, monkeypatch):
+    from app.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "SMTP_HOST", "")
+
+    resp = client.get("/healthz")
+    body = resp.get_json()
+
+    assert resp.status_code == 200
+    assert body["checks"]["smtp"]["status"] == "n/a"
+    assert body["checks"]["smtp"]["configured"] is False
+
+
+def test_healthz_smtp_configured(client, monkeypatch):
+    from app.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "SMTP_HOST", "smtp.example.com")
+
+    resp = client.get("/healthz")
+    body = resp.get_json()
+
+    assert resp.status_code == 200
+    assert body["checks"]["smtp"]["status"] == "n/a"
+    assert body["checks"]["smtp"]["configured"] is True
+
+
+def test_healthz_smtp_non_critical_under_strict(client, monkeypatch):
+    from app.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "SMTP_HOST", "")
+    monkeypatch.setattr("app.health._check_monitor_db", lambda: {"status": "ok"})
+    monkeypatch.setattr("app.health._check_target_db", lambda: {"status": "ok"})
+    monkeypatch.setattr("app.health._check_ratelimit_storage", lambda _uri: {"status": "ok"})
+
+    payload, status = build_health_payload(
+        strict=True, ratelimit_storage_uri="redis://example",
+    )
+
+    assert status == 200
+    assert payload["status"] == "ok"
+    assert payload["checks"]["smtp"]["status"] == "n/a"
+    assert payload["checks"]["smtp"]["configured"] is False
+
+
+def test_smtp_configured_strips_whitespace(monkeypatch):
+    from app.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "SMTP_HOST", "")
+    assert cfg.smtp_configured is False
+
+    monkeypatch.setattr(cfg, "SMTP_HOST", "   ")
+    assert cfg.smtp_configured is False
+
+    monkeypatch.setattr(cfg, "SMTP_HOST", "smtp.example.com")
+    assert cfg.smtp_configured is True
+
+
 def test_healthz_strict_treats_na_as_failure(client):
     """`?strict=true` flips n/a → 503 for paranoid k8s liveness."""
     resp = client.get("/healthz?strict=true")

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -8,12 +8,14 @@ Covers acceptance criteria from the issue:
 - New forgot-password request invalidates earlier active tokens
 - Successful reset invalidates all other active tokens of the user
 - After reset, old password no longer works
-- /forgot-password ALWAYS responds 200 (no leak of email existence)
+- /forgot-password responds the same for known/unknown email
+  (no leak of email existence)
 - Rate limit on /forgot-password binds to (email, IP)
 """
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -166,6 +168,65 @@ def test_forgot_known_email_sends_message(client):
     # Link is built from APP_BASE_URL, not request.host.
     assert msg.body.startswith("Здравствуйте")
     assert "http://test.local/auth/reset-password/" in msg.body
+
+
+def test_send_email_memory_backend_logs_warning(client, caplog):
+    from app.config import settings as cfg
+
+    cfg.SMTP_HOST = ""
+
+    with caplog.at_level("WARNING"):
+        assert email_mod.send_email("pii@example.com", "Subject", "Body") is True
+
+    assert "SMTP not configured; using memory email backend" in caplog.text
+    assert "pii@example.com" not in caplog.text
+    assert "Body" not in caplog.text
+
+
+def test_forgot_password_same_response_known_unknown(client):
+    _register(client, "registered@example.com")
+
+    known = client.post("/auth/forgot-password",
+                        data={"email": "registered@example.com"})
+    unknown = client.post("/auth/forgot-password",
+                          data={"email": "ghost@example.com"})
+
+    assert known.status_code == unknown.status_code == 302
+    assert known.headers["Location"] == unknown.headers["Location"]
+
+
+def test_forgot_password_logs_warning_no_pii(client, caplog):
+    _register(client, "warn@example.com")
+
+    with caplog.at_level("WARNING"):
+        resp = client.post("/auth/forgot-password",
+                           data={"email": "warn@example.com"})
+
+    assert resp.status_code == 302
+    assert "forgot-password: SMTP not configured" in caplog.text
+    assert "warn@example.com" not in caplog.text
+
+
+def test_smtp_send_calls_smtplib(client, monkeypatch):
+    from app.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(cfg, "SMTP_PORT", 587)
+    monkeypatch.setattr(cfg, "SMTP_USER", "user")
+    monkeypatch.setattr(cfg, "SMTP_PASSWORD", "pass")
+    monkeypatch.setattr(cfg, "SMTP_USE_TLS", True)
+
+    smtp = MagicMock()
+    smtp_cls = MagicMock()
+    smtp_cls.return_value.__enter__.return_value = smtp
+
+    with patch("app.email.smtplib.SMTP", smtp_cls):
+        assert email_mod.send_email("to@example.com", "Subject", "Body") is True
+
+    smtp_cls.assert_called_once_with("smtp.example.com", 587, timeout=10)
+    smtp.starttls.assert_called_once()
+    smtp.login.assert_called_once_with("user", "pass")
+    smtp.send_message.assert_called_once()
 
 
 def test_forgot_new_request_invalidates_previous_tokens(client):


### PR DESCRIPTION
Closes #223

## Что изменилось

- Добавлен `settings.smtp_configured` с `strip()` для `SMTP_HOST`.
- `send_email()` при memory backend пишет WARNING без email/тела/токена.
- `forgot_password()` пишет WARNING без PII, если пользователь найден, но SMTP не настроен.
- `/healthz` теперь показывает `checks.smtp.configured`, при этом SMTP остаётся non-critical и не влияет на общий status/HTTP-код.
- `.env.example` дополнен SMTP-переменными.
- Добавлены тесты для warning/no-PII, healthz SMTP check, config и mock SMTP.

## Проверки

- `venv/bin/pytest tests/test_password_reset.py tests/test_health.py tests/test_auth.py -q` → 68 passed
- `venv/bin/ruff check app/auth.py app/config.py app/email.py app/health.py tests/test_health.py tests/test_password_reset.py` → All checks passed