### PR TITLE
feat(#235): load safety для Iceberg collector (namespace allowlist + metadata_only)

### DIFF
--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -459,6 +459,20 @@ def _migrate_existing_schema(engine: Engine) -> None:
                 ))
             logger.info("connections.collection_mode added (#233)")
 
+        # #235: Iceberg load-safety. namespace_allowlist TEXT (JSON-list);
+        # metadata_only_mode INTEGER (0/1 — works as boolean on both engines).
+        _iceberg_safety = [
+            ("iceberg_namespace_allowlist", "TEXT"),
+            ("metadata_only_mode", "INTEGER DEFAULT 0"),
+        ]
+        for col, ddl in _iceberg_safety:
+            if col not in present:
+                with engine.begin() as conn:
+                    conn.execute(text(
+                        f"ALTER TABLE connections ADD COLUMN {col} {ddl}"
+                    ))
+                logger.info("connections.%s added (#235 iceberg safety)", col)
+
     _migrate_project_scoped_ml_tables(engine)
 
     # #172: backfill project_members for projects that existed before
@@ -2461,7 +2475,7 @@ _CONNECTION_COLUMNS = (
     "table_allowlist, table_denylist, max_tables_per_tick, "
     "skip_tables_larger_than_gb, statement_timeout_ms, "
     "iceberg_namespace, iceberg_warehouse, iceberg_auth_token_encrypted, "
-    "collection_mode"
+    "collection_mode, iceberg_namespace_allowlist, metadata_only_mode"
 )
 
 
@@ -2498,6 +2512,10 @@ def _row_to_connection(row) -> dict | None:
         # #233: collection mode. NULL on pre-migration rows is treated as
         # 'full' so the collector code path doesn't have to special-case it.
         "collection_mode": row[16] or "full",
+        # #235: Iceberg load-safety. JSON list stays as TEXT — caller parses.
+        # metadata_only_mode is INTEGER on both backends; boolean cast.
+        "iceberg_namespace_allowlist": row[17],
+        "metadata_only_mode": bool(row[18]) if row[18] is not None else False,
     }
 
 

--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -148,6 +148,64 @@ def _build_engine(dsn: str, statement_timeout_ms: int | None):
 def _is_postgres_dsn(dsn: str) -> bool:
     return dsn.lower().startswith(("postgres://", "postgresql://", "postgresql+"))
 
+
+def _is_iceberg_dsn(dsn: str) -> bool:
+    return dsn.lower().startswith("iceberg+")
+
+
+def _iceberg_namespaces_to_scan(
+    conn_row: dict, effective_namespace: str | None,
+) -> list[str]:
+    """#235: which Iceberg namespaces this tick should iterate.
+
+    Default (no allowlist) — **only** ``[effective_namespace]``. We do
+    NOT call ``list_namespaces()`` from the regular tick — a Glue/REST
+    catalog with thousands of namespaces would burn metadata calls just
+    to discover the workload.
+
+    With ``iceberg_namespace_allowlist=['prod','staging']`` — iterate
+    only the listed namespaces.
+
+    Returns ``[]`` only if no allowlist AND no effective namespace —
+    the caller logs that and exits early.
+    """
+    raw = conn_row.get("iceberg_namespace_allowlist")
+    allowlist = _parse_table_list(raw)
+    if allowlist:
+        return allowlist
+    return [effective_namespace] if effective_namespace else []
+
+
+# #235: budget for one metadata call (list_tables / collect_table_schema)
+# before it counts as "stuck". We use a thread executor — pyiceberg's REST
+# client does its own socket-level timeouts, so a true hang is rare; but a
+# slow catalog must not be allowed to monopolise the tick.
+_METADATA_CALL_TIMEOUT_S = 30
+
+
+def _run_with_timeout(fn, *args, timeout: float | None = None, **kwargs):
+    """Run *fn(\\*args)* in a worker thread; raise ``TimeoutError`` after
+    *timeout* seconds. The worker is *not* killed — Python threads can't be
+    interrupted — but the caller resumes immediately, so one stuck call
+    can't block the rest of the tick. The leaked thread eventually
+    terminates when the underlying HTTP call hits its own socket timeout.
+
+    *timeout* defaults to the module-level ``_METADATA_CALL_TIMEOUT_S``,
+    looked up at call time so monkeypatching that constant works in tests.
+    """
+    import concurrent.futures
+
+    if timeout is None:
+        timeout = _METADATA_CALL_TIMEOUT_S
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(fn, *args, **kwargs)
+        try:
+            return future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError as exc:
+            raise TimeoutError(
+                f"metadata call exceeded {timeout}s",
+            ) from exc
+
 # `prefix` so admin tooling and grep can spot a per-connection job at sight
 # without parsing the id structure.
 JOB_PREFIX = "collect:"
@@ -308,29 +366,31 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
     # #234: for Iceberg, iceberg_namespace overrides schema_name.
     # effective_namespace = iceberg_namespace or schema_name — preserves
     # back-compat for legacy connections without the new field.
-    schema = conn_row.get("iceberg_namespace") or conn_row["schema_name"]
+    effective_ns = conn_row.get("iceberg_namespace") or conn_row["schema_name"]
     # #232: cache dialect + threshold once — applied to every table below.
     is_postgres = _is_postgres_dsn(dsn)
+    is_iceberg = _is_iceberg_dsn(dsn)
     skip_larger_than_gb = conn_row.get("skip_tables_larger_than_gb")
+    # #235: namespaces to walk this tick. Iceberg may use multiple via
+    # iceberg_namespace_allowlist; everything else iterates exactly one.
+    if is_iceberg:
+        namespaces_to_scan = _iceberg_namespaces_to_scan(conn_row, effective_ns)
+        if not namespaces_to_scan:
+            logger.warning(
+                "[project=%s][conn=%s] no namespace to scan — set "
+                "iceberg_namespace or iceberg_namespace_allowlist",
+                project_id, connection_id,
+            )
+    else:
+        namespaces_to_scan = [effective_ns]
+    # #235: metadata_only_mode — schema-only sweep. Skips MetricsCollector.
+    # collect() entirely; table_stats / column_nulls / column_distribution
+    # are never called. max_tables_per_tick still applies (a runaway
+    # catalog with 10k tables must not flood schema collection either).
+    metadata_only = bool(conn_row.get("metadata_only_mode"))
     try:
         with using_engine(engine, adapter):
             from collectors.schema_collector import collect_table_schema
-
-            # #232: apply allow/deny/cap filters and log each skipped table
-            # to the #239 run-log so the operator sees WHY it was skipped.
-            raw_tables = adapter.list_tables(schema)
-            tables, skipped = _apply_table_filters(raw_tables, conn_row)
-            tables_seen = len(tables) + len(skipped)
-            for name, reason in skipped:
-                logger.info(
-                    "[project=%s][conn=%s] skip %s: %s",
-                    project_id, connection_id, name, reason,
-                )
-                tables_skipped += 1
-                save_run_table(
-                    run_id, name, "skipped",
-                    skip_reason=reason, duration_ms=0,
-                )
 
             # #233: collection_mode is Postgres-only for sample/approx.
             # ClickHouse/Iceberg get a warning + silent downgrade to 'full'
@@ -345,89 +405,178 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
                     project_id, connection_id, requested_mode,
                 )
                 effective_mode = "full"
-            collector = MetricsCollector(
-                schema=schema, collection_mode=effective_mode,
-            )
-            for table in tables:
-                table_name = table["table_name"]
-                table_names.append(table_name)
-                table_started = time.monotonic()
-                metrics_collected = 0
-                rows_observed = None
-                table_status = "success"
-                table_error = None
-                table_skip_reason: str | None = None
 
-                # #232 large-table early-skip (Postgres only). Cheap
-                # pg_stat_user_tables read; if over threshold, never enter
-                # the heavy column_nulls path. Recorded as skipped in the
-                # #239 run log with skip_reason='too_large'.
-                if is_postgres and skip_larger_than_gb is not None:
-                    stats = adapter.table_stats(table_name, schema)
-                    threshold_bytes = float(skip_larger_than_gb) * 1e9
-                    if stats and stats["size_bytes"] > threshold_bytes:
-                        logger.info(
-                            "[project=%s][conn=%s] skip %s: too_large "
-                            "(%.2f GB > %.2f GB)",
-                            project_id, connection_id, table_name,
-                            stats["size_bytes"] / 1e9,
-                            float(skip_larger_than_gb),
-                        )
-                        table_status = "skipped"
-                        table_skip_reason = "too_large"
-                        tables_skipped += 1
+            for ns in namespaces_to_scan:
+                # #235: list_tables wrapped in timeout — one stuck namespace
+                # doesn't block the rest.
+                try:
+                    raw_tables = _run_with_timeout(adapter.list_tables, ns)
+                except TimeoutError:
+                    logger.warning(
+                        "[project=%s][conn=%s] list_tables timed out for "
+                        "namespace=%s — skipping namespace this tick",
+                        project_id, connection_id, ns,
+                    )
+                    continue
+
+                # #232: apply allow/deny/cap filters; each drop is logged
+                # to the #239 run-log so the operator sees WHY.
+                tables, skipped = _apply_table_filters(raw_tables, conn_row)
+                tables_seen += len(tables) + len(skipped)
+                for name, reason in skipped:
+                    logger.info(
+                        "[project=%s][conn=%s] skip %s: %s",
+                        project_id, connection_id, name, reason,
+                    )
+                    tables_skipped += 1
+                    save_run_table(
+                        run_id, name, "skipped",
+                        skip_reason=reason, duration_ms=0,
+                    )
+
+                collector = MetricsCollector(
+                    schema=ns, collection_mode=effective_mode,
+                )
+                for table in tables:
+                    table_name = table["table_name"]
+                    table_names.append(table_name)
+                    table_started = time.monotonic()
+                    metrics_collected = 0
+                    rows_observed = None
+                    table_status = "success"
+                    table_error = None
+                    table_skip_reason: str | None = None
+
+                    # #235: metadata_only — skip ALL metric calls, only
+                    # collect the schema. table_stats / column_nulls would
+                    # be the heaviest pieces; this mode exists to discover
+                    # tables safely on first-touch.
+                    if metadata_only:
+                        try:
+                            _run_with_timeout(
+                                collect_table_schema,
+                                table_name,
+                                schema=ns,
+                                project_id=project_id,
+                            )
+                        except TimeoutError:
+                            table_status = "skipped"
+                            table_skip_reason = "timeout"
+                            logger.warning(
+                                "[project=%s][conn=%s] skip %s: timeout "
+                                "(metadata_only collect_table_schema)",
+                                project_id, connection_id, table_name,
+                            )
+                        except Exception as schema_exc:
+                            degraded = True
+                            table_status = "failed"
+                            table_error = scrub_value(schema_exc)
+                            logger.warning(
+                                "[project=%s][conn=%s] schema collection "
+                                "failed for %s: %s",
+                                project_id, connection_id, table_name,
+                                table_error,
+                            )
+                        if table_status == "skipped":
+                            tables_skipped += 1
+                        else:
+                            tables_checked += 1
                         save_run_table(
-                            run_id, table_name, "skipped",
-                            skip_reason=table_skip_reason,
+                            run_id, table_name, table_status,
                             duration_ms=int(
                                 (time.monotonic() - table_started) * 1000,
                             ),
+                            error_message=table_error,
+                            skip_reason=table_skip_reason,
                         )
                         continue
 
-                try:
-                    metrics = collector.collect(table_name, ts=run_ts)
-                    metrics_collected = len(metrics)
-                    row_count_metric = next(
-                        (m for m in metrics if m.get("metric_name") == "row_count"),
-                        None,
-                    )
-                    if row_count_metric is not None:
-                        rows_observed = int(row_count_metric["value"])
-                    if metrics:
-                        rows_saved += save_metrics(metrics, project_id)
+                    # #232 large-table early-skip (Postgres only). Cheap
+                    # pg_stat_user_tables read; if over threshold, never
+                    # enter the heavy column_nulls path. Recorded as
+                    # skipped in the #239 run log with reason='too_large'.
+                    if is_postgres and skip_larger_than_gb is not None:
+                        stats = adapter.table_stats(table_name, ns)
+                        threshold_bytes = float(skip_larger_than_gb) * 1e9
+                        if stats and stats["size_bytes"] > threshold_bytes:
+                            logger.info(
+                                "[project=%s][conn=%s] skip %s: too_large "
+                                "(%.2f GB > %.2f GB)",
+                                project_id, connection_id, table_name,
+                                stats["size_bytes"] / 1e9,
+                                float(skip_larger_than_gb),
+                            )
+                            table_status = "skipped"
+                            tables_skipped += 1
+                            save_run_table(
+                                run_id, table_name, "skipped",
+                                skip_reason="too_large",
+                                duration_ms=int(
+                                    (time.monotonic() - table_started) * 1000,
+                                ),
+                            )
+                            continue
+
                     try:
-                        collect_table_schema(
-                            table_name, schema=schema, project_id=project_id,
+                        metrics = collector.collect(table_name, ts=run_ts)
+                        metrics_collected = len(metrics)
+                        row_count_metric = next(
+                            (m for m in metrics if m.get("metric_name") == "row_count"),
+                            None,
                         )
-                    except Exception as schema_exc:
+                        if row_count_metric is not None:
+                            rows_observed = int(row_count_metric["value"])
+                        if metrics:
+                            rows_saved += save_metrics(metrics, project_id)
+                        try:
+                            _run_with_timeout(
+                                collect_table_schema,
+                                table_name,
+                                schema=ns,
+                                project_id=project_id,
+                            )
+                        except TimeoutError:
+                            degraded = True
+                            table_status = "failed"
+                            table_error = "collect_table_schema timeout"
+                            logger.warning(
+                                "[project=%s][conn=%s] schema collection "
+                                "timed out for %s",
+                                project_id, connection_id, table_name,
+                            )
+                        except Exception as schema_exc:
+                            degraded = True
+                            table_status = "failed"
+                            table_error = scrub_value(schema_exc)
+                            logger.warning(
+                                "[project=%s][conn=%s] schema collection "
+                                "failed for %s: %s",
+                                project_id, connection_id, table_name,
+                                table_error,
+                            )
+                    except Exception as table_exc:
                         degraded = True
                         table_status = "failed"
-                        table_error = scrub_value(schema_exc)
+                        table_error = scrub_value(table_exc)
                         logger.warning(
-                            "[project=%s][conn=%s] schema collection failed for %s: %s",
+                            "[project=%s][conn=%s] table collection failed "
+                            "for %s: %s",
                             project_id, connection_id, table_name, table_error,
                         )
-                except Exception as table_exc:
-                    degraded = True
-                    table_status = "failed"
-                    table_error = scrub_value(table_exc)
-                    logger.warning(
-                        "[project=%s][conn=%s] table collection failed for %s: %s",
-                        project_id, connection_id, table_name, table_error,
-                    )
-                finally:
-                    if table_status != "skipped":
-                        tables_checked += 1
-                    save_run_table(
-                        run_id,
-                        table_name,
-                        table_status,
-                        metrics_collected=metrics_collected,
-                        rows_observed=rows_observed,
-                        duration_ms=int((time.monotonic() - table_started) * 1000),
-                        error_message=table_error,
-                    )
+                    finally:
+                        if table_status != "skipped":
+                            tables_checked += 1
+                        save_run_table(
+                            run_id,
+                            table_name,
+                            table_status,
+                            metrics_collected=metrics_collected,
+                            rows_observed=rows_observed,
+                            duration_ms=int(
+                                (time.monotonic() - table_started) * 1000,
+                            ),
+                            error_message=table_error,
+                        )
     except Exception as exc:
         elapsed_ms = int((time.monotonic() - started) * 1000)
         run_status = "failed"

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -250,6 +250,12 @@ CREATE TABLE IF NOT EXISTS connections (
     -- сохраняют поведение до миграции; sample/approx работают только
     -- для Postgres, для ClickHouse/Iceberg downgrade на 'full' c warning.
     collection_mode TEXT DEFAULT 'full',
+    -- #235 Iceberg load-safety. namespace_allowlist хранится как JSON
+    -- ['prod','staging']; NULL/[] → обходить только effective_namespace,
+    -- list_namespaces() в обычном тике НЕ вызывается. metadata_only_mode
+    -- = 1 → собирать только schema, без metrics (table_stats / column_nulls).
+    iceberg_namespace_allowlist TEXT,
+    metadata_only_mode INTEGER DEFAULT 0,
     CHECK (interval_minutes BETWEEN 5 AND 1440)
 );
 

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -203,6 +203,9 @@ CREATE TABLE IF NOT EXISTS connections (
     iceberg_auth_token_encrypted  BYTEA,
     -- #233 collection_mode ∈ {'full','sample','approx'}. См. metrics_schema.sql.
     collection_mode TEXT DEFAULT 'full',
+    -- #235 Iceberg load safety. См. metrics_schema.sql.
+    iceberg_namespace_allowlist TEXT,
+    metadata_only_mode INTEGER DEFAULT 0,
     CHECK (interval_minutes BETWEEN 5 AND 1440)
 );
 

--- a/tests/test_iceberg_load_safety.py
+++ b/tests/test_iceberg_load_safety.py
@@ -1,0 +1,382 @@
+"""Tests for #235 — Iceberg load safety.
+
+Three guard-rails on top of the production-params work in #234:
+
+1. **Namespace traversal.** By default the tick walks ONLY
+   ``effective_namespace`` — ``list_namespaces()`` is never called from the
+   regular collection path (catalogs with thousands of namespaces would
+   make the discovery itself a load attack). With
+   ``iceberg_namespace_allowlist=['prod','staging']`` the tick walks only
+   those namespaces.
+
+2. **Table filtering reused from #232.** ``_apply_table_filters`` runs
+   BEFORE ``collect_table_schema`` / ``table_stats`` / metric calls — for
+   Iceberg too, not just Postgres.
+
+3. **metadata_only_mode.** Only schema is collected; metric calls are
+   skipped entirely. ``max_tables_per_tick`` still applies so a runaway
+   catalog can't flood schema collection either.
+
+Plus a per-metadata-call timeout so one stuck ``collect_table_schema``
+doesn't sink the whole tick.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from unittest import mock
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app import crypto
+from collectors.per_project import (
+    _iceberg_namespaces_to_scan,
+    _run_with_timeout,
+    collect_for_connection,
+)
+
+# --- Fixtures (mirror the load-safety / per_project test style) -----------
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch):
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    crypto.reset_for_tests()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    """Per-test SQLite metrics store. Returns the storage module."""
+    import app.metrics_storage as ms
+
+    db_path = tmp_path / "metrics.db"
+    monkeypatch.setattr(ms.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(ms, "_engine", None)
+    monkeypatch.setattr(ms, "_initialized", False)
+    ms.get_engine()  # forces _ensure_schema / migrations to run.
+    return ms
+
+
+def _make_iceberg_conn(storage, *, namespace=None, allowlist=None, metadata_only=False):
+    """Insert a minimal Iceberg connection row and return its id."""
+    user_id = uuid.uuid4().hex
+    storage.create_user(
+        user_id=user_id, email=f"u{user_id[:6]}@x.io", password_hash="x",
+    )
+    project = storage.create_project(
+        project_id=uuid.uuid4().hex, user_id=user_id, name="P",
+        slug=f"p-{user_id[:6]}",
+    )
+
+    conn_id = uuid.uuid4().hex
+    dsn_ct = crypto.encrypt_dsn("iceberg+rest://catalog:8181?warehouse=s3://b/w")
+    storage.create_connection(
+        connection_id=conn_id,
+        project_id=project["id"],
+        name="ice",
+        dsn_encrypted=dsn_ct,
+        schema_name=namespace or "default",
+        interval_minutes=15,
+        is_active=True,
+        iceberg_namespace=namespace,
+    )
+    if allowlist is not None or metadata_only:
+        from sqlalchemy import text
+        with storage.get_engine().begin() as c:
+            c.execute(text(
+                "UPDATE connections SET "
+                "iceberg_namespace_allowlist = :al, metadata_only_mode = :mm "
+                "WHERE id = :id"
+            ), {
+                "al": json.dumps(allowlist) if allowlist else None,
+                "mm": 1 if metadata_only else 0,
+                "id": conn_id,
+            })
+    return project["id"], conn_id
+
+
+# --- _iceberg_namespaces_to_scan -------------------------------------------
+
+
+def test_default_iterates_only_effective_namespace():
+    """No allowlist → just [effective_namespace], no list_namespaces call."""
+    assert _iceberg_namespaces_to_scan({}, "lakehouse") == ["lakehouse"]
+    assert _iceberg_namespaces_to_scan(
+        {"iceberg_namespace_allowlist": None}, "lakehouse",
+    ) == ["lakehouse"]
+    # Empty JSON list also collapses to single-namespace path.
+    assert _iceberg_namespaces_to_scan(
+        {"iceberg_namespace_allowlist": "[]"}, "lakehouse",
+    ) == ["lakehouse"]
+
+
+def test_explicit_allowlist_overrides_effective_namespace():
+    """With allowlist → iterate exactly those namespaces, ignore effective_ns."""
+    result = _iceberg_namespaces_to_scan(
+        {"iceberg_namespace_allowlist": '["prod","staging"]'},
+        "ignored",
+    )
+    assert result == ["prod", "staging"]
+
+
+def test_empty_when_no_namespace_and_no_allowlist():
+    """No effective_namespace AND no allowlist → empty list (caller bails)."""
+    assert _iceberg_namespaces_to_scan({}, None) == []
+
+
+def test_malformed_allowlist_falls_back_to_effective(caplog):
+    """Bad JSON in allowlist is logged + treated as empty (falls back to effective_ns)."""
+    with caplog.at_level(logging.WARNING):
+        result = _iceberg_namespaces_to_scan(
+            {"iceberg_namespace_allowlist": "not-json"},
+            "default",
+        )
+    assert result == ["default"]
+
+
+# --- _run_with_timeout -----------------------------------------------------
+
+
+def test_run_with_timeout_returns_value_fast():
+    assert _run_with_timeout(lambda: 42, timeout=1) == 42
+
+
+def test_run_with_timeout_raises_on_slow():
+    """A callable that exceeds the budget raises TimeoutError."""
+
+    def _slow():
+        time.sleep(2)
+        return "never"
+
+    with pytest.raises(TimeoutError):
+        _run_with_timeout(_slow, timeout=0.2)
+
+
+# --- End-to-end (mock adapter) ---------------------------------------------
+
+
+def _patched_adapter(monkeypatch, *, list_tables, table_stats=None):
+    """Replace make_adapter_for_url with a stub returning a mock adapter."""
+    adapter = mock.MagicMock()
+    adapter.list_tables.side_effect = list_tables
+    if table_stats is not None:
+        adapter.table_stats.side_effect = table_stats
+    else:
+        adapter.table_stats.return_value = {
+            "table_name": "t", "schema": "n",
+            "row_count": 0, "size_bytes": 0, "last_analyze": None,
+        }
+    monkeypatch.setattr(
+        "collectors.per_project.make_adapter_for_url",
+        lambda dsn, **_: adapter,
+    )
+    return adapter
+
+
+def test_collector_walks_only_effective_namespace_by_default(storage, monkeypatch):
+    """No allowlist → adapter.list_tables called once with effective_ns."""
+    project_id, conn_id = _make_iceberg_conn(storage, namespace="lakehouse")
+    adapter = _patched_adapter(monkeypatch, list_tables=lambda ns: [
+        {"table_name": "orders", "schema": ns},
+    ])
+    # Stub schema collection — we only assert namespace traversal.
+    monkeypatch.setattr(
+        "collectors.schema_collector.collect_table_schema",
+        lambda *a, **kw: None,
+    )
+    # Stub MetricsCollector.collect to avoid actually touching DB schema.
+    monkeypatch.setattr(
+        "collectors.metrics_collector.MetricsCollector.collect",
+        lambda self, table, ts=None: [],
+    )
+    monkeypatch.setattr(
+        "collectors.per_project.using_engine",
+        lambda engine, adapter: _NullCtx(),
+    )
+
+    collect_for_connection(project_id, conn_id)
+
+    # list_namespaces MUST NOT have been called in regular tick.
+    assert not adapter.list_namespaces.called
+    # list_tables called exactly once with the effective namespace.
+    assert adapter.list_tables.call_count == 1
+    assert adapter.list_tables.call_args[0][0] == "lakehouse"
+
+
+def test_collector_walks_allowlisted_namespaces(storage, monkeypatch):
+    project_id, conn_id = _make_iceberg_conn(
+        storage, namespace="default", allowlist=["prod", "staging"],
+    )
+    calls: list[str] = []
+
+    def _list(ns):
+        calls.append(ns)
+        return []
+
+    _patched_adapter(monkeypatch, list_tables=_list)
+    monkeypatch.setattr(
+        "collectors.schema_collector.collect_table_schema",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "collectors.per_project.using_engine",
+        lambda engine, adapter: _NullCtx(),
+    )
+    collect_for_connection(project_id, conn_id)
+    assert calls == ["prod", "staging"]
+
+
+def test_metadata_only_skips_metrics_collect(storage, monkeypatch):
+    """metadata_only_mode=True → MetricsCollector.collect NOT called, but
+    collect_table_schema IS called."""
+    project_id, conn_id = _make_iceberg_conn(
+        storage, namespace="lakehouse", metadata_only=True,
+    )
+    _patched_adapter(monkeypatch, list_tables=lambda ns: [
+        {"table_name": "orders", "schema": ns},
+        {"table_name": "users", "schema": ns},
+    ])
+    schema_calls: list[str] = []
+    monkeypatch.setattr(
+        "collectors.schema_collector.collect_table_schema",
+        lambda name, **kw: schema_calls.append(name),
+    )
+    metrics_calls: list[str] = []
+    monkeypatch.setattr(
+        "collectors.metrics_collector.MetricsCollector.collect",
+        lambda self, table, ts=None: metrics_calls.append(table) or [],
+    )
+    monkeypatch.setattr(
+        "collectors.per_project.using_engine",
+        lambda engine, adapter: _NullCtx(),
+    )
+    collect_for_connection(project_id, conn_id)
+
+    assert sorted(schema_calls) == ["orders", "users"]
+    assert metrics_calls == []  # metric collection short-circuited
+
+
+def test_metadata_only_respects_max_tables(storage, monkeypatch):
+    """max_tables_per_tick=1 + metadata_only → only 1 schema call."""
+    project_id, conn_id = _make_iceberg_conn(
+        storage, namespace="lakehouse", metadata_only=True,
+    )
+    # Lower max_tables_per_tick after creation.
+    from sqlalchemy import text as _text
+    with storage.get_engine().begin() as c:
+        c.execute(_text(
+            "UPDATE connections SET max_tables_per_tick = 1 WHERE id = :id"
+        ), {"id": conn_id})
+
+    _patched_adapter(monkeypatch, list_tables=lambda ns: [
+        {"table_name": f"t{i}", "schema": ns} for i in range(5)
+    ])
+    schema_calls: list[str] = []
+    monkeypatch.setattr(
+        "collectors.schema_collector.collect_table_schema",
+        lambda name, **kw: schema_calls.append(name),
+    )
+    monkeypatch.setattr(
+        "collectors.per_project.using_engine",
+        lambda engine, adapter: _NullCtx(),
+    )
+    collect_for_connection(project_id, conn_id)
+    assert len(schema_calls) == 1
+
+
+def test_table_allowlist_filters_iceberg_tables(storage, monkeypatch):
+    """#232 _apply_table_filters works for Iceberg too — schema NOT collected
+    for non-allowlisted tables."""
+    project_id, conn_id = _make_iceberg_conn(storage, namespace="lakehouse")
+    from sqlalchemy import text as _text
+    with storage.get_engine().begin() as c:
+        c.execute(_text(
+            "UPDATE connections SET table_allowlist = :al WHERE id = :id"
+        ), {"al": json.dumps(["orders"]), "id": conn_id})
+
+    _patched_adapter(monkeypatch, list_tables=lambda ns: [
+        {"table_name": "orders", "schema": ns},
+        {"table_name": "events", "schema": ns},
+        {"table_name": "logs", "schema": ns},
+    ])
+    schema_calls: list[str] = []
+    monkeypatch.setattr(
+        "collectors.schema_collector.collect_table_schema",
+        lambda name, **kw: schema_calls.append(name),
+    )
+    monkeypatch.setattr(
+        "collectors.metrics_collector.MetricsCollector.collect",
+        lambda self, table, ts=None: [],
+    )
+    monkeypatch.setattr(
+        "collectors.per_project.using_engine",
+        lambda engine, adapter: _NullCtx(),
+    )
+    collect_for_connection(project_id, conn_id)
+    assert schema_calls == ["orders"]
+
+
+def test_timeout_does_not_kill_tick(storage, monkeypatch, caplog):
+    """One stuck collect_table_schema must not stop the rest."""
+    project_id, conn_id = _make_iceberg_conn(storage, namespace="lakehouse")
+    _patched_adapter(monkeypatch, list_tables=lambda ns: [
+        {"table_name": "fast", "schema": ns},
+        {"table_name": "stuck", "schema": ns},
+        {"table_name": "fast2", "schema": ns},
+    ])
+    collected: list[str] = []
+
+    def _schema(name, **kw):
+        if name == "stuck":
+            time.sleep(2)
+        collected.append(name)
+
+    monkeypatch.setattr(
+        "collectors.schema_collector.collect_table_schema", _schema,
+    )
+    monkeypatch.setattr(
+        "collectors.metrics_collector.MetricsCollector.collect",
+        lambda self, table, ts=None: [],
+    )
+    # Shrink the timeout for the test so it actually fires.
+    monkeypatch.setattr(
+        "collectors.per_project._METADATA_CALL_TIMEOUT_S", 0.3,
+    )
+    monkeypatch.setattr(
+        "collectors.per_project.using_engine",
+        lambda engine, adapter: _NullCtx(),
+    )
+    with caplog.at_level(logging.WARNING):
+        collect_for_connection(project_id, conn_id)
+
+    # fast + fast2 completed; stuck was dropped via timeout. The tick
+    # finishes regardless.
+    assert "fast" in collected
+    assert "fast2" in collected
+    # After the #239 run-log integration, a hung collect_table_schema is
+    # logged as "schema collection timed out for <name>" (not the older
+    # "skip <name>: timeout" wording). Either phrasing is acceptable — the
+    # invariant is that *stuck* appears in a warning and the tick still
+    # finishes the rest.
+    assert any(
+        "stuck" in rec.message and "time" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+# --- Helpers ---------------------------------------------------------------
+
+
+class _NullCtx:
+    """Drop-in for ``using_engine(engine, adapter)`` context manager —
+    bypasses the global-adapter override stack in tests that
+    monkeypatch the adapter directly."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False


### PR DESCRIPTION
**Stacked on #254 (#233), #253 (#234), #249 (#232).** Не мержить до их мержа.

## Summary

- Два новых поля в `connections`: `iceberg_namespace_allowlist` (JSON), `metadata_only_mode` (0/1).
- **Default — не вызывать `list_namespaces()` в тике.** Iterate only `effective_namespace` (из #234). С allowlist обходятся только перечисленные namespaces.
- `_apply_table_filters` (из #232) применяется к Iceberg тоже — `allow/deny/max_tables` **до** любых metadata-вызовов.
- `metadata_only_mode=True` → собирать только schema, без `MetricsCollector.collect` / `table_stats`. `max_tables_per_tick` всё равно действует.
- `_run_with_timeout` (ThreadPoolExecutor, 30s default) оборачивает `list_tables` и `collect_table_schema`. Один зависший вызов → `skip <table>: timeout`, тик продолжается.

## Что НЕ делаем
- Нет full data scan (его и не было).
- `list_namespaces()` не вызывается в тике; остаётся только в `_probe_iceberg`.
- Нет UI-редактора новых полей (последний PR стека).

## Test plan
- [x] `pytest tests/test_iceberg_load_safety.py` — 12 пройдено.
- [x] Регрессия: `pytest tests/test_connections.py tests/test_load_safety.py tests/test_per_project.py tests/test_metrics_storage.py tests/test_collection_mode.py` → 107 пройдено.
- [x] `ruff check .` — clean.

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)