### PR TITLE
fix(#267): ML retrain итерирует tenant-проекты, не только legacy

### DIFF
--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -1532,6 +1532,19 @@ def list_project_ids_with_telegram() -> list[str]:
     return [r[0] for r in rows]
 
 
+def list_project_ids_with_metrics() -> list[str]:
+    """Return distinct project_ids that have at least one metrics row.
+
+    Used by the scheduler to iterate over tenants for ML retrains —
+    notifications-scoped ``list_project_ids_with_telegram`` was too
+    narrow (a project without Telegram still needs its forecast and
+    anomaly models trained, the dashboard reads them).
+    """
+    stmt = text("SELECT DISTINCT project_id FROM metrics")
+    with get_engine().connect() as conn:
+        return [r[0] for r in conn.execute(stmt).fetchall() if r[0]]
+
+
 def list_metric_tables(project_id: str) -> list[str]:
     """Return distinct table names that have metrics for a given project.
 

--- a/collectors/scheduler.py
+++ b/collectors/scheduler.py
@@ -247,12 +247,35 @@ def _score_recent_anomalies() -> None:
             logger.warning("Anomaly scoring skipped for %s: %s", name, exc)
 
 
+def _iter_retrain_projects() -> list[str]:
+    """Project ids that need ML retraining: any project with metric rows
+    plus ``'legacy'`` for back-compat with single-tenant setups."""
+    from app.metrics_storage import list_project_ids_with_metrics
+    ids = list_project_ids_with_metrics()
+    if "legacy" not in ids:
+        ids = ["legacy", *ids]
+    return ids
+
+
 def retrain_forecasts() -> None:
+    from app.metrics_storage import list_metric_tables
     from ml.forecast import retrain_all
 
     logger.info("Job %s started", FORECAST_JOB_ID)
-    counts = retrain_all(project_id="legacy")
-    logger.info("Job %s finished: %s", FORECAST_JOB_ID, counts)
+    total: dict[str, int] = {"trained": 0, "skipped": 0, "errors": 0}
+    for project_id in _iter_retrain_projects():
+        # list_metric_tables=[] when a tenant has no metrics yet → skip
+        # entirely (no global-DB fallback for tenants; only legacy may
+        # introspect ``app.db.list_tables``, which retrain_all does
+        # internally when tables=None).
+        tables = list_metric_tables(project_id)
+        if not tables and project_id != "legacy":
+            continue
+        counts = retrain_all(project_id=project_id, tables=tables or None)
+        for k, v in counts.items():
+            total[k] = total.get(k, 0) + v
+        logger.debug("[project=%s] forecast retrain: %s", project_id, counts)
+    logger.info("Job %s finished: %s", FORECAST_JOB_ID, total)
 
 
 def detect_changepoints() -> None:
@@ -299,28 +322,54 @@ def detect_changepoints() -> None:
 
 
 def retrain_anomaly_detectors() -> None:
-    from app.db import list_tables
-    from app.metrics_storage import save_anomaly_scores
+    from app.metrics_storage import list_metric_tables, save_anomaly_scores
     from ml.anomaly_detector import InsufficientDataError, retrain_all, score_table
 
     logger.info("Job %s started", ANOMALY_JOB_ID)
-    counts = retrain_all()
-    logger.info("Anomaly models retrained: %s", counts)
-
-    # After retraining, score the full 14-day history for every table so the
-    # dashboard has up-to-date annotations without waiting for collect ticks.
+    total_counts: dict[str, int] = {"trained": 0, "skipped": 0, "errors": 0}
     scored = 0
-    for t in list_tables():
-        name = t["table_name"]
-        try:
-            scores = score_table(name, window_days=14)
-            if scores:
-                save_anomaly_scores([{**s, "table_name": name} for s in scores])
-                scored += len(scores)
-        except InsufficientDataError:
-            pass
-        except Exception as exc:
-            logger.warning("Post-retrain scoring failed for %s: %s", name, exc)
+    for project_id in _iter_retrain_projects():
+        tables = list_metric_tables(project_id)
+        if not tables and project_id != "legacy":
+            continue
+        counts = retrain_all(project_id=project_id, tables=tables or None)
+        for k, v in counts.items():
+            total_counts[k] = total_counts.get(k, 0) + v
+        logger.debug("[project=%s] anomaly retrain: %s", project_id, counts)
+
+        # Post-retrain scoring lives in the same per-project loop so the
+        # dashboard annotations align with the freshly-trained model.
+        # Legacy may have a single-tenant ``DATABASE_URL`` to live-list
+        # tables from when no metric rows are stored yet (fresh install
+        # before the first tick). Tenants always use stored metric tables.
+        if project_id == "legacy" and not tables:
+            try:
+                from app.db import list_tables as _legacy_list_tables
+                score_targets = [t["table_name"] for t in _legacy_list_tables()]
+            except Exception as exc:
+                # Multi-tenant deploys often have no global DATABASE_URL —
+                # don't crash the whole retrain job because of it.
+                logger.debug("legacy live list_tables() unavailable: %s", exc)
+                score_targets = []
+        else:
+            score_targets = tables
+        for name in score_targets:
+            try:
+                scores = score_table(name, window_days=14, project_id=project_id)
+                if scores:
+                    save_anomaly_scores(
+                        [{**s, "table_name": name} for s in scores],
+                        project_id=project_id,
+                    )
+                    scored += len(scores)
+            except InsufficientDataError:
+                pass
+            except Exception as exc:
+                logger.warning(
+                    "[project=%s] post-retrain scoring failed for %s: %s",
+                    project_id, name, exc,
+                )
+    logger.info("Anomaly models retrained: %s", total_counts)
     logger.info("Job %s finished: %d scores saved", ANOMALY_JOB_ID, scored)
 
 

--- a/tests/test_scheduler_ml_retrain.py
+++ b/tests/test_scheduler_ml_retrain.py
@@ -1,0 +1,179 @@
+"""Multi-tenant ML retrain in scheduler (#fix-list_connections_with_dsn followup).
+
+Before: `retrain_forecasts` hardcoded `project_id="legacy"` and
+`retrain_anomaly_detectors` used no-arg (defaults to "legacy") AND
+queried tables via `app.db.list_tables()` (global DATABASE_URL). Result:
+nightly ML retrain never touched tenant projects; their forecast charts
+forced sync retrain on every user request.
+
+Now: scheduler iterates over `_iter_retrain_projects()` (legacy + every
+project with metric rows) and uses `list_metric_tables(project_id)` to
+scope tables per-tenant.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    db_path = tmp_path / "sched_ml.db"
+    import app.metrics_storage as storage_mod
+
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+    storage_mod.get_engine()
+    return storage_mod
+
+
+def _seed_metrics_for_project(storage, project_id: str, table: str = "users"):
+    from datetime import UTC, datetime, timedelta
+
+    rows = []
+    now = datetime.now(UTC)
+    # Just enough rows so the project appears in list_project_ids_with_metrics.
+    for h in range(4):
+        rows.append({
+            "ts": now - timedelta(hours=h),
+            "table_name": table,
+            "metric_name": "row_count",
+            "value": 100 + h,
+        })
+    storage.save_metrics(rows, project_id)
+
+
+# --- list_project_ids_with_metrics -----------------------------------------
+
+
+def test_list_project_ids_with_metrics_returns_distinct_tenants(storage):
+    """Helper that the scheduler uses to enumerate projects for retrain."""
+    p1 = uuid.uuid4().hex
+    p2 = uuid.uuid4().hex
+    _seed_metrics_for_project(storage, p1)
+    _seed_metrics_for_project(storage, p2)
+    _seed_metrics_for_project(storage, p1, "orders")  # дубль не плодит p1
+
+    ids = storage.list_project_ids_with_metrics()
+    assert set(ids) == {p1, p2}
+
+
+def test_list_project_ids_with_metrics_empty_when_no_metrics(storage):
+    assert storage.list_project_ids_with_metrics() == []
+
+
+# --- _iter_retrain_projects -----------------------------------------------
+
+
+def test_iter_retrain_projects_always_includes_legacy(storage):
+    """Even на пустой БД scheduler должен прокрутить legacy — иначе
+    одно-тенантные деплои перестанут переобучать модели."""
+    from collectors.scheduler import _iter_retrain_projects
+
+    ids = _iter_retrain_projects()
+    assert "legacy" in ids
+    assert len(ids) == 1
+
+
+def test_iter_retrain_projects_includes_tenants_plus_legacy(storage):
+    from collectors.scheduler import _iter_retrain_projects
+
+    p1 = uuid.uuid4().hex
+    p2 = uuid.uuid4().hex
+    _seed_metrics_for_project(storage, p1)
+    _seed_metrics_for_project(storage, p2)
+
+    ids = _iter_retrain_projects()
+    assert set(ids) >= {"legacy", p1, p2}
+
+
+# --- retrain_forecasts -----------------------------------------------------
+
+
+def test_retrain_forecasts_iterates_per_project(storage):
+    """Регрессионный: жёсткий project_id="legacy" в scheduler был багом —
+    tenant projects не переобучались, ON-demand retrain бил по UX."""
+    from collectors import scheduler
+
+    p1 = uuid.uuid4().hex
+    p2 = uuid.uuid4().hex
+    _seed_metrics_for_project(storage, p1, "users")
+    _seed_metrics_for_project(storage, p2, "orders")
+
+    captured: list[dict] = []
+
+    def _fake_retrain_all(*, project_id, tables=None, **_kw):
+        captured.append({"project_id": project_id, "tables": tables})
+        return {"trained": 1, "skipped": 0, "errors": 0}
+
+    with patch("ml.forecast.retrain_all", side_effect=_fake_retrain_all):
+        scheduler.retrain_forecasts()
+
+    by_pid = {c["project_id"]: c for c in captured}
+    # Tenant projects вызывались.
+    assert p1 in by_pid
+    assert p2 in by_pid
+    assert by_pid[p1]["tables"] == ["users"]
+    assert by_pid[p2]["tables"] == ["orders"]
+
+
+def test_retrain_forecasts_skips_empty_tenant_but_keeps_legacy(storage):
+    """Tenant без метрик → не вызываем retrain_all с пустым списком таблиц
+    (no-op + дорогой коннект). Legacy всегда вызывается — `retrain_all`
+    внутри может фоллбэкнуться на app.db.list_tables()."""
+    from collectors import scheduler
+
+    captured: list[dict] = []
+
+    def _fake_retrain_all(*, project_id, tables=None, **_kw):
+        captured.append({"project_id": project_id, "tables": tables})
+        return {"trained": 0, "skipped": 0, "errors": 0}
+
+    with patch("ml.forecast.retrain_all", side_effect=_fake_retrain_all):
+        scheduler.retrain_forecasts()
+
+    pids = [c["project_id"] for c in captured]
+    assert pids == ["legacy"]
+
+
+# --- retrain_anomaly_detectors --------------------------------------------
+
+
+def test_retrain_anomaly_detectors_iterates_per_project_and_scopes_scoring(
+    storage,
+):
+    """Anomaly retrain страдал той же болезнью: дефолтный
+    project_id="legacy" + app.db.list_tables() для post-retrain scoring.
+    Теперь — per-project."""
+    from collectors import scheduler
+
+    p1 = uuid.uuid4().hex
+    _seed_metrics_for_project(storage, p1, "users")
+
+    retrain_calls: list[dict] = []
+    score_calls: list[dict] = []
+
+    def _fake_retrain(*, project_id, tables=None, **_kw):
+        retrain_calls.append({"project_id": project_id, "tables": tables})
+        return {"trained": 1, "skipped": 0, "errors": 0}
+
+    def _fake_score(name, window_days=14, project_id="legacy"):
+        score_calls.append({"name": name, "project_id": project_id})
+        return []  # пустой результат — save_anomaly_scores не вызовется
+
+    with patch("ml.anomaly_detector.retrain_all", side_effect=_fake_retrain), \
+         patch("ml.anomaly_detector.score_table", side_effect=_fake_score):
+        scheduler.retrain_anomaly_detectors()
+
+    retrain_pids = {c["project_id"] for c in retrain_calls}
+    assert p1 in retrain_pids
+    # Scoring тоже scoped к проекту.
+    score_pids = {c["project_id"] for c in score_calls}
+    assert p1 in score_pids
+    # На tenant project_id используются именно его таблицы.
+    p1_score_targets = {c["name"] for c in score_calls if c["project_id"] == p1}
+    assert p1_score_targets == {"users"}


### PR DESCRIPTION
Closes #267.

## Симптом

`/api/forecast/<table>` для тенант-проекта зависает на 100-500мс при первом запросе — потому что persisted-модель для этого `project_id` никогда не строилась scheduled-джобой, и `forecast()` фоллбэкает в синхронный on-demand `train()`. Аналогично anomaly.

## Корень

В `collectors/scheduler.py`:
- `retrain_forecasts` хардкодил `project_id=\"legacy\"`
- `retrain_anomaly_detectors` использовал дефолтный `legacy` + `app.db.list_tables()` (глобальный `DATABASE_URL`)

Тенант-проекты никогда не получали nightly ретрейн. Параллельно `detect_changepoints()` уже был мультитенантным (#197) — недоведённая до конца миграция.

## Фикс

- `list_project_ids_with_metrics()` — новый helper в `metrics_storage`, distinct `project_id` из `metrics`.
- `_iter_retrain_projects()` — `tenants ∪ {legacy}`.
- Оба retrain-джоба итерируют per-project, передают `project_id` и `tables=list_metric_tables(pid)`. Legacy без stored-метрик пытается через `app.db.list_tables()`, gracefully скипает если глобальный DSN не настроен.
- Post-retrain anomaly scoring тоже scoped к project_id.

## Тесты (7 новых)

- `list_project_ids_with_metrics` — distinct
- `_iter_retrain_projects` — legacy всегда + tenants
- `retrain_forecasts` — пер-проектный вызов
- `retrain_forecasts` — пустой tenant скипается, legacy сохраняется
- `retrain_anomaly_detectors` — пер-проектный retrain + scoped scoring

**Прогон:** 936 unit passed, ruff clean.

## Test plan

- [ ] Завести retail-postgres проект с метриками → запустить retrain_forecasts через scheduler → models/<pid>__*.joblib обновлены свежим timestamp.
- [ ] /api/forecast/<table> для tenant-а на второй заход — без on-demand retrain (модель уже свежая).