### PR TITLE
fix(#256): flash вместо тихо-сломанной формы при битом DSN ciphertext

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -382,13 +382,21 @@ def edit_safety(slug: str, conn_id: str):
     if role not in ("owner", "editor"):
         abort(403)
 
-    # Decode DSN once to know the dialect. Failure to decrypt doesn't kill
-    # the edit form — operator may need to clear the bad ciphertext via the
-    # CLI; pre-fill is best-effort.
+    # Decode DSN once to know the dialect. If the ciphertext is unreadable
+    # (Fernet key rotated, file copied across envs) silently rendering the
+    # form with all dialect-gated fields disabled was confusing — the
+    # operator sees "только Postgres" hints and can't tell whether the
+    # connection broke or the UI is buggy. Surface it as a flash and send
+    # them back to the list to delete + re-create.
     try:
         plain_dsn = crypto.decrypt_dsn(conn["dsn_encrypted"])
     except crypto.InvalidToken:
-        plain_dsn = ""
+        flash(
+            "DSN подключения не расшифровывается (Fernet-ключ ротировался?). "
+            "Удалите подключение и создайте заново.",
+            "error",
+        )
+        return redirect(url_for("connections.list_connections", slug=slug))
     is_iceberg = plain_dsn.lower().startswith("iceberg+")
     is_postgres = plain_dsn.lower().startswith(
         ("postgres://", "postgresql://", "postgresql+"),

--- a/tests/test_safety_editor.py
+++ b/tests/test_safety_editor.py
@@ -108,6 +108,42 @@ def test_edit_get_renders_form_with_db_values(client):
     assert "sample" in body
 
 
+def test_edit_redirects_with_flash_when_dsn_ciphertext_unreadable(client):
+    """If the stored DSN ciphertext can't be decrypted (Fernet key rotated
+    between envs), the edit page used to render with every dialect-gated
+    field silently disabled — operator saw "только Postgres" hints and
+    had no idea the connection itself was the problem. Now we redirect to
+    the list with a clear flash so they know to delete + re-create."""
+    _register(client)
+    _add_pg(client)
+    pid, cid = _conn_id(client)
+
+    # Corrupt the ciphertext directly — simulates Fernet-key rotation:
+    # what's on disk doesn't decrypt under the current key.
+    from sqlalchemy import text
+
+    from app.metrics_storage import get_engine
+    with get_engine().begin() as c:
+        c.execute(
+            text("UPDATE connections SET dsn_encrypted = :bad WHERE id = :id"),
+            {"bad": b"not-a-valid-fernet-token", "id": cid},
+        )
+
+    resp = client.get(
+        f"/projects/default/connections/{cid}/edit", follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"].rstrip("/").endswith(
+        "/projects/default/connections",
+    )
+    # Follow the redirect and assert the flash actually rendered.
+    body = client.get(
+        f"/projects/default/connections/{cid}/edit",
+        follow_redirects=True,
+    ).get_data(as_text=True)
+    assert "не расшифровывается" in body
+
+
 def test_edit_iceberg_block_only_for_iceberg_dsn(client):
     _register(client)
     _add_pg(client)


### PR DESCRIPTION
## Зачем

Edit-form для safety-настроек подключения (#256) проглатывал \`crypto.InvalidToken\`, рендерил пустой DSN — все dialect-gated поля автоматически дисейблились с пометкой «только Postgres», и оператор не мог понять, что само подключение мёртвое после ротации Fernet-ключа.

## Что делаем

При InvalidToken на GET \`/projects/<slug>/connections/<conn_id>/edit\`:
- redirect на список подключений
- flash error: «DSN не расшифровывается (Fernet-ключ ротировался?). Удалите подключение и создайте заново.»

## Test plan
- [x] \`pytest tests/test_safety_editor.py\` — 14 пройдено, включая новый \`test_edit_redirects_with_flash_when_dsn_ciphertext_unreadable\`.
- [x] \`ruff check .\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)