### PR TITLE
feat: add read-only connection warning

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -17,8 +17,7 @@ from .health import build_health_payload
 from .instrumentation import install_http_instrumentation, metrics_response
 from .logging_setup import configure_logging
 from .projects import bp as projects_bp
-from .projects import invites_bp
-from .projects import load_current_project_into_g
+from .projects import invites_bp, load_current_project_into_g
 from .security import init_logging_filter
 from .sentry import init_sentry
 from .settings import bp as settings_bp

--- a/docs/PROD_CONNECTION_GUIDE.md
+++ b/docs/PROD_CONNECTION_GUIDE.md
@@ -1,0 +1,79 @@
+# Как подключить реальную БД
+
+Этот документ описывает, какие доступы нужны DB Monitor для подключения к production Postgres или другой рабочей БД.
+
+## Какие credentials нужны
+
+Для подключения нужен отдельный пользователь только для чтения. Не используйте admin, owner или superuser-аккаунт.
+
+Минимально нужны:
+
+- host и port БД;
+- имя базы данных;
+- имя пользователя только для чтения;
+- пароль этого пользователя;
+- schema или namespace, которые нужно мониторить.
+
+Пример DSN:
+
+```text
+postgresql://db_monitor_ro:strong-password@db.example.com:5432/app
+```
+
+## Что читает DB Monitor
+
+DB Monitor использует подключение для чтения структуры БД и расчёта метрик:
+
+- список схем, таблиц и колонок;
+- типы колонок;
+- количество строк;
+- долю `NULL` по колонкам;
+- размер таблиц, если backend отдаёт эту информацию;
+- служебную metadata, например `information_schema`.
+
+## Что DB Monitor не делает
+
+DB Monitor не должен менять данные в подключаемой БД.
+
+Пользователю для мониторинга не нужны права:
+
+- `INSERT`;
+- `UPDATE`;
+- `DELETE`;
+- DDL-права: `CREATE`, `ALTER`, `DROP`.
+
+## Минимальные права для Postgres
+
+Пример создания read-only пользователя:
+
+```sql
+CREATE USER db_monitor_ro WITH PASSWORD 'strong-password';
+
+GRANT CONNECT ON DATABASE app TO db_monitor_ro;
+GRANT USAGE ON SCHEMA public TO db_monitor_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO db_monitor_ro;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+GRANT SELECT ON TABLES TO db_monitor_ro;
+```
+
+Если нужно мониторить несколько схем, повторите `GRANT USAGE` и `GRANT SELECT` для каждой схемы.
+
+## Network requirements
+
+Приложение должно иметь сетевой доступ к БД:
+
+- host и port БД доступны из контейнера или окружения, где запущен DB Monitor;
+- firewall/security group разрешает входящие соединения от DB Monitor;
+- TLS-настройки соответствуют требованиям вашей БД;
+- DNS-имя БД резолвится внутри runtime DB Monitor.
+
+## Safety checklist
+
+Перед подключением production БД проверьте:
+
+- используется отдельный пользователь только для чтения;
+- у пользователя нет `INSERT`, `UPDATE`, `DELETE`, `CREATE`, `ALTER`, `DROP`;
+- выбраны только нужные схемы и таблицы;
+- интервал сбора подходит для нагрузки на БД;
+- тяжёлые таблицы исключены или обрабатываются отдельными load safety настройками.

--- a/templates/connections/new.html
+++ b/templates/connections/new.html
@@ -25,6 +25,14 @@
 
       {{ render_field(form.name, input_class=input_cls) }}
       {{ render_field(form.dsn, input_class=input_cls) }}
+      <div class="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+        <strong>Важно:</strong> Используйте пользователя только для чтения. DB Monitor читает структуру БД и считает метрики по таблицам.
+        Права на изменение данных не нужны: <code>INSERT</code>, <code>UPDATE</code>, <code>DELETE</code>, <code>CREATE</code>, <code>ALTER</code> и <code>DROP</code>.
+        <a href="https://github.com/aleksandr-novikov/db-monitoring/blob/master/docs/PROD_CONNECTION_GUIDE.md"
+           class="font-medium underline decoration-amber-500/60 underline-offset-2 hover:text-amber-900 dark:hover:text-amber-100">
+          Подробнее в guide
+        </a>.
+      </div>
       <p class="text-xs text-slate-500 dark:text-slate-400">
         Пример:
         <span class="font-mono">postgresql://user:password@host:5432/dbname</span><br>

--- a/templates/onboarding/add_connection.html
+++ b/templates/onboarding/add_connection.html
@@ -59,9 +59,6 @@
           </div>
         </div>
 
-        <div class="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
-          <strong>Совет:</strong> создайте read-only пользователя в БД. Мы только читаем <code>information_schema</code> и считаем NULL по колонкам — DML/DDL не нужны.
-        </div>
       </aside>
 
       {# Form — same fields as connections/new.html, different chrome. #}
@@ -72,6 +69,14 @@
 
             {{ render_field(form.name, input_class=input_cls) }}
             {{ render_field(form.dsn, input_class=input_cls) }}
+            <div class="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+              <strong>Важно:</strong> Используйте пользователя только для чтения. DB Monitor читает структуру БД и считает метрики по таблицам.
+              Права на изменение данных не нужны: <code>INSERT</code>, <code>UPDATE</code>, <code>DELETE</code>, <code>CREATE</code>, <code>ALTER</code> и <code>DROP</code>.
+              <a href="https://github.com/aleksandr-novikov/db-monitoring/blob/master/docs/PROD_CONNECTION_GUIDE.md"
+                 class="font-medium underline decoration-amber-500/60 underline-offset-2 hover:text-amber-900 dark:hover:text-amber-100">
+                Подробнее в guide
+              </a>.
+            </div>
             <p class="text-xs text-slate-500 dark:text-slate-400">
               Скопируйте DSN из подсказок слева. Пароль скрыт после ввода.
             </p>

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from cryptography.fernet import Fernet
 
@@ -161,7 +163,37 @@ def _add_connection(client, slug="default", name="Local", dsn="postgresql://u:p@
     )
 
 
+def _guide_href(html: str) -> str:
+    match = re.search(r'href="([^"]*PROD_CONNECTION_GUIDE\.md[^"]*)"', html)
+    assert match is not None
+    return match.group(1)
+
+
 # --- CRUD happy paths ------------------------------------------------------
+
+
+def test_readonly_hint_in_new_connection_form(client):
+    _register(client)
+    _add_connection(client)
+
+    resp = client.get("/projects/default/connections/new")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "только для чтения" in html
+    assert "INSERT" in html
+    assert "UPDATE" in html
+    assert "DELETE" in html
+    assert "CREATE" in html
+    assert "ALTER" in html
+    assert "DROP" in html
+    assert "PROD_CONNECTION_GUIDE" in html
+    assert html.index("только для чтения") < html.index("Сохранить")
+
+    href = _guide_href(html)
+    assert href.startswith("https://github.com/aleksandr-novikov/db-monitoring/")
+    assert "password=" not in href
+    assert "dsn=" not in href
 
 
 def test_create_connection_persists_ciphertext_not_plaintext(client):

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -10,6 +10,8 @@ Covers the acceptance bullet-list:
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from cryptography.fernet import Fernet
 
@@ -65,6 +67,12 @@ def _register(client, email="u@example.com"):
     )
 
 
+def _guide_href(html: str) -> str:
+    match = re.search(r'href="([^"]*PROD_CONNECTION_GUIDE\.md[^"]*)"', html)
+    assert match is not None
+    return match.group(1)
+
+
 # --- Public landing -------------------------------------------------------
 
 
@@ -102,6 +110,42 @@ def test_onboarding_template_rendered_when_project_empty(client):
     # Wizard-specific copy is in onboarding/add_connection.html only.
     assert "Где взять DSN" in body
     assert "Сохранить и проверить" in body
+
+
+def test_readonly_hint_in_onboarding_form(client):
+    _register(client, "readonly@example.com")
+    resp = client.get("/projects/default/connections/new")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "только для чтения" in html
+    assert "INSERT" in html
+    assert "UPDATE" in html
+    assert "DELETE" in html
+    assert "CREATE" in html
+    assert "ALTER" in html
+    assert "DROP" in html
+    assert "PROD_CONNECTION_GUIDE" in html
+    assert html.index("только для чтения") < html.index("Сохранить и проверить")
+
+    href = _guide_href(html)
+    assert href.startswith("https://github.com/aleksandr-novikov/db-monitoring/")
+    assert "password=" not in href
+    assert "dsn=" not in href
+
+
+def test_prod_connection_guide_exists():
+    from pathlib import Path
+
+    path = Path("docs/PROD_CONNECTION_GUIDE.md")
+    assert path.exists()
+    text = path.read_text(encoding="utf-8")
+    assert "read-only" in text or "только для чтения" in text
+    assert "SELECT" in text
+    assert "INSERT" in text
+    assert "UPDATE" in text
+    assert "DELETE" in text
+    assert "DDL" in text
 
 
 def test_regular_template_rendered_when_project_has_connections(client, monkeypatch):

--- a/tests/test_project_invites.py
+++ b/tests/test_project_invites.py
@@ -112,7 +112,7 @@ def owner_with_project(app, client):
 
 
 def test_create_invite_token(app, owner_with_project):
-    slug, pid = owner_with_project
+    _slug, pid = owner_with_project
     with app.app_context():
         owner = metrics_storage.get_user_by_email("owner@inv.com")
         invite = metrics_storage.create_invite_token(pid, "viewer", owner["id"])
@@ -344,7 +344,7 @@ def test_expired_token_rejected(app, client, owner_with_project):
 
 
 def test_used_token_rejected(app, client, owner_with_project):
-    slug, pid = owner_with_project
+    _slug, pid = owner_with_project
     with app.app_context():
         owner = metrics_storage.get_user_by_email("owner@inv.com")
         invite = metrics_storage.create_invite_token(pid, "viewer", owner["id"])


### PR DESCRIPTION
Closes #228

## Что изменилось

- Добавлен read-only warning в обычную форму создания подключения после поля DSN.
- Warning в onboarding-форме перенесён в тело формы после DSN, чтобы визуально находиться до кнопки `Сохранить и проверить`.
- Добавлен `docs/PROD_CONNECTION_GUIDE.md` с требованиями к production-подключению, read-only правами для Postgres и safety checklist.
- Добавлены тесты для обычной формы, onboarding-формы и guide.

## Lint fix after master merge

После подтягивания актуального `master` в PR-ветку ruff начал падать на merge-context. Поэтому в PR также есть маленькие технические правки:

- `app/app.py` — сортировка импортов после появления `invites_bp`;
- `tests/test_project_invites.py` — неиспользуемый `slug` заменён на `_slug` в двух тестах.

Эти изменения не относятся к UI warning, но нужны, чтобы PR проходил `make lint` после merge с текущим `master`.

## Проверки

- `venv/bin/ruff check .` — All checks passed
- `venv/bin/pytest tests/test_connections.py tests/test_onboarding.py tests/test_project_invites.py -q` — 57 passed
- Docker smoke-test: обе формы показывают warning, ссылка на guide есть, DSN/password не попадают в href, создание первого connection работает

## Примечание

Ссылка на guide ведёт на GitHub `master`. Она начнёт открываться после merge, когда `docs/PROD_CONNECTION_GUIDE.md` попадёт в `master`.