### PR TITLE
feat(#224): переименование проекта

### DIFF
--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -2159,6 +2159,24 @@ def list_project_members(project_id: str) -> list[dict]:
     ]
 
 
+def rename_project(project_id: str, new_name: str) -> bool:
+    """Update projects.name. Returns True when the row was found and changed,
+    False when project_id doesn't exist (#224).
+
+    slug is intentionally NOT touched — it's part of the URL and immutable
+    after creation (changing it would break invite links, bookmarks, and
+    project_members joins).
+    Caller is responsible for the owner-only access check; storage is a
+    plain UPDATE so misuse is at the route layer.
+    """
+    with get_engine().begin() as conn:
+        result = conn.execute(
+            text("UPDATE projects SET name = :name WHERE id = :id"),
+            {"name": new_name, "id": project_id},
+        )
+    return (result.rowcount or 0) > 0
+
+
 def delete_project(user_id: str, project_id: str) -> bool:
     """Hard delete. Returns True if a row was removed.
 

--- a/app/projects.py
+++ b/app/projects.py
@@ -69,6 +69,17 @@ class ProjectForm(FlaskForm):
     submit = SubmitField("Создать")
 
 
+class RenameProjectForm(FlaskForm):
+    """Standalone form for #224. Only the name is editable — slug stays put."""
+
+    name = StringField(
+        "Название",
+        validators=[DataRequired(), Length(min=1, max=80)],
+        render_kw={"autocomplete": "off", "autofocus": True},
+    )
+    submit = SubmitField("Сохранить")
+
+
 # --- Routes ---------------------------------------------------------------
 
 
@@ -176,6 +187,29 @@ def delete(slug: str):
         session.pop("current_project_id", None)
     flash(f"Проект «{project['name']}» удалён.", "info")
     return redirect(url_for("projects.list_projects"))
+
+
+@bp.route("/<slug>/rename", methods=["GET", "POST"])
+@login_required
+def rename(slug: str):
+    """Owner-only project rename (#224). slug stays immutable.
+
+    Same access check on GET and POST so the form page itself is gated —
+    a non-owner who knows the slug doesn't even get to see the form.
+    """
+    project = _require_role(slug, "owner")
+    form = RenameProjectForm(name=project["name"])
+    if form.validate_on_submit():
+        new_name = form.name.data.strip()
+        renamed = metrics_storage.rename_project(project["id"], new_name)
+        if not renamed:
+            # project_id vanished between the access check and the UPDATE
+            # (e.g. concurrent delete). Surface as 404 rather than silently
+            # rendering "saved" on a row that no longer exists.
+            abort(404)
+        flash("Проект переименован.", "success")
+        return redirect(url_for("projects.detail", slug=slug))
+    return render_template("projects/rename.html", form=form, project=project)
 
 
 @bp.route("/<slug>/switch", methods=["POST"])

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -13,6 +13,12 @@
       <span class="font-mono text-xs text-slate-500 dark:text-slate-400">{{ project.slug }}</span>
     </div>
     <div class="flex items-center gap-2">
+      {% if project.role == 'owner' %}
+        <a href="{{ url_for('projects.rename', slug=project.slug) }}"
+           class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
+          Переименовать
+        </a>
+      {% endif %}
       {% if project.role in ('owner', 'editor') %}
         <a href="{{ url_for('settings.notifications', slug=project.slug) }}"
            class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">

--- a/templates/projects/rename.html
+++ b/templates/projects/rename.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% from "auth/_macros.html" import render_field %}
+{% block title %}Переименовать проект — DB Monitor{% endblock %}
+{% block breadcrumb %}
+  <a href="{{ url_for('projects.list_projects') }}" class="hover:text-slate-700 dark:hover:text-slate-200">Проекты</a>
+  <span class="text-slate-300 dark:text-slate-600">/</span>
+  <a href="{{ url_for('projects.detail', slug=project.slug) }}" class="hover:text-slate-700 dark:hover:text-slate-200">{{ project.name }}</a>
+  <span class="text-slate-300 dark:text-slate-600">/</span>
+  <span class="font-medium text-slate-700 dark:text-slate-200">Переименование</span>
+{% endblock %}
+
+{% set input_cls = "mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent dark:border-slate-700 dark:bg-slate-950" %}
+
+{% block content %}
+  <h1 class="text-2xl font-semibold tracking-tight">Переименовать проект</h1>
+  <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+    Слаг <span class="font-mono">{{ project.slug }}</span> останется прежним — изменится только отображаемое имя.
+  </p>
+
+  <div class="mt-4">{% include "_flash.html" %}</div>
+
+  <div class="mt-6 max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <form method="POST" class="space-y-4" novalidate>
+      {{ form.hidden_tag() }}
+      {{ render_field(form.name, input_class=input_cls) }}
+      <div class="flex items-center justify-between">
+        <a href="{{ url_for('projects.detail', slug=project.slug) }}" class="text-sm text-slate-500 hover:text-accent dark:text-slate-400">← Отмена</a>
+        {{ form.submit(class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover") }}
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/tests/test_project_rename.py
+++ b/tests/test_project_rename.py
@@ -1,0 +1,361 @@
+"""Integration tests for #224 — project rename.
+
+Mirrors the test list from the acceptance criteria:
+
+- test_owner_can_rename
+- test_slug_unchanged_after_rename
+- test_viewer_cannot_get_rename_form
+- test_viewer_cannot_post_rename
+- test_editor_cannot_get_rename_form
+- test_editor_cannot_post_rename
+- test_new_name_visible_in_project_list
+- test_new_name_visible_in_detail
+- test_empty_name_rejected
+- test_long_name_rejected
+- test_rename_project_returns_false_for_unknown_id
+- test_connections_intact_after_rename
+- test_metrics_intact_after_rename
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app import metrics_storage
+from app.app import create_app
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    db_path = tmp_path / "rename.db"
+    monkeypatch.setattr(
+        metrics_storage.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}",
+    )
+    monkeypatch.setattr(metrics_storage, "_engine", None)
+    monkeypatch.setattr(metrics_storage, "_initialized", False)
+
+    import app.db
+    monkeypatch.setattr(app.db, "list_tables", lambda schema=None: [])
+
+    return create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+    })
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _register(client, email, password="secret123"):
+    return client.post("/auth/register", data={
+        "email": email, "password": password, "confirm": password,
+    })
+
+
+def _login(client, email, password="secret123"):
+    return client.post("/auth/login", data={"email": email, "password": password})
+
+
+def _logout(client):
+    client.post("/auth/logout")
+
+
+def _make_project(client, suffix=""):
+    slug = f"proj-{suffix or uuid.uuid4().hex[:8]}"
+    r = client.post("/projects/new", data={"name": f"Test {slug}", "slug": slug})
+    assert r.status_code in (302, 200)
+    return slug
+
+
+def _get_project_id_by_slug(app_ctx, slug):
+    with app_ctx.app_context():
+        with metrics_storage.get_engine().connect() as conn:
+            row = conn.execute(
+                text("SELECT id FROM projects WHERE slug = :slug"),
+                {"slug": slug},
+            ).fetchone()
+    return row[0] if row else None
+
+
+# --- fixtures: owner / viewer / editor sessions ----------------------------
+
+
+@pytest.fixture
+def owner_with_project(app, client):
+    _register(client, "owner@rn.com")
+    slug = _make_project(client, suffix="rn")
+    pid = _get_project_id_by_slug(app, slug)
+    return slug, pid
+
+
+@pytest.fixture
+def viewer_session(app, client, owner_with_project):
+    slug, pid = owner_with_project
+    _logout(client)
+    _register(client, "viewer@rn.com")
+    with app.app_context():
+        u = metrics_storage.get_user_by_email("viewer@rn.com")
+        metrics_storage.add_project_member(pid, u["id"], "viewer")
+    _logout(client)
+    _login(client, "viewer@rn.com")
+    return slug, pid
+
+
+@pytest.fixture
+def editor_session(app, client, owner_with_project):
+    slug, pid = owner_with_project
+    _logout(client)
+    _register(client, "editor@rn.com")
+    with app.app_context():
+        u = metrics_storage.get_user_by_email("editor@rn.com")
+        metrics_storage.add_project_member(pid, u["id"], "editor")
+    _logout(client)
+    _login(client, "editor@rn.com")
+    return slug, pid
+
+
+# --- storage layer ---------------------------------------------------------
+
+
+def test_rename_project_returns_true_on_success(app, owner_with_project):
+    _, pid = owner_with_project
+    with app.app_context():
+        assert metrics_storage.rename_project(pid, "Renamed") is True
+        with metrics_storage.get_engine().connect() as conn:
+            row = conn.execute(
+                text("SELECT name FROM projects WHERE id = :id"),
+                {"id": pid},
+            ).fetchone()
+    assert row[0] == "Renamed"
+
+
+def test_rename_project_returns_false_for_unknown_id(app):
+    with app.app_context():
+        assert metrics_storage.rename_project("nonexistent-id", "X") is False
+
+
+# --- route: access control -------------------------------------------------
+
+
+def test_owner_can_get_rename_form(client, owner_with_project):
+    slug, _ = owner_with_project
+    r = client.get(f"/projects/{slug}/rename")
+    assert r.status_code == 200
+    # Form is pre-filled with the current name.
+    assert "Test proj-rn" in r.data.decode()
+
+
+def test_viewer_cannot_get_rename_form(client, viewer_session):
+    slug, _ = viewer_session
+    r = client.get(f"/projects/{slug}/rename")
+    assert r.status_code == 403
+
+
+def test_viewer_cannot_post_rename(client, viewer_session):
+    slug, _ = viewer_session
+    r = client.post(f"/projects/{slug}/rename", data={"name": "Hack"})
+    assert r.status_code == 403
+
+
+def test_editor_cannot_get_rename_form(client, editor_session):
+    slug, _ = editor_session
+    r = client.get(f"/projects/{slug}/rename")
+    assert r.status_code == 403
+
+
+def test_editor_cannot_post_rename(client, editor_session):
+    slug, _ = editor_session
+    r = client.post(f"/projects/{slug}/rename", data={"name": "Hack"})
+    assert r.status_code == 403
+
+
+# --- route: happy path -----------------------------------------------------
+
+
+def test_owner_can_rename(app, client, owner_with_project):
+    slug, pid = owner_with_project
+    r = client.post(
+        f"/projects/{slug}/rename",
+        data={"name": "Production DB"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    assert r.headers["Location"].endswith(f"/projects/{slug}")
+
+    with app.app_context():
+        with metrics_storage.get_engine().connect() as conn:
+            row = conn.execute(
+                text("SELECT name, slug FROM projects WHERE id = :id"),
+                {"id": pid},
+            ).fetchone()
+    assert row[0] == "Production DB"
+    assert row[1] == slug  # slug unchanged
+
+
+def test_slug_unchanged_after_rename(client, owner_with_project):
+    slug, _ = owner_with_project
+    client.post(f"/projects/{slug}/rename", data={"name": "New Name"})
+    # Original slug still serves the project page.
+    r = client.get(f"/projects/{slug}")
+    assert r.status_code == 200
+
+
+def test_new_name_visible_in_detail(client, owner_with_project):
+    slug, _ = owner_with_project
+    client.post(f"/projects/{slug}/rename", data={"name": "Shiny Name"})
+    html = client.get(f"/projects/{slug}").data.decode()
+    assert "Shiny Name" in html
+
+
+def test_new_name_visible_in_project_list(client, owner_with_project):
+    slug, _ = owner_with_project
+    client.post(f"/projects/{slug}/rename", data={"name": "Shiny Name"})
+    html = client.get("/projects").data.decode()
+    assert "Shiny Name" in html
+
+
+def test_new_name_visible_in_header_switcher(client, owner_with_project):
+    """g.user_projects feeds the header switcher — the new name must appear
+    on any rendered page after rename (we check a fresh detail render)."""
+    slug, _ = owner_with_project
+    client.post(f"/projects/{slug}/rename", data={"name": "HeaderName"})
+    # Switch to the project so g.current_project is set, then re-render.
+    client.post(f"/projects/{slug}/switch")
+    html = client.get("/dashboard").data.decode()
+    assert "HeaderName" in html
+
+
+def test_new_name_visible_in_breadcrumbs(client, owner_with_project):
+    slug, _ = owner_with_project
+    client.post(f"/projects/{slug}/rename", data={"name": "Crumby"})
+    html = client.get(f"/projects/{slug}").data.decode()
+    # The breadcrumb block includes the project name as the trailing span.
+    assert "Crumby" in html
+
+
+# --- validation ------------------------------------------------------------
+
+
+def test_empty_name_rejected(app, client, owner_with_project):
+    slug, pid = owner_with_project
+    r = client.post(f"/projects/{slug}/rename", data={"name": ""})
+    # Re-renders form, not a redirect.
+    assert r.status_code == 200
+    assert b"Location" not in r.headers.get("Location", b"") if False else True
+
+    with app.app_context():
+        with metrics_storage.get_engine().connect() as conn:
+            row = conn.execute(
+                text("SELECT name FROM projects WHERE id = :id"),
+                {"id": pid},
+            ).fetchone()
+    # Name was not changed.
+    assert row[0] == "Test proj-rn"
+
+
+def test_long_name_rejected(app, client, owner_with_project):
+    slug, pid = owner_with_project
+    too_long = "a" * 81
+    r = client.post(f"/projects/{slug}/rename", data={"name": too_long})
+    assert r.status_code == 200
+
+    with app.app_context():
+        with metrics_storage.get_engine().connect() as conn:
+            row = conn.execute(
+                text("SELECT name FROM projects WHERE id = :id"),
+                {"id": pid},
+            ).fetchone()
+    assert row[0] == "Test proj-rn"
+
+
+def test_max_length_name_accepted(app, client, owner_with_project):
+    """Boundary check: exactly 80 chars must pass."""
+    slug, pid = owner_with_project
+    name = "x" * 80
+    r = client.post(
+        f"/projects/{slug}/rename", data={"name": name}, follow_redirects=False,
+    )
+    assert r.status_code == 302
+    with app.app_context():
+        with metrics_storage.get_engine().connect() as conn:
+            row = conn.execute(
+                text("SELECT name FROM projects WHERE id = :id"),
+                {"id": pid},
+            ).fetchone()
+    assert row[0] == name
+
+
+# --- data preservation -----------------------------------------------------
+
+
+def test_connections_intact_after_rename(app, client, owner_with_project):
+    slug, pid = owner_with_project
+    # Seed two connections directly via storage (route layer crypto setup
+    # would be overkill here — we only care that the rows survive).
+    with app.app_context():
+        metrics_storage.create_connection(
+            connection_id="c1", project_id=pid, name="db1",
+            dsn_encrypted=b"x", schema_name="public", interval_minutes=15,
+        )
+        metrics_storage.create_connection(
+            connection_id="c2", project_id=pid, name="db2",
+            dsn_encrypted=b"y", schema_name="public", interval_minutes=15,
+        )
+
+    client.post(f"/projects/{slug}/rename", data={"name": "After"})
+
+    with app.app_context():
+        conns = metrics_storage.list_connections_for_project(pid)
+    assert {c["name"] for c in conns} == {"db1", "db2"}
+
+
+def test_metrics_intact_after_rename(app, client, owner_with_project):
+    slug, pid = owner_with_project
+    with app.app_context():
+        metrics_storage.save_metrics([
+            {"ts": "2026-06-08T00:00:00", "table_name": "t1",
+             "metric_name": "row_count", "value": 100.0},
+            {"ts": "2026-06-08T00:05:00", "table_name": "t1",
+             "metric_name": "row_count", "value": 110.0},
+        ], project_id=pid)
+
+    client.post(f"/projects/{slug}/rename", data={"name": "After"})
+
+    with app.app_context():
+        with metrics_storage.get_engine().connect() as conn:
+            row = conn.execute(
+                text("SELECT COUNT(*) FROM metrics WHERE project_id = :pid"),
+                {"pid": pid},
+            ).fetchone()
+    assert row[0] == 2
+
+
+# --- UI link visibility ----------------------------------------------------
+
+
+def test_owner_sees_rename_link_on_detail(client, owner_with_project):
+    slug, _ = owner_with_project
+    html = client.get(f"/projects/{slug}").data.decode()
+    assert f"/projects/{slug}/rename" in html
+    assert "Переименовать" in html
+
+
+def test_viewer_does_not_see_rename_link(client, viewer_session):
+    slug, _ = viewer_session
+    html = client.get(f"/projects/{slug}").data.decode()
+    assert "Переименовать" not in html
+
+
+def test_editor_does_not_see_rename_link(client, editor_session):
+    slug, _ = editor_session
+    html = client.get(f"/projects/{slug}").data.decode()
+    assert "Переименовать" not in html


### PR DESCRIPTION
## Summary

- Owner может изменить отображаемое имя проекта на отдельной странице `/projects/<slug>/rename`.
- Slug **не меняется** — он часть URL, иначе ломаются invite-ссылки и закладки.
- Только `role='owner'`: viewer/editor получают 403 одинаково на GET и POST (форма гейтится тем же `_require_role`).

## Что внутри

- `rename_project(project_id, new_name) -> bool` в `app/metrics_storage.py` — обычный UPDATE по id, возвращает `True` если строка была обновлена.
- `RenameProjectForm` (DataRequired, Length 1–80) + роут `GET/POST /projects/<slug>/rename` в `app/projects.py`.
- Шаблон `templates/projects/rename.html` + ссылка «Переименовать» в шапке `detail.html` (owner only).

## Test plan

- [x] `pytest tests/test_project_rename.py` — 21 тест, покрывают все acceptance criteria (доступ для owner/viewer/editor, GET/POST, валидация пустого / длинного имени, slug неизменен, новое имя видно в detail / list / header / breadcrumbs, connections и metrics на месте).
- [x] Регрессия: `pytest tests/test_auth.py tests/test_projects.py tests/test_roles.py` — 68 проходят.
- [ ] Локально: owner → создать проект → «Переименовать» → проверить, что новое имя видно в списке проектов, шапке и хлебных крошках; slug в URL не изменился.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)