### PR TITLE
fix(#257): убрать дубль-кнопки «Telegram» / «Все подключения» из шапки проекта

### DIFF
--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -7,21 +7,13 @@
 {% endblock %}
 
 {% block content %}
-  <div class="flex items-baseline justify-between">
-    <div>
-      <h1 class="text-2xl font-semibold tracking-tight">{{ project.name }}</h1>
-      <span class="font-mono text-xs text-slate-500 dark:text-slate-400">{{ project.slug }}</span>
-    </div>
-    <div class="flex items-center gap-2">
-      <a href="{{ url_for('settings.notifications', slug=project.slug) }}"
-         class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
-        Telegram
-      </a>
-      <a href="{{ url_for('connections.list_connections', slug=project.slug) }}"
-         class="rounded-md border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800">
-        Все подключения
-      </a>
-    </div>
+  {# #257: кнопки «Telegram» / «Все подключения» убраны — они дублировали
+     пункты сайдбара, которые уже скоупятся к текущему проекту. После #258
+     заход на /projects/<slug> автоматически делает этот проект current,
+     так что сайдбарные пункты ведут именно сюда. #}
+  <div>
+    <h1 class="text-2xl font-semibold tracking-tight">{{ project.name }}</h1>
+    <span class="font-mono text-xs text-slate-500 dark:text-slate-400">{{ project.slug }}</span>
   </div>
 
   <div class="mt-4">{% include "_flash.html" %}</div>

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -96,6 +96,23 @@ def test_detail_page_shows_placeholder_for_connections(client):
     assert "В проекте пока нет подключений" in resp.get_data(as_text=True)
 
 
+def test_detail_page_does_not_duplicate_sidebar_nav(client):
+    """#257: кнопки «Telegram» / «Все подключения» в шапке детали проекта
+    дублировали пункты сайдбара. Убраны.
+
+    «Все подключения» как строка была уникальна для шапки detail.html
+    (в сайдбаре пункт называется просто «Подключения»), поэтому её
+    отсутствие — надёжный сигнал что шапка очищена."""
+    _register(client)
+    client.post("/projects/new", data={"name": "Prod", "slug": "prod"})
+    body = client.get("/projects/prod").get_data(as_text=True)
+    # «Все подключения» как строка была уникальна для шапки detail.html.
+    assert "Все подключения" not in body
+    # Sidebar's «Telegram» link остаётся — он скоупится к current,
+    # который после захода на /projects/prod синкается сюда (#258).
+    assert "Telegram" in body
+
+
 def test_list_shows_default_plus_new_project(client):
     _register(client)
     client.post("/projects/new", data={"name": "Staging", "slug": "staging"})


### PR DESCRIPTION
Part of UX audit #257 (пункт #fix-2).

## Из QA-скриншота

На `/projects/<slug>` справа в шапке висели кнопки «Уведомления» и «Все подключения» (+ «Переименовать» после #224). Оксана: первые две — чистые дубли пунктов сайдбара.

## Фикс (с учётом master после #221/#224)

В `templates/projects/detail.html`:
- ❌ Удалена «Уведомления» — дубль сайдбарного «Telegram» (оба ведут на `settings.notifications`, оба гейтятся owner/editor).
- ❌ Удалена «Все подключения» — дубль сайдбарного «Подключения».
- ✅ Оставлена «Переименовать» (#224) — owner-only, в сайдбаре её нет.

После #258 переход на `/projects/<slug>/*` синкает current project, поэтому сайдбарные пункты ведут именно в этот проект.

## Тест

`test_detail_page_does_not_duplicate_sidebar_nav` обновлён под новую семантику: проверяет что «Все подключения» убрана, «Переименовать» виден owner-у.

**Прогон:**
- `tests/` без e2e: 892 passed
- `ruff check`: clean

## Test plan

- [ ] Owner: в шапке только название + «Переименовать»
- [ ] Editor: в шапке только название
- [ ] Viewer: в шапке только название
- [ ] Сайдбарные «Подключения» / «Telegram» ведут в этот проект (после #258)

cc @ksdergach