### PR TITLE
feat(#234): production-параметры Iceberg подключения (namespace/warehouse/auth)

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -33,8 +33,14 @@ from flask_wtf import FlaskForm
 from sqlalchemy import create_engine, make_url, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.pool import NullPool
-from wtforms import BooleanField, IntegerField, StringField, SubmitField
-from wtforms.validators import DataRequired, Length, NumberRange
+from wtforms import (
+    BooleanField,
+    IntegerField,
+    PasswordField,
+    StringField,
+    SubmitField,
+)
+from wtforms.validators import DataRequired, Length, NumberRange, Optional
 
 from app import crypto, metrics_storage
 from app.auth import limiter
@@ -89,6 +95,25 @@ class ConnectionForm(FlaskForm):
         default=15,
     )
     is_active = BooleanField("Активен", default=True)
+    # #234: Iceberg production params. Поля опциональны — для не-Iceberg
+    # DSN остаются пустыми (JS прячет блок при вводе non-iceberg+ DSN).
+    # Token идёт через PasswordField — браузер не подсказывает значение
+    # из истории и не показывает plaintext в tooltip dev-tools.
+    iceberg_namespace = StringField(
+        "Iceberg namespace",
+        validators=[Optional(), Length(max=256)],
+        render_kw={"placeholder": "lakehouse"},
+    )
+    iceberg_warehouse = StringField(
+        "Iceberg warehouse",
+        validators=[Optional(), Length(max=256)],
+        render_kw={"placeholder": "s3://bucket/warehouse"},
+    )
+    iceberg_auth_token = PasswordField(
+        "Iceberg auth token",
+        validators=[Optional(), Length(max=2000)],
+        render_kw={"autocomplete": "off", "placeholder": "Bearer token"},
+    )
     submit = SubmitField("Сохранить")
 
 
@@ -137,6 +162,19 @@ def new_connection(slug: str):
     form = ConnectionForm()
     if form.validate_on_submit():
         raw_dsn = form.dsn.data
+        # #234: Iceberg fields are only meaningful for iceberg+ DSNs. JS
+        # hides them otherwise, but the server has to ignore them too —
+        # a hand-crafted POST shouldn't be able to attach an Iceberg
+        # token to a Postgres connection.
+        is_iceberg = raw_dsn.lower().startswith("iceberg+")
+        iceberg_ns = (form.iceberg_namespace.data or "").strip() or None
+        iceberg_wh = (form.iceberg_warehouse.data or "").strip() or None
+        iceberg_token = (form.iceberg_auth_token.data or "").strip()
+        token_ct = (
+            crypto.encrypt_token(iceberg_token)
+            if is_iceberg and iceberg_token
+            else None
+        )
         conn_row = metrics_storage.create_connection(
             connection_id=uuid.uuid4().hex,
             project_id=project["id"],
@@ -145,6 +183,9 @@ def new_connection(slug: str):
             schema_name=form.schema_name.data.strip(),
             interval_minutes=form.interval_minutes.data,
             is_active=form.is_active.data,
+            iceberg_namespace=iceberg_ns if is_iceberg else None,
+            iceberg_warehouse=iceberg_wh if is_iceberg else None,
+            iceberg_auth_token_encrypted=token_ct,
         )
         # #54: register the APScheduler job immediately if the connection
         # is active. The scheduler is process-wide (started at app boot);
@@ -166,7 +207,12 @@ def new_connection(slug: str):
         # with a positive flash; failure → /connections with the code so
         # they can edit/delete and retry.
         if is_first:
-            result = probe_connection(raw_dsn)
+            result = probe_connection(
+                raw_dsn,
+                iceberg_namespace=iceberg_ns if is_iceberg else None,
+                iceberg_warehouse=iceberg_wh if is_iceberg else None,
+                iceberg_auth_token=iceberg_token if is_iceberg else None,
+            )
             if result["status"] == "ok":
                 flash(
                     "Подключение проверено. Сбор метрик запустится через "
@@ -240,7 +286,30 @@ def test_connection(slug: str, conn_id: str):
             "status": "error", "code": "invalid_ciphertext",
             "message": "Сохранённый DSN не расшифровывается. Пересохрани подключение.",
         }), 422
-    result = probe_connection(plain)
+    # #234: decrypt the Iceberg auth token (if any) and pass all Iceberg
+    # fields into probe_connection so the catalog smoke-test uses the
+    # same config the collector will use. decrypt_token raises on key
+    # mismatch — caught with the same code as DSN invalidation.
+    iceberg_token: str | None = None
+    if conn.get("iceberg_auth_token_encrypted"):
+        try:
+            iceberg_token = crypto.decrypt_token(
+                conn["iceberg_auth_token_encrypted"],
+            )
+        except crypto.InvalidToken:
+            return jsonify({
+                "status": "error", "code": "invalid_ciphertext",
+                "message": (
+                    "Сохранённый Iceberg auth token не расшифровывается. "
+                    "Пересохрани подключение."
+                ),
+            }), 422
+    result = probe_connection(
+        plain,
+        iceberg_namespace=conn.get("iceberg_namespace"),
+        iceberg_warehouse=conn.get("iceberg_warehouse"),
+        iceberg_auth_token=iceberg_token,
+    )
     status_code = 200 if result["status"] == "ok" else 422
     return jsonify(result), status_code
 
@@ -341,17 +410,57 @@ def _classify_error(exc: BaseException) -> tuple[str, str]:
     return "error", "Ошибка подключения (см. логи сервера)."
 
 
-def _probe_iceberg(dsn: str) -> dict:
+def _probe_iceberg(
+    dsn: str,
+    *,
+    namespace: str | None = None,
+    warehouse: str | None = None,
+    auth_token: str | None = None,
+) -> dict:
     """Lightweight probe for iceberg+rest:// and iceberg+glue:// DSNs.
 
     Calls list_namespaces() on the catalog — no data scan, just a metadata
-    round-trip.  Falls back gracefully if pyiceberg is not installed.
+    round-trip. If *namespace* is given:
+      - checked against the catalog's namespace list →
+        ``namespace_not_found`` if missing,
+      - else list_tables(namespace) is called and ``tables_found`` returned.
+
+    *warehouse* / *auth_token* override any same-named values inside the
+    DSN query string (#234 — form values win so the operator can rotate
+    a token without re-saving the DSN). Empty/None means "use whatever the
+    DSN already has".
     """
     started = time.monotonic()
     try:
         from app.db import make_adapter_for_url
-        adapter = make_adapter_for_url(dsn)
+        adapter = make_adapter_for_url(
+            dsn, warehouse=warehouse, auth_token=auth_token,
+        )
         namespaces = adapter.list_namespaces()
+        if namespace:
+            # Normalise: pyiceberg returns ((ns,),) or ((parent, child),).
+            existing = {".".join(ns) if isinstance(ns, tuple | list)
+                        else str(ns) for ns in namespaces}
+            if namespace not in existing:
+                latency_ms = int((time.monotonic() - started) * 1000)
+                return {
+                    "status": "error",
+                    "code": "namespace_not_found",
+                    "message": (
+                        f"Namespace {namespace!r} не найден в catalog. "
+                        f"Доступны: {sorted(existing) or '—'}."
+                    ),
+                    "latency_ms": latency_ms,
+                }
+            tables = adapter.list_tables(namespace)
+            latency_ms = int((time.monotonic() - started) * 1000)
+            return {
+                "status": "ok",
+                "database": "iceberg",
+                "version": f"namespace={namespace}",
+                "tables_found": len(tables),
+                "latency_ms": latency_ms,
+            }
         latency_ms = int((time.monotonic() - started) * 1000)
         return {
             "status": "ok",
@@ -365,10 +474,13 @@ def _probe_iceberg(dsn: str) -> dict:
             "message": "pyiceberg не установлен на сервере.",
         }
     except Exception as exc:
+        # Token must never leak into the user-facing message. The catch-all
+        # text is intentionally generic; full traceback (scrubbed via
+        # DSNFilter) goes to server logs only.
         logger.warning("iceberg probe failed: %s", exc, exc_info=True)
         latency_ms = int((time.monotonic() - started) * 1000)
         return {
-            "status": "error", "code": "error",
+            "status": "error", "code": "catalog_error",
             "message": "Iceberg catalog недоступен или DSN неверен.",
             "latency_ms": latency_ms,
         }
@@ -415,14 +527,22 @@ def _probe_clickhouse(dsn: str) -> dict:
         engine.dispose()
 
 
-def probe_connection(dsn: str) -> dict:
+def probe_connection(
+    dsn: str,
+    *,
+    iceberg_namespace: str | None = None,
+    iceberg_warehouse: str | None = None,
+    iceberg_auth_token: str | None = None,
+) -> dict:
     """Try connecting and reading a couple of harmless metadata bits.
 
     Dialect support: PostgreSQL (full), ClickHouse (full, #141),
-    Iceberg REST/Glue (#111). Other dialects return ``unsupported_dialect``
-    until a per-dialect probe lands. The JSON response is identical shape
-    across success and failure so the UI never has to branch on keys,
-    only on ``status``.
+    Iceberg REST/Glue (#111, expanded in #234). Other dialects return
+    ``unsupported_dialect``. The JSON response is identical shape across
+    success and failure so the UI never has to branch on keys, only on
+    ``status``.
+
+    Iceberg-specific params (#234) are no-ops for non-Iceberg backends.
     """
     try:
         backend = make_url(dsn).get_backend_name()
@@ -433,7 +553,12 @@ def probe_connection(dsn: str) -> dict:
         }
 
     if backend.startswith("iceberg"):
-        return _probe_iceberg(dsn)
+        return _probe_iceberg(
+            dsn,
+            namespace=iceberg_namespace,
+            warehouse=iceberg_warehouse,
+            auth_token=iceberg_auth_token,
+        )
 
     if backend == "clickhouse":
         return _probe_clickhouse(dsn)

--- a/app/db.py
+++ b/app/db.py
@@ -431,13 +431,31 @@ class IcebergAdapter(DBAdapter):
     metadata — no full table scan, even on billion-row tables.
     """
 
-    def __init__(self, url: str):
+    def __init__(
+        self,
+        url: str,
+        *,
+        warehouse: str | None = None,
+        auth_token: str | None = None,
+    ):
+        """*warehouse* and *auth_token* (#234) override matching DSN query
+        params. The form value wins — operators can rotate a token without
+        re-saving the whole DSN. None/empty means "keep DSN value as-is"."""
         parsed = urlparse(url)
         catalog_type = parsed.scheme.split("+", 1)[1]  # "rest" or "glue"
         qs = parse_qs(parsed.query)
 
         # All query params become catalog props (warehouse, s3.endpoint, etc.)
         props: dict = {key: values[0] for key, values in qs.items()}
+
+        # #234: explicit form overrides win over DSN query params.
+        if warehouse:
+            props["warehouse"] = warehouse
+        if auth_token:
+            # PyIceberg REST catalog reads bearer tokens from the "token"
+            # property. Keep "credential" as-is if the DSN already has one
+            # (basic auth); only set the bearer token field.
+            props["token"] = auth_token
 
         if catalog_type == "rest":
             from pyiceberg.catalog.rest import RestCatalog
@@ -587,15 +605,24 @@ _ADAPTERS: dict[str, type[DBAdapter]] = {
 }
 
 
-def _make_adapter(cls: type[DBAdapter], url: str) -> DBAdapter:
+def _make_adapter(
+    cls: type[DBAdapter],
+    url: str,
+    *,
+    warehouse: str | None = None,
+    auth_token: str | None = None,
+) -> DBAdapter:
     """Instantiate an adapter, passing ``url`` for catalog-based adapters.
 
     Catalog-based adapters (IcebergAdapter) need the raw DSN to connect to
     their catalog API — they don't use SQLAlchemy. SQL adapters take no args.
     If you add a new catalog-based adapter, add it to this condition.
+
+    *warehouse* / *auth_token* (#234) are only used by IcebergAdapter and
+    silently ignored for SQL adapters.
     """
     if issubclass(cls, IcebergAdapter):
-        return cls(url)
+        return cls(url, warehouse=warehouse, auth_token=auth_token)
     return cls()
 
 
@@ -617,11 +644,19 @@ def get_adapter() -> DBAdapter:
     return _adapter
 
 
-def make_adapter_for_url(url: str) -> DBAdapter:
+def make_adapter_for_url(
+    url: str,
+    *,
+    warehouse: str | None = None,
+    auth_token: str | None = None,
+) -> DBAdapter:
     """Build a fresh adapter for a given DSN — for the per-project scheduler.
 
     Bypasses the module-level singleton (which is keyed off ``settings.
     DATABASE_URL``). Cheap operation — adapters hold no state.
+
+    *warehouse* / *auth_token* (#234) are forwarded to IcebergAdapter and
+    silently ignored for SQL adapters.
     """
     key = _adapter_key(url)
     cls = _ADAPTERS.get(key)
@@ -630,7 +665,7 @@ def make_adapter_for_url(url: str) -> DBAdapter:
             f"Unsupported database backend: {key!r}. "
             f"Supported: {sorted(_ADAPTERS)}"
         )
-    return _make_adapter(cls, url)
+    return _make_adapter(cls, url, warehouse=warehouse, auth_token=auth_token)
 
 
 def list_tables(schema: str | None = None) -> list[dict]:

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -426,6 +426,23 @@ def _migrate_existing_schema(engine: Engine) -> None:
                     ))
                 logger.info("connections.%s added (#232 load safety)", col)
 
+        # #234: Iceberg production params. namespace/warehouse — plain TEXT,
+        # auth token — binary ciphertext. BLOB on SQLite, BYTEA on Postgres;
+        # ALTER TABLE syntax differs only in the type keyword.
+        token_type = "BYTEA" if _is_postgres() else "BLOB"
+        _iceberg_columns = [
+            ("iceberg_namespace", "TEXT"),
+            ("iceberg_warehouse", "TEXT"),
+            ("iceberg_auth_token_encrypted", token_type),
+        ]
+        for col, ddl in _iceberg_columns:
+            if col not in present:
+                with engine.begin() as conn:
+                    conn.execute(text(
+                        f"ALTER TABLE connections ADD COLUMN {col} {ddl}"
+                    ))
+                logger.info("connections.%s added (#234 iceberg params)", col)
+
     _migrate_project_scoped_ml_tables(engine)
 
     # #172: backfill project_members for projects that existed before
@@ -2380,6 +2397,9 @@ def create_connection(
     schema_name: str = "public",
     interval_minutes: int = 15,
     is_active: bool = True,
+    iceberg_namespace: str | None = None,
+    iceberg_warehouse: str | None = None,
+    iceberg_auth_token_encrypted: bytes | None = None,
 ) -> dict:
     """Insert a new DB connection. dsn_encrypted is Fernet ciphertext.
 
@@ -2396,14 +2416,20 @@ def create_connection(
         "interval_minutes": int(interval_minutes),
         "is_active": 1 if is_active else 0,
         "created_at": now,
+        "iceberg_namespace": iceberg_namespace,
+        "iceberg_warehouse": iceberg_warehouse,
+        "iceberg_auth_token_encrypted": iceberg_auth_token_encrypted,
     }
     stmt = text("""
         INSERT INTO connections
             (id, project_id, name, dsn_encrypted, schema_name,
-             interval_minutes, is_active, created_at)
+             interval_minutes, is_active, created_at,
+             iceberg_namespace, iceberg_warehouse, iceberg_auth_token_encrypted)
         VALUES
             (:id, :project_id, :name, :dsn_encrypted, :schema_name,
-             :interval_minutes, :is_active, :created_at)
+             :interval_minutes, :is_active, :created_at,
+             :iceberg_namespace, :iceberg_warehouse,
+             :iceberg_auth_token_encrypted)
     """)
     with get_engine().begin() as conn:
         conn.execute(stmt, payload)
@@ -2417,7 +2443,8 @@ _CONNECTION_COLUMNS = (
     "id, project_id, name, dsn_encrypted, schema_name, "
     "interval_minutes, is_active, created_at, "
     "table_allowlist, table_denylist, max_tables_per_tick, "
-    "skip_tables_larger_than_gb, statement_timeout_ms"
+    "skip_tables_larger_than_gb, statement_timeout_ms, "
+    "iceberg_namespace, iceberg_warehouse, iceberg_auth_token_encrypted"
 )
 
 
@@ -2443,6 +2470,13 @@ def _row_to_connection(row) -> dict | None:
         ),
         "statement_timeout_ms": (
             int(row[12]) if row[12] is not None else None
+        ),
+        # #234: Iceberg production params. Token ciphertext is bytes (cast
+        # from memoryview on Postgres); namespace/warehouse plain text.
+        "iceberg_namespace": row[13],
+        "iceberg_warehouse": row[14],
+        "iceberg_auth_token_encrypted": (
+            bytes(row[15]) if row[15] is not None else None
         ),
     }
 

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -249,6 +249,32 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
         _inc_collector_error_counter()
         return
 
+    # #234: decrypt Iceberg auth token (if stored) and pass with warehouse
+    # so the adapter uses the production-rotated value, not just the DSN.
+    iceberg_token: str | None = None
+    if conn_row.get("iceberg_auth_token_encrypted"):
+        try:
+            iceberg_token = crypto.decrypt_token(
+                conn_row["iceberg_auth_token_encrypted"],
+            )
+        except crypto.InvalidToken:
+            run_error = scrub_value(
+                "Iceberg auth token ciphertext invalid",
+            )
+            logger.warning(
+                "[project=%s][conn=%s] %s",
+                project_id, connection_id, run_error,
+            )
+            update_collector_run(
+                run_id,
+                status="failed",
+                finished_at=datetime.now(UTC),
+                duration_ms=int((time.monotonic() - started) * 1000),
+                error_message=run_error,
+            )
+            _inc_collector_error_counter()
+            return
+
     try:
         # Iceberg uses a catalog API (not SQLAlchemy) — skip engine creation.
         # For all other dialects, create a per-tick NullPool engine so
@@ -257,7 +283,11 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
         # ClickHouse / Iceberg ignore the value (spec).
         if not dsn.lower().startswith("iceberg+"):
             engine = _build_engine(dsn, conn_row.get("statement_timeout_ms"))
-        adapter = make_adapter_for_url(dsn)
+        adapter = make_adapter_for_url(
+            dsn,
+            warehouse=conn_row.get("iceberg_warehouse"),
+            auth_token=iceberg_token,
+        )
     except Exception as exc:
         run_error = scrub_value(exc)
         logger.warning("[project=%s][conn=%s] %s",
@@ -275,7 +305,10 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
         return
 
     run_ts = datetime.now(UTC)
-    schema = conn_row["schema_name"]
+    # #234: for Iceberg, iceberg_namespace overrides schema_name.
+    # effective_namespace = iceberg_namespace or schema_name — preserves
+    # back-compat for legacy connections without the new field.
+    schema = conn_row.get("iceberg_namespace") or conn_row["schema_name"]
     # #232: cache dialect + threshold once — applied to every table below.
     is_postgres = _is_postgres_dsn(dsn)
     skip_larger_than_gb = conn_row.get("skip_tables_larger_than_gb")

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -240,6 +240,12 @@ CREATE TABLE IF NOT EXISTS connections (
     max_tables_per_tick        INTEGER DEFAULT 50,
     skip_tables_larger_than_gb REAL,
     statement_timeout_ms       INTEGER DEFAULT 30000,
+    -- #234 Iceberg production params. namespace/warehouse — plain TEXT,
+    -- auth token шифруется отдельно через crypto.encrypt_token (НЕ
+    -- encrypt_dsn — разные lifecycles для DSN-rotation и token-rotation).
+    iceberg_namespace             TEXT,
+    iceberg_warehouse             TEXT,
+    iceberg_auth_token_encrypted  BLOB,
     CHECK (interval_minutes BETWEEN 5 AND 1440)
 );
 

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -197,6 +197,10 @@ CREATE TABLE IF NOT EXISTS connections (
     max_tables_per_tick        INTEGER DEFAULT 50,
     skip_tables_larger_than_gb DOUBLE PRECISION,
     statement_timeout_ms       INTEGER DEFAULT 30000,
+    -- #234 Iceberg production params. См. metrics_schema.sql.
+    iceberg_namespace             TEXT,
+    iceberg_warehouse             TEXT,
+    iceberg_auth_token_encrypted  BYTEA,
     CHECK (interval_minutes BETWEEN 5 AND 1440)
 );
 

--- a/templates/connections/new.html
+++ b/templates/connections/new.html
@@ -37,13 +37,30 @@
         Пример:
         <span class="font-mono">postgresql://user:password@host:5432/dbname</span><br>
         <span class="font-mono">mysql+pymysql://user:password@host:3306/dbname</span><br>
-        <span class="font-mono">clickhouse+native://user:password@host:9000/dbname</span>
+        <span class="font-mono">clickhouse+native://user:password@host:9000/dbname</span><br>
+        <span class="font-mono">iceberg+rest://catalog.host:8181?warehouse=s3://bucket/path</span>
       </p>
 
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {{ render_field(form.schema_name, input_class=input_cls) }}
         {{ render_field(form.interval_minutes, input_class=input_cls) }}
       </div>
+
+      {# #234: Iceberg production params. Скрыты по умолчанию; JS внизу
+         показывает блок, когда DSN начинается на iceberg+. На сервере
+         ConnectionForm всё равно игнорирует эти поля для не-Iceberg DSN. #}
+      <fieldset id="iceberg-fields" class="hidden space-y-4 rounded-md border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950">
+        <legend class="-mx-1 px-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Iceberg
+        </legend>
+        {{ render_field(form.iceberg_namespace, input_class=input_cls) }}
+        {{ render_field(form.iceberg_warehouse, input_class=input_cls) }}
+        {{ render_field(form.iceberg_auth_token, input_class=input_cls) }}
+        <p class="text-xs text-slate-500 dark:text-slate-400">
+          Namespace / warehouse в форме переопределяют значения из DSN.
+          Token хранится зашифрованным и не отображается в списке подключений.
+        </p>
+      </fieldset>
 
       <div class="flex items-center gap-2">
         {{ form.is_active(class="h-4 w-4 rounded border-slate-300 text-accent focus:ring-accent dark:border-slate-700 dark:bg-slate-950") }}
@@ -56,4 +73,21 @@
       </div>
     </form>
   </div>
+
+  {# #234: показываем Iceberg-блок только когда DSN начинается на
+     iceberg+. Чек срабатывает на input и на initial load (нет post-back
+     с заполненным DSN, но handler идемпотентен). #}
+  <script>
+    (function () {
+      const dsn = document.getElementById("{{ form.dsn.id }}");
+      const ice = document.getElementById("iceberg-fields");
+      if (!dsn || !ice) return;
+      const toggle = () => {
+        const v = (dsn.value || "").toLowerCase();
+        ice.classList.toggle("hidden", !v.startsWith("iceberg+"));
+      };
+      dsn.addEventListener("input", toggle);
+      toggle();
+    })();
+  </script>
 {% endblock %}

--- a/templates/onboarding/add_connection.html
+++ b/templates/onboarding/add_connection.html
@@ -56,6 +56,17 @@
               </div>
             </div>
 
+            <div>
+              <div class="font-semibold text-slate-800 dark:text-slate-200">Iceberg (REST)</div>
+              <div class="mt-1 break-all font-mono text-[11px]">
+                iceberg+rest://catalog.host:8181?warehouse=s3://bucket/path
+              </div>
+              <div class="mt-1 text-slate-500 dark:text-slate-400">
+                Namespace, warehouse и Bearer токен можно задать ниже —
+                их значения перекрывают то, что в DSN.
+              </div>
+            </div>
+
           </div>
         </div>
 
@@ -86,6 +97,21 @@
               {{ render_field(form.interval_minutes, input_class=input_cls) }}
             </div>
 
+            {# #234: Iceberg-блок. JS внизу страницы показывает его, когда
+               DSN начинается на iceberg+. #}
+            <fieldset id="iceberg-fields" class="hidden space-y-4 rounded-md border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950">
+              <legend class="-mx-1 px-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Iceberg
+              </legend>
+              {{ render_field(form.iceberg_namespace, input_class=input_cls) }}
+              {{ render_field(form.iceberg_warehouse, input_class=input_cls) }}
+              {{ render_field(form.iceberg_auth_token, input_class=input_cls) }}
+              <p class="text-xs text-slate-500 dark:text-slate-400">
+                Namespace / warehouse в форме переопределяют значения из DSN.
+                Token хранится зашифрованным.
+              </p>
+            </fieldset>
+
             <div class="flex items-center gap-2">
               {{ form.is_active(class="h-4 w-4 rounded border-slate-300 text-accent focus:ring-accent dark:border-slate-700 dark:bg-slate-950") }}
               <label for="{{ form.is_active.id }}" class="text-sm text-slate-600 dark:text-slate-300">{{ form.is_active.label.text }}</label>
@@ -103,4 +129,18 @@
 
     </div>
   </div>
+
+  <script>
+    (function () {
+      const dsn = document.getElementById("{{ form.dsn.id }}");
+      const ice = document.getElementById("iceberg-fields");
+      if (!dsn || !ice) return;
+      const toggle = () => {
+        const v = (dsn.value || "").toLowerCase();
+        ice.classList.toggle("hidden", !v.startsWith("iceberg+"));
+      };
+      dsn.addEventListener("input", toggle);
+      toggle();
+    })();
+  </script>
 {% endblock %}

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -396,7 +396,7 @@ def test_probe_connection_iceberg_ok(monkeypatch):
     monkeypatch.setattr("app.connections.make_adapter_for_url", fake_adapter, raising=False)
 
     import app.connections as conn_mod
-    monkeypatch.setattr(conn_mod, "_probe_iceberg", lambda dsn: {
+    monkeypatch.setattr(conn_mod, "_probe_iceberg", lambda dsn, **_: {
         "status": "ok",
         "database": "iceberg",
         "version": "2 namespace(s)",
@@ -417,7 +417,10 @@ def test_probe_iceberg_ok(monkeypatch):
     fake_adapter = MagicMock()
     fake_adapter.list_namespaces.return_value = [("ns1",), ("ns2",)]
 
-    monkeypatch.setattr("app.db.make_adapter_for_url", lambda dsn: fake_adapter)
+    monkeypatch.setattr(
+        "app.db.make_adapter_for_url",
+        lambda dsn, **_: fake_adapter,
+    )
 
     result = _probe_iceberg("iceberg+rest://localhost:8181?warehouse=s3://bucket/wh")
     assert result["status"] == "ok"
@@ -429,7 +432,7 @@ def test_probe_iceberg_import_error(monkeypatch):
     """_probe_iceberg returns unsupported_dialect when pyiceberg is missing."""
     from app.connections import _probe_iceberg
 
-    def _raise_import(dsn):
+    def _raise_import(dsn, **_):
         raise ImportError("No module named 'pyiceberg'")
 
     monkeypatch.setattr("app.db.make_adapter_for_url", _raise_import)
@@ -443,14 +446,15 @@ def test_probe_iceberg_connection_error(monkeypatch):
     """_probe_iceberg returns error dict (not exception) when catalog is unreachable."""
     from app.connections import _probe_iceberg
 
-    def _raise(dsn):
+    def _raise(dsn, **_):
         raise ConnectionError("catalog unreachable")
 
     monkeypatch.setattr("app.db.make_adapter_for_url", _raise)
 
     result = _probe_iceberg("iceberg+rest://localhost:8181?warehouse=s3://bucket/wh")
     assert result["status"] == "error"
-    assert result["code"] == "error"
+    # #234: catch-all path classified as catalog_error (was "error" before).
+    assert result["code"] == "catalog_error"
     assert "latency_ms" in result
 
 
@@ -469,6 +473,224 @@ def test_iceberg_adapter_list_namespaces():
     result = adapter.list_namespaces()
     assert result == [("warehouse",)]
     fake_catalog.list_namespaces.assert_called_once()
+
+
+# --- #234 Iceberg production params ----------------------------------------
+
+
+def test_iceberg_auth_token_roundtrip():
+    """encrypt_token + decrypt_token roundtrip — token must come back intact."""
+    from app import crypto
+
+    plain = "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"
+    ct = crypto.encrypt_token(plain)
+    assert ct != plain.encode()
+    assert isinstance(ct, bytes)
+    assert crypto.decrypt_token(ct) == plain
+
+
+def test_iceberg_adapter_form_warehouse_overrides_dsn_query():
+    """#234: explicit warehouse arg wins over warehouse= in DSN query."""
+    from unittest.mock import MagicMock, patch
+
+    from app.db import IcebergAdapter
+
+    fake = MagicMock()
+    with patch("pyiceberg.catalog.rest.RestCatalog", return_value=fake) as ctor:
+        IcebergAdapter(
+            "iceberg+rest://localhost:8181?warehouse=s3://old/wh",
+            warehouse="s3://new/wh",
+        )
+    # RestCatalog was constructed with warehouse from the override, not DSN.
+    _, kwargs = ctor.call_args
+    assert kwargs["warehouse"] == "s3://new/wh"
+
+
+def test_iceberg_adapter_auth_token_passed_to_catalog():
+    """#234: auth_token arg becomes the `token` catalog property."""
+    from unittest.mock import MagicMock, patch
+
+    from app.db import IcebergAdapter
+
+    fake = MagicMock()
+    with patch("pyiceberg.catalog.rest.RestCatalog", return_value=fake) as ctor:
+        IcebergAdapter(
+            "iceberg+rest://localhost:8181?warehouse=s3://b/w",
+            auth_token="bearer-abc123",
+        )
+    _, kwargs = ctor.call_args
+    assert kwargs["token"] == "bearer-abc123"
+
+
+def test_probe_iceberg_namespace_not_found(monkeypatch):
+    """#234: probe distinguishes missing namespace from empty namespace."""
+    from unittest.mock import MagicMock
+
+    from app.connections import _probe_iceberg
+
+    fake = MagicMock()
+    fake.list_namespaces.return_value = [("prod",), ("staging",)]
+    monkeypatch.setattr("app.db.make_adapter_for_url", lambda dsn, **_: fake)
+
+    result = _probe_iceberg(
+        "iceberg+rest://h:8181?warehouse=s3://b/w",
+        namespace="nonexistent",
+    )
+    assert result["status"] == "error"
+    assert result["code"] == "namespace_not_found"
+    # list_tables must NOT have been called once we knew the namespace is bogus.
+    assert not fake.list_tables.called
+
+
+def test_probe_iceberg_namespace_exists_tables_zero(monkeypatch):
+    """#234: namespace exists, tables_found=0 → ok status (not an error)."""
+    from unittest.mock import MagicMock
+
+    from app.connections import _probe_iceberg
+
+    fake = MagicMock()
+    fake.list_namespaces.return_value = [("empty_ns",)]
+    fake.list_tables.return_value = []
+    monkeypatch.setattr("app.db.make_adapter_for_url", lambda dsn, **_: fake)
+
+    result = _probe_iceberg(
+        "iceberg+rest://h:8181?warehouse=s3://b/w",
+        namespace="empty_ns",
+    )
+    assert result["status"] == "ok"
+    assert result["tables_found"] == 0
+
+
+def test_probe_iceberg_passes_overrides_to_adapter(monkeypatch):
+    """#234: namespace/warehouse/auth_token reach make_adapter_for_url."""
+    from unittest.mock import MagicMock
+
+    from app.connections import _probe_iceberg
+
+    captured = {}
+
+    def fake_factory(dsn, *, warehouse=None, auth_token=None, **_):
+        captured["warehouse"] = warehouse
+        captured["auth_token"] = auth_token
+        fake = MagicMock()
+        fake.list_namespaces.return_value = [("ns",)]
+        fake.list_tables.return_value = []
+        return fake
+
+    monkeypatch.setattr("app.db.make_adapter_for_url", fake_factory)
+    _probe_iceberg(
+        "iceberg+rest://h:8181",
+        namespace="ns",
+        warehouse="s3://override",
+        auth_token="bearer-x",
+    )
+    assert captured == {"warehouse": "s3://override", "auth_token": "bearer-x"}
+
+
+def test_create_iceberg_connection_persists_namespace_and_encrypts_token(client):
+    """#234: POST /new with Iceberg fields stores ns/warehouse + encrypts token."""
+    from app import crypto
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+
+    _register(client)
+    resp = client.post(
+        "/projects/default/connections/new",
+        data={
+            "name": "Lakehouse",
+            "dsn": "iceberg+rest://catalog:8181?warehouse=s3://b/w",
+            "schema_name": "public",
+            "interval_minutes": 15,
+            "is_active": "y",
+            "iceberg_namespace": "lakehouse",
+            "iceberg_warehouse": "s3://prod/wh",
+            "iceberg_auth_token": "bearer-secret-token-xyz",
+        },
+    )
+    assert resp.status_code == 302
+
+    user = get_user_by_email("u@example.com")
+    project = list_projects_for_user(user["id"])[0]
+    conns = list_connections_for_project(project["id"])
+    assert len(conns) == 1
+    row = conns[0]
+    assert row["iceberg_namespace"] == "lakehouse"
+    assert row["iceberg_warehouse"] == "s3://prod/wh"
+    # Token is encrypted at rest and round-trips via decrypt_token.
+    assert b"bearer-secret-token-xyz" not in row["iceberg_auth_token_encrypted"]
+    assert (
+        crypto.decrypt_token(row["iceberg_auth_token_encrypted"])
+        == "bearer-secret-token-xyz"
+    )
+
+
+def test_iceberg_fields_ignored_for_postgres_dsn(client):
+    """#234: server discards Iceberg fields when DSN is not iceberg+ — defence
+    against a hand-crafted POST attaching a token to a Postgres connection."""
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+
+    _register(client)
+    client.post(
+        "/projects/default/connections/new",
+        data={
+            "name": "PG",
+            "dsn": "postgresql://u:p@h:5432/d",
+            "schema_name": "public",
+            "interval_minutes": 15,
+            "is_active": "y",
+            "iceberg_namespace": "should-be-ignored",
+            "iceberg_warehouse": "s3://nope",
+            "iceberg_auth_token": "should-not-be-stored",
+        },
+    )
+    user = get_user_by_email("u@example.com")
+    project = list_projects_for_user(user["id"])[0]
+    row = list_connections_for_project(project["id"])[0]
+    assert row["iceberg_namespace"] is None
+    assert row["iceberg_warehouse"] is None
+    assert row["iceberg_auth_token_encrypted"] is None
+
+
+def test_iceberg_token_not_in_list_response(client):
+    """#234: GET /connections never includes the auth token plaintext."""
+    _register(client)
+    client.post(
+        "/projects/default/connections/new",
+        data={
+            "name": "Lakehouse",
+            "dsn": "iceberg+rest://catalog:8181?warehouse=s3://b/w",
+            "schema_name": "public",
+            "interval_minutes": 15,
+            "is_active": "y",
+            "iceberg_namespace": "lakehouse",
+            "iceberg_auth_token": "ultra-secret-token-12345",
+        },
+    )
+    resp = client.get("/projects/default/connections")
+    assert "ultra-secret-token-12345" not in resp.get_data(as_text=True)
+
+
+def test_effective_namespace_falls_back_to_schema_name():
+    """#234: collector uses iceberg_namespace or schema_name. With NULL ns,
+    schema_name wins (back-compat with pre-#234 connections)."""
+    # Exercised via the small fallback expression used in
+    # collectors/per_project.collect_for_connection — no DB needed.
+    conn_row_legacy = {"iceberg_namespace": None, "schema_name": "default"}
+    conn_row_explicit = {"iceberg_namespace": "lakehouse", "schema_name": "default"}
+    assert (
+        conn_row_legacy.get("iceberg_namespace") or conn_row_legacy["schema_name"]
+    ) == "default"
+    assert (
+        conn_row_explicit.get("iceberg_namespace")
+        or conn_row_explicit["schema_name"]
+    ) == "lakehouse"
 
 
 def test_interval_minutes_filter_formats_daily_interval():

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -157,7 +157,7 @@ def test_regular_template_rendered_when_project_has_connections(client, monkeypa
     import app.connections as conn_mod
     monkeypatch.setattr(
         conn_mod, "probe_connection",
-        lambda dsn: {"status": "ok", "database": "x", "version": "y", "latency_ms": 1},
+        lambda dsn, **_: {"status": "ok", "database": "x", "version": "y", "latency_ms": 1},
     )
     client.post("/projects/default/connections/new", data={
         "name": "First", "dsn": "postgresql://u:p@h:5432/d",
@@ -178,7 +178,7 @@ def test_first_connection_auto_test_success_redirects_to_dashboard(client, monke
     import app.connections as conn_mod
     monkeypatch.setattr(
         conn_mod, "probe_connection",
-        lambda dsn: {
+        lambda dsn, **_: {
             "status": "ok", "database": "appdb",
             "version": "PostgreSQL 16.1", "latency_ms": 4,
         },
@@ -200,7 +200,7 @@ def test_first_connection_auto_test_failure_redirects_to_connections_list(client
     import app.connections as conn_mod
     monkeypatch.setattr(
         conn_mod, "probe_connection",
-        lambda dsn: {
+        lambda dsn, **_: {
             "status": "error", "code": "auth_failed",
             "message": "Неверный логин или пароль.", "latency_ms": 12,
         },
@@ -266,7 +266,7 @@ def test_dashboard_no_empty_state_with_at_least_one_connection(client, monkeypat
     import app.connections as conn_mod
     monkeypatch.setattr(
         conn_mod, "probe_connection",
-        lambda dsn: {"status": "ok", "database": "x", "version": "y", "latency_ms": 1},
+        lambda dsn, **_: {"status": "ok", "database": "x", "version": "y", "latency_ms": 1},
     )
     # Add one connection; redirect goes to /dashboard (success path).
     client.post("/projects/default/connections/new", data={


### PR DESCRIPTION
**Stacked on #249 (#232).** Не мержить до мержа #249.

## Summary

- 3 новых поля в `connections`: `iceberg_namespace`, `iceberg_warehouse`, `iceberg_auth_token_encrypted` (BLOB/BYTEA).
- Token шифруется через `crypto.encrypt_token` (не `encrypt_dsn` — отдельный lifecycle для ротации токена).
- `_probe_iceberg(dsn, *, namespace, warehouse, auth_token)` различает `namespace_not_found` vs пустой namespace (`tables_found=0`).
- `IcebergAdapter` + `make_adapter_for_url` пробрасывают warehouse/auth_token; для не-Iceberg адаптеров аргументы игнорируются.
- JS visibility toggle в `connections/new.html` и `onboarding/add_connection.html` — Iceberg-блок виден только при `iceberg+` DSN; сервер дополнительно отбрасывает поля для не-Iceberg DSN.
- `collect_for_connection` использует `iceberg_namespace or schema_name` (effective_namespace, back-compat для legacy подключений).

## Что НЕ делаем
- Нет UI для Glue auth (IAM/ARN) — Glue продолжает работать через DSN как раньше.
- Нет S3/MinIO credentials UI.

## Test plan
- [x] `pytest tests/test_connections.py` — 37 пройдено, включая 9 новых для #234.
- [x] `pytest tests/test_load_safety.py tests/test_per_project.py tests/test_metrics_storage.py` — регрессия, 96 пройдено.
- [x] `ruff check .` — clean.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)