### PR TITLE
fix(#258): синкаем session.current_project_id + g.current_project с URL slug

### DIFF
--- a/app/projects.py
+++ b/app/projects.py
@@ -114,10 +114,25 @@ def _require_owned_project(slug: str) -> dict:
     membership row passes. Owner-only mutations (e.g. delete project) must
     additionally call ``metrics_storage.get_member_role`` and check for
     ``'owner'`` themselves.
+
+    Side effect (#258): syncs ``session["current_project_id"]`` AND
+    ``g.current_project`` to the slug-resolved project. Without this,
+    header switcher kept showing the previously-active project even after
+    navigating into a sibling project's pages — the URL is the
+    authoritative current-context signal, session only persists it across
+    visits to global pages (/dashboard etc).
+
+    ``g.current_project`` is rewritten here because ``before_request``
+    already ran with the *old* session value — the template renders from
+    ``g``, so without the in-request override the header would only
+    refresh on the next page load.
     """
     project = metrics_storage.get_project_by_slug(current_user.id, slug)
     if project is None:
         abort(404)
+    if session.get("current_project_id") != project["id"]:
+        session["current_project_id"] = project["id"]
+    g.current_project = project
     return project
 
 

--- a/templates/projects/list.html
+++ b/templates/projects/list.html
@@ -30,16 +30,11 @@
                class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
               Telegram
             </a>
+            {# #258: «Сделать текущим» больше не нужна — переход в проект
+               через slug-роут сам синкает session.current_project_id.
+               Бейдж остаётся как индикатор активного контекста. #}
             {% if g.current_project and g.current_project.id == project.id %}
               <span class="rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">текущий</span>
-            {% else %}
-              <form method="POST" action="{{ url_for('projects.switch', slug=project.slug) }}">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit"
-                        class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
-                  Сделать текущим
-                </button>
-              </form>
             {% endif %}
             <form method="POST" action="{{ url_for('projects.delete', slug=project.slug) }}"
                   onsubmit="return confirm('Удалить проект «{{ project.name }}»?');">

--- a/tests/e2e/test_project_switcher_sync.py
+++ b/tests/e2e/test_project_switcher_sync.py
@@ -1,0 +1,159 @@
+"""E2E: switcher в шапке следует за URL slug (#258).
+
+Симптом, обнаруженный QA: ходишь по `/projects/<slug>/*`, а top-right
+project switcher продолжает показывать предыдущий current project. Фикс:
+slug-роуты синкают `session.current_project_id` через
+`_require_owned_project`. Здесь — реальный браузер проверяет что после
+навигации по slug-роуту шапка показывает имя проекта из URL.
+
+Single-test структура: page-fixture у pytest-playwright function-scope,
+поэтому держать «логин один раз и потом 4 теста» нельзя без боли с
+shared-page. Делаем один последовательный сценарий — всё-равно вся
+проверка это «прошли N URL и в шапке правильный заголовок».
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from collections.abc import Iterator
+
+import pytest
+from cryptography.fernet import Fernet
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def switcher_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Real Flask с LOGIN_DISABLED=False — нужен реальный auth-flow."""
+    import os
+    os.environ["FERNET_KEY"] = Fernet.generate_key().decode()
+
+    from app import crypto
+    crypto.reset_for_tests()
+
+    metrics_db = tmp_path_factory.mktemp("e2e-switcher") / "metrics.db"
+
+    from app.config import settings
+    settings.MONITOR_DB_URL = f"sqlite:///{metrics_db}"
+
+    from app import metrics_storage
+    metrics_storage._engine = None
+    metrics_storage._initialized = False
+    metrics_storage.get_engine()
+
+    from app import db
+    originals = {
+        "list_tables": db.list_tables,
+        "table_schema": db.table_schema,
+        "table_stats": db.table_stats,
+        "column_nulls": db.column_nulls,
+        "column_distribution": db.column_distribution,
+    }
+    db.list_tables = lambda schema=None: []
+    db.table_schema = lambda t, schema=None: []
+    db.table_stats = lambda t, schema=None: None
+    db.column_nulls = lambda t, schema=None: []
+    db.column_distribution = lambda t, schema=None, top_n=20: []
+
+    from app.app import create_app
+
+    app = create_app({
+        "TESTING": True,
+        "LOGIN_DISABLED": False,
+        "WTF_CSRF_ENABLED": False,
+        "RATELIMIT_ENABLED": False,
+    })
+    port = _free_port()
+
+    from werkzeug.serving import make_server
+
+    server = make_server("127.0.0.1", port, app, threaded=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        for name, fn in originals.items():
+            setattr(db, name, fn)
+
+
+_EMAIL = "e2e-switcher@x.io"
+_PASSWORD = "supersecret1"
+
+
+def _switcher_text(page: Page) -> str:
+    return page.locator("header details summary").first.inner_text()
+
+
+def test_switcher_follows_url_slug_across_project_pages(
+    switcher_server: str, page: Page,
+):
+    """Один сквозной сценарий — register → создать 2-й проект → пройти
+    по slug-роутам и убедиться что шапка следует за URL."""
+    base = switcher_server
+
+    # 1. Register — auto-creates Default + auto-makes it current.
+    page.goto(f"{base}/auth/register")
+    page.fill("input[name='email']", _EMAIL)
+    page.fill("input[name='password']", _PASSWORD)
+    page.fill("input[name='confirm']", _PASSWORD)
+    page.click("input[type='submit'], button[type='submit']")
+    page.wait_for_url(lambda url: "/auth/register" not in url, timeout=5_000)
+
+    # 2. Create second project «Production» — projects.new_project
+    # auto-switches, current = Production after this.
+    page.goto(f"{base}/projects/new")
+    page.fill("input[name='name']", "Production")
+    page.fill("input[name='slug']", "prod")
+    page.click("main form button[type='submit'], main form input[type='submit']")
+    page.wait_for_url(lambda url: "/projects/new" not in url, timeout=5_000)
+    assert "Production" in _switcher_text(page)
+
+    # 3. Бага из QA: /projects/default — шапка должна стать Default,
+    # а не остаться на Production.
+    page.goto(f"{base}/projects/default")
+    expect(page.locator("header details summary")).to_contain_text("Default")
+    assert "Default" in _switcher_text(page)
+
+    # 4. То же для /projects/<slug>/connections — переключаемся обратно
+    # на Production через URL подключений.
+    page.goto(f"{base}/projects/prod/connections")
+    expect(page.locator("header details summary")).to_contain_text("Production")
+
+    # 5. То же для /projects/<slug>/settings/notifications.
+    page.goto(f"{base}/projects/default/settings/notifications")
+    expect(page.locator("header details summary")).to_contain_text("Default")
+
+    # 6. После всей пляски сессия зафиксирована на Default — открытие
+    # глобального /dashboard это подтверждает (он берёт current из session).
+    page.goto(f"{base}/dashboard/")
+    expect(page.locator("header details summary")).to_contain_text("Default")
+
+
+def test_projects_list_no_longer_renders_make_current_button(
+    switcher_server: str, page: Page,
+):
+    """`templates/projects/list.html`: «Сделать текущим» убрана,
+    бейдж «текущий» остаётся."""
+    base = switcher_server
+    # Юзер уже создан в предыдущем тесте (module-scope server). Логинимся.
+    page.goto(f"{base}/auth/login")
+    page.fill("input[name='email']", _EMAIL)
+    page.fill("input[name='password']", _PASSWORD)
+    page.click("input[type='submit'], button[type='submit']")
+    page.wait_for_url(lambda url: "/auth/login" not in url, timeout=5_000)
+
+    page.goto(f"{base}/projects")
+    expect(page.locator("text=Сделать текущим")).to_have_count(0)
+    expect(page.locator("text=текущий")).to_have_count(1)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -243,3 +243,82 @@ def test_new_project_requires_login(client):
     resp = client.get("/projects/new", follow_redirects=False)
     assert resp.status_code == 302
     assert "/auth/login" in resp.headers["Location"]
+
+
+# --- #258: slug routes sync session.current_project_id ---------------------
+
+
+def _current_project_id(client) -> str | None:
+    with client.session_transaction() as sess:
+        return sess.get("current_project_id")
+
+
+def test_detail_route_syncs_current_project_with_url_slug(client):
+    """Open /projects/default after switcher is on Production →
+    current_project_id flips back to Default."""
+    _register(client)
+    client.post("/projects/new", data={"name": "Production", "slug": "prod"})
+    # new_project auto-switched to "prod". Navigate to /projects/default
+    # without using the switch route.
+    resp = client.get("/projects/default")
+    assert resp.status_code == 200
+    # Body shows Default's switcher.
+    body = resp.get_data(as_text=True)
+    assert "Default" in body
+    # Session updated server-side.
+    with client.session_transaction() as sess:
+        assert sess.get("current_project_id") is not None
+    # The switcher (rendered from g.current_project) should now show
+    # Default, not Production.
+    assert ">Default<" in body
+
+
+def test_connections_list_route_syncs_current_project_with_url_slug(client):
+    _register(client)
+    client.post("/projects/new", data={"name": "Production", "slug": "prod"})
+    prod_pid = _current_project_id(client)
+    # Navigate to /projects/default/connections — should sync back.
+    client.get("/projects/default/connections")
+    default_pid = _current_project_id(client)
+    assert default_pid is not None
+    assert default_pid != prod_pid
+
+
+def test_notifications_route_syncs_current_project_with_url_slug(client):
+    _register(client)
+    client.post("/projects/new", data={"name": "Production", "slug": "prod"})
+    prod_pid = _current_project_id(client)
+    client.get("/projects/default/settings/notifications")
+    default_pid = _current_project_id(client)
+    assert default_pid is not None
+    assert default_pid != prod_pid
+
+
+def test_404_on_stranger_slug_does_not_change_current_project(client):
+    """abort(404) fires before the sync — stranger's slug must not leak
+    its ID into session.current_project_id."""
+    _register(client, "a@example.com")
+    client.post("/projects/new", data={"name": "Theirs", "slug": "theirs"})
+    _logout(client)
+
+    _register(client, "b@example.com")
+    # Normalize: hit /dashboard so load_current_project_into_g seeds b's
+    # Default into session (otherwise stale a's id may linger).
+    client.get("/dashboard/")
+    pid_before = _current_project_id(client)
+    assert pid_before is not None
+
+    resp = client.get("/projects/theirs")
+    assert resp.status_code == 404
+    # Session unchanged — the 404 short-circuited before the sync write.
+    assert _current_project_id(client) == pid_before
+
+
+def test_projects_list_no_longer_renders_make_current_button(client):
+    """#258 cleanup: 'Сделать текущим' кнопка убрана. Бейдж «текущий» остаётся."""
+    _register(client)
+    client.post("/projects/new", data={"name": "Production", "slug": "prod"})
+    resp = client.get("/projects")
+    body = resp.get_data(as_text=True)
+    assert "Сделать текущим" not in body
+    assert "текущий" in body  # badge


### PR DESCRIPTION
Closes #258. Part of UX audit #257.

## Симптом (с QA-скриншота)

Открываешь `/projects/retail-postgres`, в шапке top-right switcher продолжает показывать «Events ClickHouse!» — а на странице «Retail Postgres!». Аналогично для `/projects/<slug>/connections` и `/projects/<slug>/settings/notifications`.

## Корень

`load_current_project_into_g` (`app/projects.py:194-225`) — `before_request` хук — тянет current project **только** из `session["current_project_id"]`. Slug-роуты принимают slug, но в session ничего не пишут. Единственное место, которое явно меняло session — `projects.switch` POST. Поэтому переход по slug-URL не обновлял шапку.

## Фикс

В `_require_owned_project` (`app/projects.py`) — единая точка lookup-or-404 для всех slug-роутов — добавлен синк двух вещей:

1. `session["current_project_id"] = project["id"]` — чтобы дальнейшие GET-ы на глобальные страницы (`/dashboard`, `/dashboard/schema`, ...) оставались в нужном контексте.
2. `g.current_project = project` — `before_request` уже отработал на момент входа в route handler, без этого шапка обновилась бы только на следующем запросе.

Обе записи idempotent.

## Cleanup

Кнопка «Сделать текущим» в `templates/projects/list.html` была костылём вокруг той же проблемы. Убрана — клик по имени проекта (ведёт на `/projects/<slug>/connections`) теперь сам синкает. Бейдж `текущий` рядом с активным проектом оставлен.

## Тесты

**Unit (5 новых в `tests/test_projects.py`):**
- `test_detail_route_syncs_current_project_with_url_slug`
- `test_connections_list_route_syncs_current_project_with_url_slug`
- `test_notifications_route_syncs_current_project_with_url_slug`
- `test_404_on_stranger_slug_does_not_change_current_project` — `abort(404)` срабатывает до session-write
- `test_projects_list_no_longer_renders_make_current_button`

**E2E (`tests/e2e/test_project_switcher_sync.py`, новый файл):**
- `test_switcher_follows_url_slug_across_project_pages` — реальный Chromium: register → создать второй проект → пройти по `/projects/default` → `/projects/prod/connections` → `/projects/default/settings/notifications`, на каждом шаге шапка следует за URL.
- `test_projects_list_no_longer_renders_make_current_button` — кнопки нет, бейдж есть.

**Прогон:**
- `tests/` без e2e: 772 passed
- `tests/e2e/`: 17 passed (включая 2 новых)
- `ruff check`: clean

## Test plan

- [ ] Открыть `/projects/<other-slug>` пока в session current = X → шапка показывает other
- [ ] Открыть `/projects/<other-slug>/connections` → то же
- [ ] Открыть `/projects/<other-slug>/settings/notifications` → то же
- [ ] Открыть `/projects/non-existent-slug` → 404, session не изменилась
- [ ] Перезагрузить `/dashboard` после навигации — current зафиксирован

cc @ksdergach