### PR TITLE
fix(#269): tenant per-project тик пересчитывает drift cache

### DIFF
--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -630,6 +630,33 @@ def collect_for_connection(project_id: str, connection_id: str) -> None:
     # silence is the default.
     if rows_saved > 0:
         _maybe_notify_anomalies(project_id, table_names)
+        _refresh_drift_cache(project_id, table_names)
+
+
+def _refresh_drift_cache(project_id: str, table_names: list[str]) -> None:
+    """Recompute and persist the drift report for the tables this tick
+    just touched.
+
+    Was a process-wide job riding on the legacy ``collect_all_tables``
+    tick — tenants never saw their drift cache refreshed, so /api/drift
+    returned stale rows even hours after the underlying distribution
+    snapshots had updated. Per-tick scoping is cheap because the math
+    runs entirely off ``monitor.db`` (no live target-DB introspection).
+    """
+    if not table_names:
+        return
+    try:
+        from ml.drift import compute_and_store_drift_all
+        counts = compute_and_store_drift_all(
+            project_id=project_id, tables=table_names,
+        )
+        logger.debug(
+            "[project=%s] drift cache refreshed: %s", project_id, counts,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "[project=%s] drift refresh failed: %s", project_id, exc,
+        )
 
 
 def _load_telegram_config(project_id: str) -> tuple[str, str, int] | None:

--- a/tests/test_per_project.py
+++ b/tests/test_per_project.py
@@ -247,6 +247,48 @@ def test_collect_for_connection_writes_metrics_with_project_id(storage, tmp_path
     assert other_rows == []
 
 
+def test_collect_for_connection_refreshes_drift_cache_per_project(
+    storage, monkeypatch,
+):
+    """Регрессионный (#fix-per-project-drift): tenant per-project тик
+    раньше пропускал drift refresh — он жил в legacy collect_all_tables.
+    Эффект: /api/drift/<table> тенантов отдавал stale данные. Теперь
+    тик пересчитывает drift с tables=table_names этого подключения."""
+    _user_id, project, conn = _seed_user_with_active_connection(
+        storage, dsn="postgresql://u:p@unreachable:5432/d",
+    )
+    from collectors import metrics_collector
+
+    fake_rows = [{
+        "ts": datetime.now(UTC), "table_name": "users",
+        "metric_name": "row_count", "value": 42.0,
+    }]
+    import app.db as db_mod
+
+    def fake_list_tables(self, schema):
+        return [{"table_name": "users", "schema": schema}]
+
+    captured: list[dict] = []
+    import ml.drift as drift_mod
+
+    def fake_compute(*, project_id, tables=None):
+        captured.append({"project_id": project_id, "tables": list(tables or [])})
+        return {"tables": len(tables or []), "rows": 0}
+
+    import unittest.mock as mock
+    with mock.patch.object(metrics_collector.MetricsCollector, "collect",
+                           return_value=fake_rows), \
+         mock.patch.object(db_mod.PostgresAdapter, "list_tables",
+                           autospec=True, side_effect=fake_list_tables), \
+         mock.patch.object(drift_mod, "compute_and_store_drift_all",
+                           side_effect=fake_compute):
+        collect_for_connection(project["id"], conn["id"])
+
+    assert len(captured) == 1
+    assert captured[0]["project_id"] == project["id"]
+    assert captured[0]["tables"] == ["users"]
+
+
 def test_collect_for_connection_skips_inactive(storage):
     """Job re-checks is_active on each tick — covers the race where a
     connection is deactivated between job-fire scheduling and the actual


### PR DESCRIPTION
Closes #269. Follow-up на #267 (та же multi-tenant дыра, другой угол).

## Симптом

`/api/drift/<table>` для тенант-проекта возвращает stale данные часами, хотя per-project collector регулярно пишет свежие `column_distribution` снапшоты.

## Корень

`compute_and_store_drift_all()` вызывалось ТОЛЬКО из legacy `collect_all_tables` тика (scheduler.py:128). Per-project тик в `collectors/per_project.py::collect_for_connection` не дёргал. В multi-tenant deploy-ях legacy тик вообще может не запускаться.

## Фикс

Добавлен `_refresh_drift_cache(project_id, table_names)` в per-project тике после `_maybe_notify_anomalies`. Вся работа на `monitor.db`, без live introspection — дёшево. Срабатывает только если `rows_saved > 0`.

## Тест

`test_collect_for_connection_refreshes_drift_cache_per_project` — мок `compute_and_store_drift_all`, проверка что вызывается ровно один раз с `project_id` тенанта и `tables=["users"]`.

**Прогон:** 937 unit, ruff clean.