### PR TITLE
feat(#239): add collector run log backend

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -161,6 +161,21 @@ def _auto_promote_admin() -> None:
         )
 
 
+def _cleanup_stale_collector_runs() -> None:
+    """Mark collector runs left in running state by a crashed process."""
+    try:
+        from app.metrics_storage import cleanup_stale_collector_runs
+        updated = cleanup_stale_collector_runs()
+        if updated:
+            logging.getLogger("app.startup").warning(
+                "Marked %d stale collector run(s) as failed", updated,
+            )
+    except Exception as exc:  # pragma: no cover - defensive boot guard
+        logging.getLogger("app.startup").warning(
+            "Collector run stale cleanup failed: %s", exc,
+        )
+
+
 def create_app(config: dict | None = None):
     # Order matters: configure formatters/handlers BEFORE the DSN-scrub
     # filter so the scrubber gets attached to the JSON/text handler we
@@ -192,6 +207,7 @@ def create_app(config: dict | None = None):
 
     if config:
         app.config.update(config)
+    _cleanup_stale_collector_runs()
 
     # Under TESTING, disable login_required gating and CSRF so existing
     # dashboard/admin/api tests that don't care about auth keep working.

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -1,12 +1,13 @@
 import json
 import logging
 import threading
+import uuid
 from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import create_engine, event, text
+from sqlalchemy import bindparam, create_engine, event, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 
@@ -2452,6 +2453,218 @@ def set_connection_active(
             "v": 1 if is_active else 0,
         })
     return (result.rowcount or 0) > 0
+
+
+# --- Collector run log (#239) ----------------------------------------------
+
+
+def save_collector_run(
+    run_id: str,
+    project_id: str,
+    connection_id: str,
+    started_at: datetime,
+    mode: str = "scheduled",
+) -> None:
+    """Create a persistent collector run row in ``running`` state."""
+    stmt = text("""
+        INSERT INTO collector_runs
+            (id, project_id, connection_id, started_at, status, mode)
+        VALUES
+            (:id, :project_id, :connection_id, :started_at, 'running', :mode)
+    """)
+    with get_engine().begin() as conn:
+        conn.execute(stmt, {
+            "id": run_id,
+            "project_id": project_id,
+            "connection_id": connection_id,
+            "started_at": _iso(started_at),
+            "mode": mode,
+        })
+
+
+def save_run_table(
+    run_id: str,
+    table_name: str,
+    status: str,
+    **kwargs,
+) -> None:
+    """Append one table-level result for a collector run."""
+    payload = {
+        "id": kwargs.get("id") or uuid.uuid4().hex,
+        "run_id": run_id,
+        "table_name": table_name,
+        "status": status,
+        "metrics_collected": int(kwargs.get("metrics_collected") or 0),
+        "rows_observed": kwargs.get("rows_observed"),
+        "duration_ms": kwargs.get("duration_ms"),
+        "skip_reason": kwargs.get("skip_reason"),
+        "error_message": kwargs.get("error_message"),
+    }
+    stmt = text("""
+        INSERT INTO collector_run_tables
+            (id, run_id, table_name, status, metrics_collected, rows_observed,
+             duration_ms, skip_reason, error_message)
+        VALUES
+            (:id, :run_id, :table_name, :status, :metrics_collected,
+             :rows_observed, :duration_ms, :skip_reason, :error_message)
+    """)
+    with get_engine().begin() as conn:
+        conn.execute(stmt, payload)
+
+
+def update_collector_run(
+    run_id: str,
+    *,
+    status: str,
+    finished_at: datetime,
+    **kwargs,
+) -> None:
+    """Finish or update a collector run row."""
+    payload = {
+        "id": run_id,
+        "status": status,
+        "finished_at": _iso(finished_at),
+        "tables_total": int(kwargs.get("tables_total") or 0),
+        "tables_checked": int(kwargs.get("tables_checked") or 0),
+        "tables_skipped": int(kwargs.get("tables_skipped") or 0),
+        "metrics_collected": int(kwargs.get("metrics_collected") or 0),
+        "duration_ms": kwargs.get("duration_ms"),
+        "error_message": kwargs.get("error_message"),
+    }
+    stmt = text("""
+        UPDATE collector_runs
+        SET status = :status,
+            finished_at = :finished_at,
+            tables_total = :tables_total,
+            tables_checked = :tables_checked,
+            tables_skipped = :tables_skipped,
+            metrics_collected = :metrics_collected,
+            duration_ms = :duration_ms,
+            error_message = :error_message
+        WHERE id = :id
+    """)
+    with get_engine().begin() as conn:
+        conn.execute(stmt, payload)
+
+
+def _parse_stored_ts(value: Any) -> datetime:
+    normalized = _normalize_ts(value)
+    if normalized is None:
+        return datetime.now(UTC)
+    parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def cleanup_stale_collector_runs(now: datetime | None = None) -> int:
+    """Mark process-crashed ``running`` collector runs as failed."""
+    now = now or datetime.now(UTC)
+    stmt = text("""
+        SELECT id, started_at
+        FROM collector_runs
+        WHERE status = 'running'
+    """)
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt).fetchall()
+    if not rows:
+        return 0
+
+    payload = []
+    for run_id, started_at in rows:
+        started = _parse_stored_ts(started_at)
+        duration_ms = max(0, int((now - started).total_seconds() * 1000))
+        payload.append({
+            "id": run_id,
+            "finished_at": _iso(now),
+            "duration_ms": duration_ms,
+            "error_message": "collector process stopped before finishing the run",
+        })
+
+    with get_engine().begin() as conn:
+        conn.execute(text("""
+            UPDATE collector_runs
+            SET status = 'failed',
+                finished_at = :finished_at,
+                duration_ms = :duration_ms,
+                error_message = :error_message
+            WHERE id = :id AND status = 'running'
+        """), payload)
+    return len(payload)
+
+
+def list_collector_runs(
+    project_id: str,
+    connection_id: str,
+    limit: int = 10,
+) -> list[dict]:
+    """Return newest collector runs with nested table rows for the UI."""
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = 10
+    limit = max(1, min(limit, 100))
+    runs_stmt = text("""
+        SELECT id, project_id, connection_id, started_at, finished_at, status,
+               mode, tables_total, tables_checked, tables_skipped,
+               metrics_collected, duration_ms, error_message
+        FROM collector_runs
+        WHERE project_id = :project_id
+          AND connection_id = :connection_id
+        ORDER BY started_at DESC, id DESC
+        LIMIT :limit
+    """)
+    with get_engine().connect() as conn:
+        run_rows = conn.execute(runs_stmt, {
+            "project_id": project_id,
+            "connection_id": connection_id,
+            "limit": limit,
+        }).fetchall()
+        run_ids = [r[0] for r in run_rows]
+        table_rows = []
+        if run_ids:
+            table_rows = conn.execute(text("""
+                SELECT run_id, id, table_name, status, metrics_collected,
+                       rows_observed, duration_ms, skip_reason, error_message
+                FROM collector_run_tables
+                WHERE run_id IN :run_ids
+                ORDER BY table_name
+            """).bindparams(bindparam("run_ids", expanding=True)), {
+                "run_ids": run_ids,
+            }).fetchall()
+
+    tables_by_run: dict[str, list[dict]] = {run_id: [] for run_id in run_ids}
+    for row in table_rows:
+        tables_by_run[row[0]].append({
+            "id": row[1],
+            "table_name": row[2],
+            "status": row[3],
+            "metrics_collected": int(row[4] or 0),
+            "rows_observed": row[5],
+            "duration_ms": row[6],
+            "skip_reason": row[7],
+            "error_message": row[8],
+        })
+
+    return [
+        {
+            "id": row[0],
+            "project_id": row[1],
+            "connection_id": row[2],
+            "started_at": _normalize_ts(row[3]),
+            "finished_at": _normalize_ts(row[4]),
+            "status": row[5],
+            "mode": row[6],
+            "tables_total": int(row[7] or 0),
+            "tables_checked": int(row[8] or 0),
+            "tables_skipped": int(row[9] or 0),
+            "metrics_collected": int(row[10] or 0),
+            "duration_ms": row[11],
+            "error_message": row[12],
+            "tables": tables_by_run.get(row[0], []),
+        }
+        for row in run_rows
+    ]
 
 
 def record_successful_login(user_id: str, email: str) -> None:

--- a/app/security.py
+++ b/app/security.py
@@ -80,6 +80,17 @@ _BEARER_TOKEN_IN_TEXT = re.compile(
     r"(?i)\b(?P<scheme>Bearer|Token)\s+(?P<value>[A-Za-z0-9._\-]{10,})"
 )
 
+# Generic query/key-value secrets seen in exception strings:
+# ``?token=...``, ``password=...``, ``api_key=...``. Keep the key so the
+# message remains diagnosable, mask only the value.
+_SECRET_PARAM_IN_TEXT = re.compile(
+    r"(?i)"
+    r"(?P<prefix>(?:^|[?&\s,;{(]))"
+    r"(?P<key>(?:password|passwd|pwd|token|access[_-]?token|"
+    r"refresh[_-]?token|api[_-]?key|apikey)\b\s*[=:]\s*)"
+    r"(?P<quote>[\"']?)(?![^&\s\"';]*\*\*\*)(?P<value>[^&\s\"';]+)(?P=quote)"
+)
+
 
 def mask_dsn(url: str) -> str:
     """Return *url* with the password component replaced by ``***``.
@@ -150,6 +161,13 @@ def _scrub(value):
         # Bearer / Token <value> в Authorization-headers + iceberg auth.
         scrubbed = _BEARER_TOKEN_IN_TEXT.sub(
             lambda m: f"{m.group('scheme')} {_PASSWORD_PLACEHOLDER}",
+            scrubbed,
+        )
+        scrubbed = _SECRET_PARAM_IN_TEXT.sub(
+            lambda m: (
+                f"{m.group('prefix')}{m.group('key')}{m.group('quote')}"
+                f"{_PASSWORD_PLACEHOLDER}{m.group('quote')}"
+            ),
             scrubbed,
         )
         return scrubbed

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from collections.abc import Iterable
 from datetime import UTC, datetime
 
@@ -34,8 +35,12 @@ from app.db import make_adapter_for_url, using_engine
 from app.metrics_storage import (
     get_connection,
     list_projects_for_user,
+    save_collector_run,
     save_metrics,
+    save_run_table,
+    update_collector_run,
 )
+from app.security import scrub_value
 from collectors.metrics_collector import MetricsCollector
 
 logger = logging.getLogger(__name__)
@@ -65,6 +70,15 @@ def parse_job_id(job_id: str) -> tuple[str, str] | None:
 # --- The job body ---------------------------------------------------------
 
 
+def _inc_collector_error_counter() -> None:
+    """Best-effort Prometheus error counter bump."""
+    try:
+        from app.instrumentation import collector_runs_total
+        collector_runs_total.labels(result="error").inc()
+    except ImportError:
+        pass
+
+
 def collect_for_connection(project_id: str, connection_id: str) -> None:
     """Single tick: enumerate tables on the connection's DSN, save metrics
     tagged with the project_id.
@@ -74,84 +88,193 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
     ``app.security.DSNFilter`` from #56 scrubs at LogRecord construction.
     """
     started = time.monotonic()
+    run_started_at = datetime.now(UTC)
+    run_id = uuid.uuid4().hex
+    run_created = False
+    engine = None
+    rows_saved = 0
+    tables_seen = 0
+    tables_checked = 0
+    tables_skipped = 0
+    degraded = False
+    run_status = "success"
+    run_error: str | None = None
+    table_names: list[str] = []
+
     conn_row = get_connection(project_id, connection_id)
-    if conn_row is None or not conn_row["is_active"]:
+    if conn_row is None:
         logger.info("[project=%s][conn=%s] skipped — inactive/deleted",
                     project_id, connection_id)
+        return
+
+    save_collector_run(
+        run_id,
+        project_id=project_id,
+        connection_id=connection_id,
+        started_at=run_started_at,
+        mode="scheduled",
+    )
+    run_created = True
+
+    if not conn_row["is_active"]:
+        logger.info("[project=%s][conn=%s] skipped — inactive/deleted",
+                    project_id, connection_id)
+        update_collector_run(
+            run_id,
+            status="skipped",
+            finished_at=datetime.now(UTC),
+            duration_ms=int((time.monotonic() - started) * 1000),
+            error_message="connection inactive or deleted",
+        )
         return
 
     try:
         dsn = crypto.decrypt_dsn(conn_row["dsn_encrypted"])
     except crypto.InvalidToken:
-        logger.warning("[project=%s][conn=%s] DSN ciphertext invalid — "
-                       "Fernet key rotated? Re-save the connection.",
-                       project_id, connection_id)
+        run_error = scrub_value(
+            "DSN ciphertext invalid — Fernet key rotated? Re-save the connection."
+        )
+        logger.warning("[project=%s][conn=%s] %s",
+                       project_id, connection_id, run_error)
+        update_collector_run(
+            run_id,
+            status="failed",
+            finished_at=datetime.now(UTC),
+            duration_ms=int((time.monotonic() - started) * 1000),
+            error_message=run_error,
+        )
+        _inc_collector_error_counter()
         return
 
-    # Iceberg uses a catalog API (not SQLAlchemy) — skip engine creation.
-    # For all other dialects, create a per-tick NullPool engine so connections
-    # don't leak across scheduler runs.
-    engine = None
-    if not dsn.lower().startswith("iceberg+"):
-        from sqlalchemy import create_engine
-        from sqlalchemy.pool import NullPool
-
-        engine = create_engine(
-            dsn, poolclass=NullPool, connect_args={"connect_timeout": 5},
-        )
-
     try:
+        # Iceberg uses a catalog API (not SQLAlchemy) — skip engine creation.
+        # For all other dialects, create a per-tick NullPool engine so connections
+        # don't leak across scheduler runs.
+        if not dsn.lower().startswith("iceberg+"):
+            from sqlalchemy import create_engine
+            from sqlalchemy.pool import NullPool
+
+            engine = create_engine(
+                dsn, poolclass=NullPool, connect_args={"connect_timeout": 5},
+            )
         adapter = make_adapter_for_url(dsn)
-    except ValueError as exc:
-        logger.warning("[project=%s][conn=%s] %s", project_id, connection_id, exc)
+    except Exception as exc:
+        run_error = scrub_value(exc)
+        logger.warning("[project=%s][conn=%s] %s",
+                       project_id, connection_id, run_error)
+        update_collector_run(
+            run_id,
+            status="failed",
+            finished_at=datetime.now(UTC),
+            duration_ms=int((time.monotonic() - started) * 1000),
+            error_message=run_error,
+        )
         if engine:
             engine.dispose()
+        _inc_collector_error_counter()
         return
 
     run_ts = datetime.now(UTC)
     schema = conn_row["schema_name"]
-    rows_saved = 0
-    tables_seen = 0
     try:
         with using_engine(engine, adapter):
             from collectors.schema_collector import collect_table_schema
             tables = adapter.list_tables(schema)
+            tables_seen = len(tables)
             collector = MetricsCollector(schema=schema)
             for table in tables:
-                tables_seen += 1
-                metrics = collector.collect(table["table_name"], ts=run_ts)
-                if metrics:
-                    rows_saved += save_metrics(metrics, project_id)
+                table_name = table["table_name"]
+                table_names.append(table_name)
+                table_started = time.monotonic()
+                metrics_collected = 0
+                rows_observed = None
+                table_status = "success"
+                table_error = None
                 try:
-                    collect_table_schema(table["table_name"], schema=schema, project_id=project_id)
-                except Exception as schema_exc:
+                    metrics = collector.collect(table_name, ts=run_ts)
+                    metrics_collected = len(metrics)
+                    row_count_metric = next(
+                        (m for m in metrics if m.get("metric_name") == "row_count"),
+                        None,
+                    )
+                    if row_count_metric is not None:
+                        rows_observed = int(row_count_metric["value"])
+                    if metrics:
+                        rows_saved += save_metrics(metrics, project_id)
+                    try:
+                        collect_table_schema(
+                            table_name, schema=schema, project_id=project_id,
+                        )
+                    except Exception as schema_exc:
+                        degraded = True
+                        table_status = "failed"
+                        table_error = scrub_value(schema_exc)
+                        logger.warning(
+                            "[project=%s][conn=%s] schema collection failed for %s: %s",
+                            project_id, connection_id, table_name, table_error,
+                        )
+                except Exception as table_exc:
+                    degraded = True
+                    table_status = "failed"
+                    table_error = scrub_value(table_exc)
                     logger.warning(
-                        "[project=%s][conn=%s] schema collection failed for %s: %s",
-                        project_id, connection_id, table["table_name"], schema_exc,
+                        "[project=%s][conn=%s] table collection failed for %s: %s",
+                        project_id, connection_id, table_name, table_error,
+                    )
+                finally:
+                    if table_status != "skipped":
+                        tables_checked += 1
+                    else:
+                        tables_skipped += 1
+                    save_run_table(
+                        run_id,
+                        table_name,
+                        table_status,
+                        metrics_collected=metrics_collected,
+                        rows_observed=rows_observed,
+                        duration_ms=int((time.monotonic() - table_started) * 1000),
+                        error_message=table_error,
                     )
     except Exception as exc:
         elapsed_ms = int((time.monotonic() - started) * 1000)
+        run_status = "failed"
+        run_error = scrub_value(exc)
         logger.warning(
             "[project=%s][conn=%s] collection failed after %dms: %s",
-            project_id, connection_id, elapsed_ms, exc,
+            project_id, connection_id, elapsed_ms, run_error,
         )
-        if engine:
-            engine.dispose()
         # #101: count the failed tick. Late import so a missing
         # prometheus-client install doesn't break collection itself.
+        _inc_collector_error_counter()
+    finally:
+        elapsed_ms = int((time.monotonic() - started) * 1000)
         try:
-            from app.instrumentation import collector_runs_total
-            collector_runs_total.labels(result="error").inc()
-        except ImportError:
-            pass
+            if run_created:
+                final_status = run_status
+                if run_status == "success" and degraded:
+                    final_status = "warning"
+                update_collector_run(
+                    run_id,
+                    status=final_status,
+                    finished_at=datetime.now(UTC),
+                    tables_total=tables_seen,
+                    tables_checked=tables_checked,
+                    tables_skipped=tables_skipped,
+                    metrics_collected=rows_saved,
+                    duration_ms=elapsed_ms,
+                    error_message=run_error,
+                )
+        finally:
+            if engine:
+                engine.dispose()
+
+    if run_status == "failed":
         return
 
-    if engine:
-        engine.dispose()
-    elapsed_ms = int((time.monotonic() - started) * 1000)
     logger.info(
         "[project=%s][conn=%s] collected %d metrics across %d tables in %dms",
-        project_id, connection_id, rows_saved, tables_seen, elapsed_ms,
+        project_id, connection_id, rows_saved, tables_seen,
+        int((time.monotonic() - started) * 1000),
     )
     try:
         from app.instrumentation import collector_runs_total
@@ -164,7 +287,7 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
     # configured via /settings/notifications (#143). No global fallback —
     # silence is the default.
     if rows_saved > 0:
-        _maybe_notify_anomalies(project_id, [t["table_name"] for t in tables])
+        _maybe_notify_anomalies(project_id, table_names)
 
 
 def _load_telegram_config(project_id: str) -> tuple[str, str, int] | None:

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -234,6 +234,50 @@ CREATE TABLE IF NOT EXISTS connections (
 
 CREATE INDEX IF NOT EXISTS idx_connections_project ON connections (project_id);
 
+-- Persistent collector run log (#239). UI reads this in #240 to explain
+-- what happened during each scheduled/manual collection tick.
+CREATE TABLE IF NOT EXISTS collector_runs (
+    id                TEXT PRIMARY KEY,
+    project_id        TEXT NOT NULL,
+    connection_id     TEXT NOT NULL REFERENCES connections(id) ON DELETE CASCADE,
+    started_at        TEXT NOT NULL,
+    finished_at       TEXT,
+    status            TEXT NOT NULL DEFAULT 'running'
+                      CHECK (status IN ('running', 'success', 'warning', 'failed', 'skipped')),
+    mode              TEXT NOT NULL DEFAULT 'scheduled'
+                      CHECK (mode IN ('full', 'manual', 'scheduled')),
+    tables_total      INTEGER DEFAULT 0,
+    tables_checked    INTEGER DEFAULT 0,
+    tables_skipped    INTEGER DEFAULT 0,
+    metrics_collected INTEGER DEFAULT 0,
+    duration_ms       INTEGER,
+    error_message     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS collector_run_tables (
+    id                TEXT PRIMARY KEY,
+    run_id            TEXT NOT NULL REFERENCES collector_runs(id) ON DELETE CASCADE,
+    table_name        TEXT NOT NULL,
+    status            TEXT NOT NULL CHECK (status IN ('success', 'skipped', 'failed')),
+    metrics_collected INTEGER DEFAULT 0,
+    rows_observed     INTEGER,
+    duration_ms       INTEGER,
+    skip_reason       TEXT CHECK (
+                          skip_reason IS NULL OR skip_reason IN (
+                              'denylisted', 'not_in_allowlist', 'too_large',
+                              'timeout', 'max_tables_limit'
+                          )
+                      ),
+    error_message     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_collector_runs_conn
+    ON collector_runs (connection_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_collector_runs_project_started
+    ON collector_runs (project_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_collector_run_tables_run
+    ON collector_run_tables (run_id);
+
 -- Failed login attempts (#56). Используется для per-email lockout после
 -- 5 неуспешных попыток в окне 15 минут. Append-only лог: успешный логин
 -- ничего не пишет, очистка — purge_old_failed_logins по retention.

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -196,6 +196,48 @@ CREATE TABLE IF NOT EXISTS connections (
 
 CREATE INDEX IF NOT EXISTS idx_connections_project ON connections (project_id);
 
+CREATE TABLE IF NOT EXISTS collector_runs (
+    id                TEXT PRIMARY KEY,
+    project_id        TEXT NOT NULL,
+    connection_id     TEXT NOT NULL REFERENCES connections(id) ON DELETE CASCADE,
+    started_at        TIMESTAMPTZ NOT NULL,
+    finished_at       TIMESTAMPTZ,
+    status            TEXT NOT NULL DEFAULT 'running'
+                      CHECK (status IN ('running', 'success', 'warning', 'failed', 'skipped')),
+    mode              TEXT NOT NULL DEFAULT 'scheduled'
+                      CHECK (mode IN ('full', 'manual', 'scheduled')),
+    tables_total      INTEGER DEFAULT 0,
+    tables_checked    INTEGER DEFAULT 0,
+    tables_skipped    INTEGER DEFAULT 0,
+    metrics_collected INTEGER DEFAULT 0,
+    duration_ms       INTEGER,
+    error_message     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS collector_run_tables (
+    id                TEXT PRIMARY KEY,
+    run_id            TEXT NOT NULL REFERENCES collector_runs(id) ON DELETE CASCADE,
+    table_name        TEXT NOT NULL,
+    status            TEXT NOT NULL CHECK (status IN ('success', 'skipped', 'failed')),
+    metrics_collected INTEGER DEFAULT 0,
+    rows_observed     INTEGER,
+    duration_ms       INTEGER,
+    skip_reason       TEXT CHECK (
+                          skip_reason IS NULL OR skip_reason IN (
+                              'denylisted', 'not_in_allowlist', 'too_large',
+                              'timeout', 'max_tables_limit'
+                          )
+                      ),
+    error_message     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_collector_runs_conn
+    ON collector_runs (connection_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_collector_runs_project_started
+    ON collector_runs (project_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_collector_run_tables_run
+    ON collector_run_tables (run_id);
+
 CREATE TABLE IF NOT EXISTS failed_login_attempts (
     email        TEXT NOT NULL,
     attempted_at TIMESTAMPTZ NOT NULL,

--- a/tests/test_collector_run_log.py
+++ b/tests/test_collector_run_log.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest import mock
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from app import crypto
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    db_path = tmp_path / "metrics.db"
+    import app.metrics_storage as storage_mod
+
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    return storage_mod
+
+
+def _seed_connection(storage, *, project_id: str | None = None, active: bool = True):
+    user_id = uuid.uuid4().hex
+    storage.create_user(
+        user_id=user_id,
+        email=f"u{user_id[:8]}@example.test",
+        password_hash="x",
+    )
+    project = storage.create_project(
+        project_id=project_id or uuid.uuid4().hex,
+        user_id=user_id,
+        name="Project",
+        slug=f"p-{user_id[:8]}",
+    )
+    conn = storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"],
+        name="main",
+        dsn_encrypted=crypto.encrypt_dsn("postgresql://user:pass@db/app"),
+        schema_name="public",
+        is_active=active,
+    )
+    return project, conn
+
+
+def test_schema_tables_indexes_and_checks_exist(storage):
+    engine = storage.get_engine()
+    with engine.connect() as conn:
+        tables = {
+            r[0]
+            for r in conn.execute(text(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ))
+        }
+        indexes = {
+            r[0]
+            for r in conn.execute(text(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            ))
+        }
+
+    assert "collector_runs" in tables
+    assert "collector_run_tables" in tables
+    assert "idx_collector_runs_conn" in indexes
+    assert "idx_collector_runs_project_started" in indexes
+    assert "idx_collector_run_tables_run" in indexes
+
+    project, conn_row = _seed_connection(storage)
+    with pytest.raises(IntegrityError):
+        storage.save_collector_run(
+            uuid.uuid4().hex,
+            project["id"],
+            conn_row["id"],
+            datetime.now(UTC),
+            mode="bad-mode",
+        )
+
+
+def test_collector_run_helpers_list_and_tenant_isolation(storage):
+    project_a, conn_a = _seed_connection(storage, project_id="proj-a")
+    project_b, conn_b = _seed_connection(storage, project_id="proj-b")
+    started = datetime.now(UTC)
+
+    run_a = uuid.uuid4().hex
+    storage.save_collector_run(run_a, project_a["id"], conn_a["id"], started)
+    storage.save_run_table(
+        run_a,
+        "users",
+        "success",
+        metrics_collected=3,
+        rows_observed=42,
+        duration_ms=11,
+    )
+    storage.update_collector_run(
+        run_a,
+        status="success",
+        finished_at=started + timedelta(seconds=1),
+        tables_total=1,
+        tables_checked=1,
+        metrics_collected=3,
+        duration_ms=1000,
+    )
+
+    run_b = uuid.uuid4().hex
+    storage.save_collector_run(run_b, project_b["id"], conn_b["id"], started)
+    storage.update_collector_run(
+        run_b,
+        status="success",
+        finished_at=started,
+    )
+
+    runs_a = storage.list_collector_runs(project_a["id"], conn_a["id"])
+    runs_b = storage.list_collector_runs(project_b["id"], conn_b["id"])
+
+    assert [r["id"] for r in runs_a] == [run_a]
+    assert [r["id"] for r in runs_b] == [run_b]
+    assert runs_a[0]["tables"][0]["table_name"] == "users"
+    assert runs_a[0]["tables"][0]["rows_observed"] == 42
+    assert storage.list_collector_runs(project_b["id"], conn_a["id"]) == []
+    assert storage.list_collector_runs(project_a["id"], conn_a["id"], limit="bad")[0]["id"] == run_a
+
+
+def test_cleanup_stale_collector_runs(storage):
+    project, conn_row = _seed_connection(storage)
+    started = datetime.now(UTC) - timedelta(seconds=2)
+    run_id = uuid.uuid4().hex
+    storage.save_collector_run(run_id, project["id"], conn_row["id"], started)
+
+    updated = storage.cleanup_stale_collector_runs(now=datetime.now(UTC))
+
+    assert updated == 1
+    run = storage.list_collector_runs(project["id"], conn_row["id"])[0]
+    assert run["status"] == "failed"
+    assert run["finished_at"] is not None
+    assert run["duration_ms"] >= 0
+    assert "stopped before finishing" in run["error_message"]
+
+
+def test_cascade_delete_connection_removes_run_log(storage):
+    project, conn_row = _seed_connection(storage)
+    run_id = uuid.uuid4().hex
+    storage.save_collector_run(run_id, project["id"], conn_row["id"], datetime.now(UTC))
+    storage.save_run_table(run_id, "users", "success")
+
+    assert storage.delete_connection(project["id"], conn_row["id"]) is True
+
+    with storage.get_engine().connect() as conn:
+        run_count = conn.execute(text("SELECT COUNT(*) FROM collector_runs")).scalar()
+        table_count = conn.execute(text("SELECT COUNT(*) FROM collector_run_tables")).scalar()
+    assert run_count == 0
+    assert table_count == 0
+
+
+def test_collect_for_connection_success_creates_run_log(storage):
+    import app.db as db_mod
+    from collectors import metrics_collector, per_project
+
+    project, conn_row = _seed_connection(storage)
+    fake_rows = [{
+        "ts": datetime.now(UTC),
+        "table_name": "users",
+        "metric_name": "row_count",
+        "value": 42,
+    }]
+
+    def fake_list_tables(self, schema):
+        return [{"table_name": "users", "schema": schema}]
+
+    with mock.patch.object(
+        metrics_collector.MetricsCollector, "collect", return_value=fake_rows,
+    ), mock.patch.object(
+        db_mod.PostgresAdapter, "list_tables", autospec=True, side_effect=fake_list_tables,
+    ), mock.patch(
+        "collectors.schema_collector.collect_table_schema", return_value=None,
+    ):
+        per_project.collect_for_connection(project["id"], conn_row["id"])
+
+    run = storage.list_collector_runs(project["id"], conn_row["id"])[0]
+    assert run["status"] == "success"
+    assert run["tables_checked"] == 1
+    assert run["metrics_collected"] == 1
+    assert run["tables"][0]["status"] == "success"
+    assert run["tables"][0]["rows_observed"] == 42
+
+
+def test_collect_for_connection_inactive_logged_as_skipped(storage):
+    from collectors import per_project
+
+    project, conn_row = _seed_connection(storage, active=False)
+
+    per_project.collect_for_connection(project["id"], conn_row["id"])
+
+    run = storage.list_collector_runs(project["id"], conn_row["id"])[0]
+    assert run["status"] == "skipped"
+    assert run["error_message"] == "connection inactive or deleted"
+
+
+def test_collect_for_connection_table_failure_sets_warning_and_scrubs(storage):
+    import app.db as db_mod
+    from collectors import metrics_collector, per_project
+
+    project, conn_row = _seed_connection(storage)
+
+    def fake_list_tables(self, schema):
+        return [{"table_name": "users", "schema": schema}]
+
+    with mock.patch.object(
+        metrics_collector.MetricsCollector,
+        "collect",
+        side_effect=RuntimeError("boom postgresql://u:secret@db/app?token=abc"),
+    ), mock.patch.object(
+        db_mod.PostgresAdapter, "list_tables", autospec=True, side_effect=fake_list_tables,
+    ):
+        per_project.collect_for_connection(project["id"], conn_row["id"])
+
+    run = storage.list_collector_runs(project["id"], conn_row["id"])[0]
+    assert run["status"] == "warning"
+    assert run["tables"][0]["status"] == "failed"
+    assert "secret" not in run["tables"][0]["error_message"]
+    assert "token=abc" not in run["tables"][0]["error_message"]
+    assert "abc" not in run["tables"][0]["error_message"]
+
+
+def test_collect_for_connection_invalid_engine_url_logged_as_failed(storage):
+    from app.instrumentation import collector_runs_total
+    from collectors import per_project
+    from tests.test_prometheus_metrics import _get_value
+
+    project, conn_row = _seed_connection(storage)
+    with storage.get_engine().begin() as db_conn:
+        db_conn.execute(
+            text("UPDATE connections SET dsn_encrypted = :dsn WHERE id = :id"),
+            {
+                "id": conn_row["id"],
+                "dsn": crypto.encrypt_dsn("not-a-url"),
+            },
+        )
+
+    before = _get_value(collector_runs_total, result="error")
+    per_project.collect_for_connection(project["id"], conn_row["id"])
+    after = _get_value(collector_runs_total, result="error")
+
+    run = storage.list_collector_runs(project["id"], conn_row["id"])[0]
+    assert run["status"] == "failed"
+    assert run["finished_at"] is not None
+    assert run["error_message"]
+    assert after - before == 1


### PR DESCRIPTION
Closes #239

## Summary

- add `collector_runs` and `collector_run_tables` to SQLite and Timescale schemas with status/mode/skip_reason checks and lookup indexes
- add storage helpers for run creation, table-level rows, run finalization, stale cleanup, and tenant-scoped `list_collector_runs()`
- wire `collect_for_connection()` to persist run lifecycle, scrub stored errors, record table outcomes, and keep `collector_runs_total` updated for failures
- mark stale `running` runs as `failed` on app startup
- extend secret scrubbing for query/key-value secrets used in persisted error messages

## Notes

- inactive connections are persisted as `skipped`
- already deleted / unknown connections remain application-log only because `collector_runs.connection_id` keeps the FK/cascade contract to `connections(id)`
- UI is intentionally out of scope and will be handled by #240

## Testing

- `PATH=./venv/bin:$PATH ./venv/bin/pytest` → 851 passed, 6 skipped, 15 deselected
- `PATH=./venv/bin:$PATH ./venv/bin/pytest tests/test_collector_run_log.py tests/test_prometheus_metrics.py tests/test_per_project.py tests/test_metrics_storage.py` → 53 passed
- `PATH=./venv/bin:$PATH ./venv/bin/pytest tests/test_security.py tests/test_secrets_scrub.py tests/test_project_notifications.py::test_dsn_filter_scrubs_token_in_exception tests/test_password_reset.py::test_forgot_password_logs_warning_no_pii` → 39 passed
- SQLite smoke: `E2E_SQLITE_RUN_LOG_OK`
- Timescale smoke: `E2E_TIMESCALE_RUN_LOG_OK`