### PR TITLE
feat(#232): load safety настройки для Postgres collector

### DIFF
--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -405,6 +405,27 @@ def _migrate_existing_schema(engine: Engine) -> None:
             "(throttle cache reset; recreated below with project_id in PK)"
         )
 
+    # #232: connections gets per-connection load-safety knobs. All five columns
+    # are NULL-default (or sensible defaults) so existing rows preserve the
+    # pre-#232 behavior on next boot. SQLite/Postgres both honor a plain
+    # ALTER TABLE … ADD COLUMN here.
+    if _table_exists(engine, "connections"):
+        present = _existing_columns(engine, "connections")
+        _safety_columns = [
+            ("table_allowlist", "TEXT"),
+            ("table_denylist", "TEXT"),
+            ("max_tables_per_tick", "INTEGER DEFAULT 50"),
+            ("skip_tables_larger_than_gb", "REAL"),
+            ("statement_timeout_ms", "INTEGER DEFAULT 30000"),
+        ]
+        for col, ddl in _safety_columns:
+            if col not in present:
+                with engine.begin() as conn:
+                    conn.execute(text(
+                        f"ALTER TABLE connections ADD COLUMN {col} {ddl}"
+                    ))
+                logger.info("connections.%s added (#232 load safety)", col)
+
     _migrate_project_scoped_ml_tables(engine)
 
     # #172: backfill project_members for projects that existed before
@@ -2389,6 +2410,17 @@ def create_connection(
     return payload
 
 
+# Columns selected by every connection read. Centralised so a new column
+# (#232 load-safety knobs, etc.) lands in one place instead of being added
+# to three SELECTs that drift apart.
+_CONNECTION_COLUMNS = (
+    "id, project_id, name, dsn_encrypted, schema_name, "
+    "interval_minutes, is_active, created_at, "
+    "table_allowlist, table_denylist, max_tables_per_tick, "
+    "skip_tables_larger_than_gb, statement_timeout_ms"
+)
+
+
 def _row_to_connection(row) -> dict | None:
     if row is None:
         return None
@@ -2401,15 +2433,25 @@ def _row_to_connection(row) -> dict | None:
         "interval_minutes": int(row[5]),
         "is_active": bool(row[6]),
         "created_at": _normalize_ts(row[7]),
+        # #232: load-safety knobs. May be NULL on rows created before the
+        # migration; collector code MUST tolerate missing/None values.
+        "table_allowlist": row[8],
+        "table_denylist": row[9],
+        "max_tables_per_tick": int(row[10]) if row[10] is not None else None,
+        "skip_tables_larger_than_gb": (
+            float(row[11]) if row[11] is not None else None
+        ),
+        "statement_timeout_ms": (
+            int(row[12]) if row[12] is not None else None
+        ),
     }
 
 
 def list_connections_for_project(project_id: str) -> list[dict]:
-    stmt = text("""
-        SELECT id, project_id, name, dsn_encrypted, schema_name,
-               interval_minutes, is_active, created_at
-        FROM connections WHERE project_id = :pid ORDER BY created_at
-    """)
+    stmt = text(
+        f"SELECT {_CONNECTION_COLUMNS} FROM connections "
+        "WHERE project_id = :pid ORDER BY created_at"
+    )
     with get_engine().connect() as conn:
         rows = conn.execute(stmt, {"pid": project_id}).fetchall()
     return [_row_to_connection(r) for r in rows]
@@ -2419,11 +2461,10 @@ def get_connection(project_id: str, connection_id: str) -> dict | None:
     """Scoped to project — never returns a connection from a different
     project even when the id is guessable. Defends against horizontal
     escalation via id-in-URL."""
-    stmt = text("""
-        SELECT id, project_id, name, dsn_encrypted, schema_name,
-               interval_minutes, is_active, created_at
-        FROM connections WHERE id = :id AND project_id = :pid
-    """)
+    stmt = text(
+        f"SELECT {_CONNECTION_COLUMNS} FROM connections "
+        "WHERE id = :id AND project_id = :pid"
+    )
     with get_engine().connect() as conn:
         row = conn.execute(stmt, {"id": connection_id, "pid": project_id}).fetchone()
     return _row_to_connection(row)

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -22,6 +22,7 @@ Lifecycle hooks:
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 import uuid
@@ -44,6 +45,108 @@ from app.security import scrub_value
 from collectors.metrics_collector import MetricsCollector
 
 logger = logging.getLogger(__name__)
+
+
+# --- #232 load-safety helpers ---------------------------------------------
+
+
+def _parse_table_list(raw: str | None) -> list[str]:
+    """Decode a stored allow/denylist into a list of table names.
+
+    The column is plain TEXT holding a JSON array — kept as JSON rather than
+    a comma-split string so a future name with a comma (legal in Postgres
+    via quoting) doesn't silently split into two entries. Any failure (None,
+    empty string, bad JSON, non-list, non-string entries) collapses to ``[]``
+    so an operator typo in the DB doesn't take the collector down — a
+    malformed list reads as "no constraint" and we log once.
+    """
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        logger.warning(
+            "invalid JSON in connection safety list, treating as empty: %r", raw,
+        )
+        return []
+    if not isinstance(parsed, list):
+        logger.warning(
+            "connection safety list must be a JSON array, got %s", type(parsed).__name__,
+        )
+        return []
+    return [str(x).strip() for x in parsed if isinstance(x, str)]
+
+
+def _apply_table_filters(
+    tables: list[dict], conn_row: dict,
+) -> tuple[list[dict], list[tuple[str, str]]]:
+    """Apply allowlist → denylist → max_tables_per_tick.
+
+    Returns (kept, skipped) where *skipped* is a list of (table_name, reason)
+    so the caller can log every drop with a stable reason code:
+    ``not_in_allowlist`` | ``denylisted`` | ``max_tables_limit``.
+
+    Order matters and is fixed by spec:
+      1. Sort by table_name for deterministic output across ticks.
+      2. Drop names not in allowlist (empty allowlist = no constraint).
+      3. Drop names in denylist (empty denylist = no constraint).
+      4. Cap at max_tables_per_tick AFTER both lists — the cap should
+         apply to the user-intended set, not to the catalog-order prefix.
+    """
+    allowlist = set(_parse_table_list(conn_row.get("table_allowlist")))
+    denylist = set(_parse_table_list(conn_row.get("table_denylist")))
+    max_tables = conn_row.get("max_tables_per_tick")
+
+    ordered = sorted(tables, key=lambda t: t["table_name"])
+    kept: list[dict] = []
+    skipped: list[tuple[str, str]] = []
+    for t in ordered:
+        name = t["table_name"]
+        if allowlist and name not in allowlist:
+            skipped.append((name, "not_in_allowlist"))
+            continue
+        if name in denylist:
+            skipped.append((name, "denylisted"))
+            continue
+        kept.append(t)
+
+    if max_tables is not None and max_tables >= 0 and len(kept) > max_tables:
+        for t in kept[max_tables:]:
+            skipped.append((t["table_name"], "max_tables_limit"))
+        kept = kept[:max_tables]
+    return kept, skipped
+
+
+def _build_engine(dsn: str, statement_timeout_ms: int | None):
+    """Create the per-tick SQLAlchemy engine.
+
+    Extracted so tests can introspect the connect_args without driving a
+    full collection tick. ``statement_timeout_ms`` is applied via the
+    libpq ``options`` parameter (session-scoped on every connection of
+    this engine) on Postgres only — for ClickHouse / MySQL / Iceberg the
+    parameter is meaningless and we leave the connect_args minimal.
+
+    Note on SET LOCAL: the issue spec suggested ``SET LOCAL
+    statement_timeout`` from a separate transaction, but SET LOCAL is
+    scoped to its transaction and the adapter opens its own connections
+    per query — so a one-shot SET LOCAL never reaches them. ``-c
+    statement_timeout=...`` in the connect options applies session-wide
+    and survives across the adapter's queries.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    connect_args: dict = {"connect_timeout": 5}
+    if dsn.lower().startswith(("postgres://", "postgresql://", "postgresql+")) \
+            and statement_timeout_ms and statement_timeout_ms > 0:
+        connect_args["options"] = (
+            f"-c statement_timeout={int(statement_timeout_ms)}"
+        )
+    return create_engine(dsn, poolclass=NullPool, connect_args=connect_args)
+
+
+def _is_postgres_dsn(dsn: str) -> bool:
+    return dsn.lower().startswith(("postgres://", "postgresql://", "postgresql+"))
 
 # `prefix` so admin tooling and grep can spot a per-connection job at sight
 # without parsing the id structure.
@@ -148,15 +251,12 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
 
     try:
         # Iceberg uses a catalog API (not SQLAlchemy) — skip engine creation.
-        # For all other dialects, create a per-tick NullPool engine so connections
-        # don't leak across scheduler runs.
+        # For all other dialects, create a per-tick NullPool engine so
+        # connections don't leak across scheduler runs. _build_engine wires
+        # the #232 statement_timeout for Postgres at the libpq options layer;
+        # ClickHouse / Iceberg ignore the value (spec).
         if not dsn.lower().startswith("iceberg+"):
-            from sqlalchemy import create_engine
-            from sqlalchemy.pool import NullPool
-
-            engine = create_engine(
-                dsn, poolclass=NullPool, connect_args={"connect_timeout": 5},
-            )
+            engine = _build_engine(dsn, conn_row.get("statement_timeout_ms"))
         adapter = make_adapter_for_url(dsn)
     except Exception as exc:
         run_error = scrub_value(exc)
@@ -176,11 +276,29 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
 
     run_ts = datetime.now(UTC)
     schema = conn_row["schema_name"]
+    # #232: cache dialect + threshold once — applied to every table below.
+    is_postgres = _is_postgres_dsn(dsn)
+    skip_larger_than_gb = conn_row.get("skip_tables_larger_than_gb")
     try:
         with using_engine(engine, adapter):
             from collectors.schema_collector import collect_table_schema
-            tables = adapter.list_tables(schema)
-            tables_seen = len(tables)
+
+            # #232: apply allow/deny/cap filters and log each skipped table
+            # to the #239 run-log so the operator sees WHY it was skipped.
+            raw_tables = adapter.list_tables(schema)
+            tables, skipped = _apply_table_filters(raw_tables, conn_row)
+            tables_seen = len(tables) + len(skipped)
+            for name, reason in skipped:
+                logger.info(
+                    "[project=%s][conn=%s] skip %s: %s",
+                    project_id, connection_id, name, reason,
+                )
+                tables_skipped += 1
+                save_run_table(
+                    run_id, name, "skipped",
+                    skip_reason=reason, duration_ms=0,
+                )
+
             collector = MetricsCollector(schema=schema)
             for table in tables:
                 table_name = table["table_name"]
@@ -190,6 +308,35 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
                 rows_observed = None
                 table_status = "success"
                 table_error = None
+                table_skip_reason: str | None = None
+
+                # #232 large-table early-skip (Postgres only). Cheap
+                # pg_stat_user_tables read; if over threshold, never enter
+                # the heavy column_nulls path. Recorded as skipped in the
+                # #239 run log with skip_reason='too_large'.
+                if is_postgres and skip_larger_than_gb is not None:
+                    stats = adapter.table_stats(table_name, schema)
+                    threshold_bytes = float(skip_larger_than_gb) * 1e9
+                    if stats and stats["size_bytes"] > threshold_bytes:
+                        logger.info(
+                            "[project=%s][conn=%s] skip %s: too_large "
+                            "(%.2f GB > %.2f GB)",
+                            project_id, connection_id, table_name,
+                            stats["size_bytes"] / 1e9,
+                            float(skip_larger_than_gb),
+                        )
+                        table_status = "skipped"
+                        table_skip_reason = "too_large"
+                        tables_skipped += 1
+                        save_run_table(
+                            run_id, table_name, "skipped",
+                            skip_reason=table_skip_reason,
+                            duration_ms=int(
+                                (time.monotonic() - table_started) * 1000,
+                            ),
+                        )
+                        continue
+
                 try:
                     metrics = collector.collect(table_name, ts=run_ts)
                     metrics_collected = len(metrics)
@@ -224,8 +371,6 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
                 finally:
                     if table_status != "skipped":
                         tables_checked += 1
-                    else:
-                        tables_skipped += 1
                     save_run_table(
                         run_id,
                         table_name,

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -229,6 +229,17 @@ CREATE TABLE IF NOT EXISTS connections (
     interval_minutes INTEGER NOT NULL DEFAULT 15,
     is_active        INTEGER NOT NULL DEFAULT 1,
     created_at       TEXT NOT NULL,
+    -- #232 load-safety knobs. table_allowlist / table_denylist хранятся
+    -- как JSON-массив строк ('["users","orders"]'); NULL = «не задано».
+    -- max_tables_per_tick — hard cap на число обработанных таблиц за тик,
+    -- применяется ПОСЛЕ allow/denylist. skip_tables_larger_than_gb и
+    -- statement_timeout_ms — только Postgres; для ClickHouse/Iceberg
+    -- игнорируются (см. collectors/per_project.py).
+    table_allowlist            TEXT,
+    table_denylist             TEXT,
+    max_tables_per_tick        INTEGER DEFAULT 50,
+    skip_tables_larger_than_gb REAL,
+    statement_timeout_ms       INTEGER DEFAULT 30000,
     CHECK (interval_minutes BETWEEN 5 AND 1440)
 );
 

--- a/scripts/set_connection_safety.py
+++ b/scripts/set_connection_safety.py
@@ -1,0 +1,123 @@
+"""CLI to configure per-connection load-safety knobs (#232).
+
+UI editor for these fields is intentionally a separate task — until then
+operators bump the values via this script (or a SQL session). Usage:
+
+    python -m scripts.set_connection_safety <connection_id> [options]
+
+Examples:
+    # Restrict to two tables, cap at 5 per tick.
+    python -m scripts.set_connection_safety abc123 \\
+        --allowlist users,orders --max 5
+
+    # Drop noisy audit tables, skip anything over 10 GB.
+    python -m scripts.set_connection_safety abc123 \\
+        --denylist audit_logs,events_raw --max-size-gb 10
+
+    # Tighten Postgres statement timeout to 10 s.
+    python -m scripts.set_connection_safety abc123 --timeout-ms 10000
+
+    # Clear allowlist (back to "all tables").
+    python -m scripts.set_connection_safety abc123 --allowlist ''
+
+Lookups are by *connection id* (UUID hex) — owner-scoping is left to whoever
+runs the script. The collector picks up new values on its next tick; no
+restart needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sqlalchemy import text
+
+from app.metrics_storage import get_engine
+
+
+def _parse_csv_or_empty(raw: str | None) -> str | None:
+    """Comma-list → JSON array. Empty string clears the field (NULL)."""
+    if raw is None:
+        return None  # flag not provided — don't touch
+    raw = raw.strip()
+    if raw == "":
+        return ""  # sentinel: clear to NULL
+    items = [s.strip() for s in raw.split(",") if s.strip()]
+    return json.dumps(items)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("connection_id", help="Connection UUID hex")
+    parser.add_argument(
+        "--allowlist",
+        help="Comma-separated table names. Empty string clears (back to "
+             "'all tables').",
+    )
+    parser.add_argument(
+        "--denylist",
+        help="Comma-separated table names to skip. Empty string clears.",
+    )
+    parser.add_argument(
+        "--max", dest="max_tables", type=int,
+        help="max_tables_per_tick — hard cap after allow/denylist.",
+    )
+    parser.add_argument(
+        "--max-size-gb", dest="max_size_gb", type=float,
+        help="Postgres only: skip tables larger than this many GB. "
+             "Negative value clears.",
+    )
+    parser.add_argument(
+        "--timeout-ms", dest="timeout_ms", type=int,
+        help="Postgres only: SET statement_timeout for collector queries. "
+             "0 clears.",
+    )
+    args = parser.parse_args()
+
+    updates: dict[str, object] = {}
+    if args.allowlist is not None:
+        v = _parse_csv_or_empty(args.allowlist)
+        updates["table_allowlist"] = None if v == "" else v
+    if args.denylist is not None:
+        v = _parse_csv_or_empty(args.denylist)
+        updates["table_denylist"] = None if v == "" else v
+    if args.max_tables is not None:
+        updates["max_tables_per_tick"] = args.max_tables
+    if args.max_size_gb is not None:
+        updates["skip_tables_larger_than_gb"] = (
+            None if args.max_size_gb < 0 else args.max_size_gb
+        )
+    if args.timeout_ms is not None:
+        updates["statement_timeout_ms"] = (
+            None if args.timeout_ms <= 0 else args.timeout_ms
+        )
+
+    if not updates:
+        print("No fields supplied — nothing to update.", file=sys.stderr)
+        return 2
+
+    set_clause = ", ".join(f"{col} = :{col}" for col in updates)
+    params = dict(updates)
+    params["id"] = args.connection_id
+
+    with get_engine().begin() as conn:
+        result = conn.execute(
+            text(f"UPDATE connections SET {set_clause} WHERE id = :id"),
+            params,
+        )
+    if (result.rowcount or 0) == 0:
+        print(
+            f"FATAL: no connection with id={args.connection_id}",
+            file=sys.stderr,
+        )
+        return 2
+
+    for col, val in updates.items():
+        print(f"  {col} = {val!r}")
+    print(f"Updated connection {args.connection_id}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -191,6 +191,12 @@ CREATE TABLE IF NOT EXISTS connections (
     interval_minutes INTEGER NOT NULL DEFAULT 15,
     is_active        INTEGER NOT NULL DEFAULT 1,
     created_at       TIMESTAMPTZ NOT NULL,
+    -- #232 load-safety knobs. See comment in metrics_schema.sql.
+    table_allowlist            TEXT,
+    table_denylist             TEXT,
+    max_tables_per_tick        INTEGER DEFAULT 50,
+    skip_tables_larger_than_gb DOUBLE PRECISION,
+    statement_timeout_ms       INTEGER DEFAULT 30000,
     CHECK (interval_minutes BETWEEN 5 AND 1440)
 );
 

--- a/tests/test_load_safety.py
+++ b/tests/test_load_safety.py
@@ -1,0 +1,386 @@
+"""Integration tests for #232 — Postgres load-safety knobs.
+
+Covers:
+- _parse_table_list edge cases (None, "", invalid JSON, non-list, non-string entries)
+- _apply_table_filters: allowlist → denylist → max ordering & determinism
+- collect_for_connection: large-table skip via table_stats BEFORE column_nulls
+- _build_engine wires statement_timeout into Postgres connect_args, not into
+  ClickHouse / Iceberg
+
+The integration tests reuse the same monkeypatch pattern as test_per_project.py:
+real SQLite metrics DB + stubbed adapter so we never touch a live Postgres.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from unittest import mock
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+from collectors.per_project import (
+    _apply_table_filters,
+    _build_engine,
+    _parse_table_list,
+    collect_for_connection,
+)
+
+
+# --- Fixtures (mirror test_per_project.py) --------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    db_path = tmp_path / "safety.db"
+    import app.metrics_storage as storage_mod
+    monkeypatch.setattr(
+        storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}",
+    )
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    return storage_mod
+
+
+def _seed(storage, dsn: str):
+    user_id = uuid.uuid4().hex
+    storage.create_user(
+        user_id=user_id, email=f"u{user_id[:6]}@x.io", password_hash="x",
+    )
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=user_id, name="P", slug="default",
+    )
+    conn = storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"],
+        name="local",
+        dsn_encrypted=crypto.encrypt_dsn(dsn),
+        schema_name="public",
+        interval_minutes=15,
+        is_active=True,
+    )
+    return user_id, project, conn
+
+
+def _set_safety(storage, conn_id, **kwargs):
+    """Patch safety columns directly via SQL — there's no UI/route yet."""
+    from sqlalchemy import text
+    set_clause = ", ".join(f"{c} = :{c}" for c in kwargs)
+    params = {**kwargs, "id": conn_id}
+    with storage.get_engine().begin() as conn:
+        conn.execute(
+            text(f"UPDATE connections SET {set_clause} WHERE id = :id"),
+            params,
+        )
+
+
+# --- _parse_table_list ----------------------------------------------------
+
+
+def test_parse_table_list_none_or_empty():
+    assert _parse_table_list(None) == []
+    assert _parse_table_list("") == []
+
+
+def test_parse_table_list_valid_array():
+    assert _parse_table_list('["users","orders"]') == ["users", "orders"]
+
+
+def test_parse_table_list_strips_entries():
+    assert _parse_table_list('["  users  ","orders"]') == ["users", "orders"]
+
+
+def test_parse_table_list_invalid_json_logs_and_returns_empty(caplog):
+    with caplog.at_level(logging.WARNING):
+        assert _parse_table_list("not-json") == []
+    assert any("invalid JSON" in r.message for r in caplog.records)
+
+
+def test_parse_table_list_non_list_logs_and_returns_empty(caplog):
+    with caplog.at_level(logging.WARNING):
+        assert _parse_table_list('"users"') == []
+    assert any("must be a JSON array" in r.message for r in caplog.records)
+
+
+def test_parse_table_list_drops_non_string_entries():
+    """A mixed-type array silently drops the non-strings rather than
+    crashing — defensive in case someone seeds the column from Python."""
+    assert _parse_table_list('["users", 42, "orders"]') == ["users", "orders"]
+
+
+# --- _apply_table_filters -------------------------------------------------
+
+
+def _tt(*names):
+    return [{"table_name": n, "schema": "public"} for n in names]
+
+
+def test_allowlist_filters_tables():
+    tables = _tt("users", "orders", "events")
+    conn = {"table_allowlist": '["users"]', "max_tables_per_tick": 50}
+    kept, skipped = _apply_table_filters(tables, conn)
+    assert [t["table_name"] for t in kept] == ["users"]
+    assert ("orders", "not_in_allowlist") in skipped
+    assert ("events", "not_in_allowlist") in skipped
+
+
+def test_denylist_skips_tables():
+    tables = _tt("users", "orders", "audit_logs")
+    conn = {"table_denylist": '["audit_logs"]', "max_tables_per_tick": 50}
+    kept, skipped = _apply_table_filters(tables, conn)
+    assert [t["table_name"] for t in kept] == ["orders", "users"]
+    assert ("audit_logs", "denylisted") in skipped
+
+
+def test_max_tables_applied_after_filters():
+    tables = _tt("users", "orders", "events")
+    conn = {
+        "table_allowlist": '["users","orders","events"]',
+        "max_tables_per_tick": 2,
+    }
+    kept, skipped = _apply_table_filters(tables, conn)
+    # Alphabetical: events, orders, users → first 2 kept.
+    assert [t["table_name"] for t in kept] == ["events", "orders"]
+    assert ("users", "max_tables_limit") in skipped
+
+
+def test_max_tables_does_not_clip_before_allowlist():
+    """Cap is applied AFTER allowlist filtering — not to the catalog prefix."""
+    tables = _tt("aaa", "bbb", "ccc", "users")
+    conn = {"table_allowlist": '["users"]', "max_tables_per_tick": 2}
+    kept, _ = _apply_table_filters(tables, conn)
+    # Even though "users" is alphabetically 4th, allowlist filters first.
+    assert [t["table_name"] for t in kept] == ["users"]
+
+
+def test_deterministic_order():
+    """Two calls with the same input yield the same ordering."""
+    tables = _tt("z", "a", "m", "b")
+    conn = {"max_tables_per_tick": 2}
+    k1, _ = _apply_table_filters(tables, conn)
+    k2, _ = _apply_table_filters(tables, conn)
+    assert [t["table_name"] for t in k1] == [t["table_name"] for t in k2]
+    assert [t["table_name"] for t in k1] == ["a", "b"]
+
+
+def test_empty_allowlist_processes_all():
+    """allowlist='[]' must NOT exclude everything — it means "not set"."""
+    tables = _tt("users", "orders")
+    conn = {"table_allowlist": "[]", "max_tables_per_tick": 50}
+    kept, _ = _apply_table_filters(tables, conn)
+    assert {t["table_name"] for t in kept} == {"users", "orders"}
+
+
+def test_empty_denylist_excludes_nothing():
+    tables = _tt("users", "orders")
+    conn = {"table_denylist": "[]", "max_tables_per_tick": 50}
+    kept, _ = _apply_table_filters(tables, conn)
+    assert {t["table_name"] for t in kept} == {"users", "orders"}
+
+
+def test_invalid_json_allowlist_treated_as_empty(caplog):
+    """A typo in the DB shouldn't kill the collector. Malformed allowlist
+    reads as 'no constraint' so the tick still produces metrics."""
+    tables = _tt("users", "orders")
+    conn = {"table_allowlist": "not-json", "max_tables_per_tick": 50}
+    with caplog.at_level(logging.WARNING):
+        kept, _ = _apply_table_filters(tables, conn)
+    assert {t["table_name"] for t in kept} == {"users", "orders"}
+
+
+def test_exact_match_case_sensitive():
+    """allowlist entries are exact-match — 'Users' ≠ 'users'."""
+    tables = _tt("users", "Users")
+    conn = {"table_allowlist": '["users"]', "max_tables_per_tick": 50}
+    kept, _ = _apply_table_filters(tables, conn)
+    assert [t["table_name"] for t in kept] == ["users"]
+
+
+def test_negative_max_tables_does_not_truncate():
+    """max_tables_per_tick=0 means "skip everything"; we cap at 0 cleanly."""
+    tables = _tt("a", "b")
+    conn = {"max_tables_per_tick": 0}
+    kept, skipped = _apply_table_filters(tables, conn)
+    assert kept == []
+    assert {n for n, _ in skipped} == {"a", "b"}
+
+
+# --- _build_engine --------------------------------------------------------
+
+
+def _capture_create_engine_call(monkeypatch):
+    """Patch sqlalchemy.create_engine in the collectors module, capture the
+    connect_args passed in. Returns a dict reference that the test populates.
+    """
+    import sqlalchemy
+    captured: dict = {}
+    real = sqlalchemy.create_engine
+
+    def fake_create_engine(dsn, **kwargs):
+        captured["dsn"] = dsn
+        captured["kwargs"] = kwargs
+        # Return a stub — _build_engine's caller doesn't actually use it.
+        return mock.MagicMock(name="engine_stub")
+    monkeypatch.setattr(sqlalchemy, "create_engine", fake_create_engine)
+    return captured, real
+
+
+def test_build_engine_postgres_includes_statement_timeout(monkeypatch):
+    captured, _ = _capture_create_engine_call(monkeypatch)
+    _build_engine("postgresql://u:p@h/d", statement_timeout_ms=10000)
+    opts = captured["kwargs"]["connect_args"].get("options", "")
+    assert "statement_timeout=10000" in opts
+
+
+def test_build_engine_postgres_omits_timeout_when_none(monkeypatch):
+    captured, _ = _capture_create_engine_call(monkeypatch)
+    _build_engine("postgresql://u:p@h/d", statement_timeout_ms=None)
+    assert "options" not in captured["kwargs"]["connect_args"]
+
+
+def test_build_engine_postgres_omits_timeout_when_zero(monkeypatch):
+    captured, _ = _capture_create_engine_call(monkeypatch)
+    _build_engine("postgresql://u:p@h/d", statement_timeout_ms=0)
+    assert "options" not in captured["kwargs"]["connect_args"]
+
+
+def test_build_engine_clickhouse_ignores_statement_timeout(monkeypatch):
+    """statement_timeout is a Postgres-only knob — never leaks into other
+    dialects' connect_args."""
+    captured, _ = _capture_create_engine_call(monkeypatch)
+    _build_engine("clickhouse+native://u:p@h:9000/d", statement_timeout_ms=10000)
+    assert "options" not in captured["kwargs"]["connect_args"]
+
+
+def test_build_engine_mysql_ignores_statement_timeout(monkeypatch):
+    captured, _ = _capture_create_engine_call(monkeypatch)
+    _build_engine("mysql+pymysql://u:p@h:3306/d", statement_timeout_ms=10000)
+    assert "options" not in captured["kwargs"]["connect_args"]
+
+
+# --- collect_for_connection: large-table skip -----------------------------
+
+
+def _stub_collector(rows):
+    from collectors import metrics_collector
+    return mock.patch.object(
+        metrics_collector.MetricsCollector, "collect", return_value=rows,
+    )
+
+
+def test_skip_large_table_before_column_nulls(storage, caplog):
+    """When size_bytes > threshold the collector's `.collect()` is never
+    invoked for that table — verified by asserting on the mock."""
+    _, project, conn = _seed(storage, dsn="postgresql://u:p@h/d")
+    _set_safety(storage, conn["id"], skip_tables_larger_than_gb=1.0)
+
+    import app.db as db_mod
+
+    def fake_list_tables(self, schema):
+        return [
+            {"table_name": "small", "schema": schema},
+            {"table_name": "huge", "schema": schema},
+        ]
+
+    def fake_stats(self, table_name, schema):
+        if table_name == "huge":
+            return {"table_name": "huge", "schema": schema,
+                    "row_count": 0, "size_bytes": int(2e9), "last_analyze": None}
+        return {"table_name": "small", "schema": schema,
+                "row_count": 0, "size_bytes": int(100), "last_analyze": None}
+
+    collected: list[str] = []
+
+    def fake_collect(self, table_name, ts=None):
+        collected.append(table_name)
+        return [{"ts": datetime.now(UTC), "table_name": table_name,
+                 "metric_name": "row_count", "value": 1.0}]
+
+    from collectors import metrics_collector
+    with mock.patch.object(db_mod.PostgresAdapter, "list_tables",
+                           autospec=True, side_effect=fake_list_tables), \
+         mock.patch.object(db_mod.PostgresAdapter, "table_stats",
+                           autospec=True, side_effect=fake_stats), \
+         mock.patch.object(metrics_collector.MetricsCollector, "collect",
+                           autospec=True, side_effect=fake_collect), \
+         caplog.at_level(logging.INFO):
+        collect_for_connection(project["id"], conn["id"])
+
+    assert collected == ["small"]
+    assert any("too_large" in r.message for r in caplog.records)
+
+
+def test_skip_large_table_not_triggered_when_null(storage):
+    _, project, conn = _seed(storage, dsn="postgresql://u:p@h/d")
+    # No skip_tables_larger_than_gb set — default NULL.
+
+    import app.db as db_mod
+
+    def fake_list_tables(self, schema):
+        return [{"table_name": "huge", "schema": schema}]
+
+    stats_calls: list[str] = []
+
+    def fake_stats(self, table_name, schema):
+        stats_calls.append(table_name)
+        return {"table_name": table_name, "schema": schema,
+                "row_count": 0, "size_bytes": int(99e9), "last_analyze": None}
+
+    collected: list[str] = []
+
+    def fake_collect(self, table_name, ts=None):
+        collected.append(table_name)
+        return []
+
+    from collectors import metrics_collector
+    with mock.patch.object(db_mod.PostgresAdapter, "list_tables",
+                           autospec=True, side_effect=fake_list_tables), \
+         mock.patch.object(db_mod.PostgresAdapter, "table_stats",
+                           autospec=True, side_effect=fake_stats), \
+         mock.patch.object(metrics_collector.MetricsCollector, "collect",
+                           autospec=True, side_effect=fake_collect):
+        collect_for_connection(project["id"], conn["id"])
+
+    # collect() still runs; table_stats() not invoked when the skip is off.
+    assert collected == ["huge"]
+    assert stats_calls == []
+
+
+def test_allowlist_drives_what_collect_runs(storage):
+    """End-to-end: allowlist=['users'] → MetricsCollector.collect called
+    only for 'users', skipped rows logged with 'not_in_allowlist'."""
+    _, project, conn = _seed(storage, dsn="postgresql://u:p@h/d")
+    _set_safety(storage, conn["id"], table_allowlist=json.dumps(["users"]))
+
+    import app.db as db_mod
+
+    def fake_list_tables(self, schema):
+        return [
+            {"table_name": "users", "schema": schema},
+            {"table_name": "orders", "schema": schema},
+        ]
+
+    collected: list[str] = []
+
+    def fake_collect(self, table_name, ts=None):
+        collected.append(table_name)
+        return []
+
+    from collectors import metrics_collector
+    with mock.patch.object(db_mod.PostgresAdapter, "list_tables",
+                           autospec=True, side_effect=fake_list_tables), \
+         mock.patch.object(metrics_collector.MetricsCollector, "collect",
+                           autospec=True, side_effect=fake_collect):
+        collect_for_connection(project["id"], conn["id"])
+
+    assert collected == ["users"]

--- a/tests/test_load_safety.py
+++ b/tests/test_load_safety.py
@@ -30,7 +30,6 @@ from collectors.per_project import (
     collect_for_connection,
 )
 
-
 # --- Fixtures (mirror test_per_project.py) --------------------------------
 
 
@@ -297,7 +296,7 @@ def test_skip_large_table_before_column_nulls(storage, caplog):
             return {"table_name": "huge", "schema": schema,
                     "row_count": 0, "size_bytes": int(2e9), "last_analyze": None}
         return {"table_name": "small", "schema": schema,
-                "row_count": 0, "size_bytes": int(100), "last_analyze": None}
+                "row_count": 0, "size_bytes": 100, "last_analyze": None}
 
     collected: list[str] = []
 


### PR DESCRIPTION
## Summary

- Пять новых полей в `connections`: `table_allowlist`, `table_denylist`, `max_tables_per_tick`, `skip_tables_larger_than_gb`, `statement_timeout_ms`.
- `collect_for_connection()` применяет allow/deny/cap в детерминированном порядке (sort → allow → deny → cap), пропуски логируются с stable reason (`not_in_allowlist` / `denylisted` / `too_large` / `max_tables_limit`).
- `skip_tables_larger_than_gb` проверяется **до** `MetricsCollector.collect()` — тяжёлый `column_nulls` не запускается для отфильтрованных таблиц.
- `statement_timeout_ms` уходит в libpq options (`-c statement_timeout=…`) только для Postgres — ClickHouse/Iceberg игнорируют.
- `scripts/set_connection_safety.py` — CLI редактор до появления UI.

## Что НЕ делаем (из спеки)
- Нет UI-редактора safety-настроек (отдельная задача).
- `skip_tables_larger_than_gb` / `statement_timeout_ms` не применяются к ClickHouse/Iceberg.
- Нет schema-qualified имён в allowlist/denylist — только `table_name`.

## Замечание об отклонении от спеки

Спека предлагает `SET LOCAL statement_timeout` в отдельной транзакции до итерации таблиц. Так не работает — `SET LOCAL` действует только в рамках своей транзакции, а адаптер открывает новое соединение per query. Использовал libpq `options` через `connect_args` — session-wide для всех соединений engine.

## Test plan

- [x] `pytest tests/test_load_safety.py` — 24 теста: parser edge-cases, фильтры (allow/deny/cap order + determinism), `_build_engine` для Postgres/MySQL/ClickHouse, end-to-end large-table skip & allowlist routing через мок-адаптер.
- [x] Регрессия: `pytest tests/test_per_project.py tests/test_metrics_storage.py tests/test_connections.py tests/test_roles.py` → 90 проходят.
- [ ] Ручная проверка на Retail Postgres demo (шаги из issue).

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)