### PR TITLE
fix(#264): list_connections_with_dsn оставляет ряд с битым FERNET_KEY в списке

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -692,15 +692,24 @@ def list_connections_with_dsn(project_id: str) -> list[dict]:
     """Same as ``metrics_storage.list_connections_for_project`` but with
     decrypted DSN injected (key ``dsn``) and masked DSN (key ``dsn_masked``).
 
-    Use this from the per-project APScheduler (#54) when it lands. Caller
-    must still respect ownership — this helper assumes ``project_id`` was
-    validated against ``current_user`` upstream.
+    Connections whose ciphertext can't be decrypted (rotated/lost
+    ``FERNET_KEY``) are returned with ``dsn=None`` and
+    ``dsn_masked="<ошибка дешифровки>"`` — they MUST be visible in the UI
+    so the user can delete or re-create them. Silently dropping them
+    makes the project look empty while the row is still in the DB,
+    which produces confusing "В проекте пока нет подключений" states
+    next to a populated /connections list.
+
+    Caller must still respect ownership — this helper assumes
+    ``project_id`` was validated against ``current_user`` upstream.
+    DSN-consuming callers (collectors etc.) must filter ``dsn is not None``.
     """
     items: list[dict] = []
     for c in metrics_storage.list_connections_for_project(project_id):
         try:
             plain = crypto.decrypt_dsn(c["dsn_encrypted"])
         except crypto.InvalidToken:
+            items.append({**c, "dsn": None, "dsn_masked": "<ошибка дешифровки>"})
             continue
         items.append({**c, "dsn": plain, "dsn_masked": mask_dsn(plain)})
     return items

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -702,3 +702,53 @@ def test_interval_minutes_filter_formats_daily_interval():
     assert fmt(15) == "каждые 15 мин"
     assert fmt(60) == "каждый час"
     assert fmt(1440) == "раз в сутки"
+
+
+def test_list_connections_with_dsn_keeps_row_when_decrypt_fails(client):
+    """Бывшая бага: при ротации FERNET_KEY помеченные `<ошибка дешифровки>`
+    строки молча выкидывались из `/projects/<slug>` детальной страницы,
+    но оставались на `/connections`. UI разъезжался: «нет подключений» в
+    одном месте, реальный ряд с error-маской в другом. Теперь оставляем
+    в списке с dsn=None и маской."""
+    import uuid
+
+    from cryptography.fernet import Fernet
+
+    from app import connections, crypto, metrics_storage
+
+    _register(client)
+    project = metrics_storage.get_project_by_slug(
+        metrics_storage.get_user_by_email("u@example.com")["id"],
+        "default",
+    )
+
+    # Шифруем текущим ключом → ОК.
+    good = metrics_storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"],
+        name="good",
+        dsn_encrypted=crypto.encrypt_dsn("postgresql://u:p@h:5432/d"),
+        schema_name="public", interval_minutes=15, is_active=True,
+    )
+    # Шифруем «потерянным» ключом — для рантайм-сессии ciphertext
+    # станет битым (InvalidToken). Так воспроизводится ротация ключа.
+    other_fernet = Fernet(Fernet.generate_key())
+    rotated_ciphertext = other_fernet.encrypt(b"postgresql://u:p@h:5432/d")
+    bad = metrics_storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"],
+        name="rotated-key",
+        dsn_encrypted=rotated_ciphertext,
+        schema_name="public", interval_minutes=15, is_active=True,
+    )
+
+    items = connections.list_connections_with_dsn(project["id"])
+    names = {i["name"]: i for i in items}
+    assert set(names) == {"good", "rotated-key"}, (
+        "битый ряд должен остаться в списке, иначе UI разъезжается"
+    )
+    assert names["good"]["dsn"] == "postgresql://u:p@h:5432/d"
+    assert names["rotated-key"]["dsn"] is None
+    assert names["rotated-key"]["dsn_masked"] == "<ошибка дешифровки>"
+    assert names["good"]["id"] == good["id"]
+    assert names["rotated-key"]["id"] == bad["id"]


### PR DESCRIPTION
Closes #264.

## Симптом

QA-walk: на `/projects/retail-postgres` секция «Подключения к БД» показывала «В проекте пока нет подключений», хотя `/projects/retail-postgres/connections` нормально рендерил тот же ряд с маской `<ошибка дешифровки>`. Воспроизводится когда `FERNET_KEY` сменён/потерян относительно момента шифрования.

## Корень

`app/connections.py:691-706` молча делал `continue` на `InvalidToken`. `app/connections.py:117-122` (роут списка подключений) на ту же ошибку отдавал маску `<ошибка дешифровки>` и оставлял ряд. Два разных поведения на одних данных.

## Фикс

Оставляем ряд с `dsn=None` + `dsn_masked="<ошибка дешифровки>"`. DSN-консумеры (collector, когда подключится) фильтруют `dsn is not None`. Docstring обновлён.

## Тест

`test_list_connections_with_dsn_keeps_row_when_decrypt_fails` — создаёт 2 connection-а (один зашифрован текущим ключом, второй — другим Fernet-ключом), вызывает функцию, проверяет:
- оба ряда в списке
- хороший имеет реальный DSN
- битый имеет `dsn=None` + маску ошибки

**Прогон:** 904 unit passed, ruff clean.