### PR TITLE
feat(#240): статус подключения на странице проекта

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from datetime import UTC, datetime
 
 from flask import Flask, jsonify, redirect, render_template
 from flask_wtf.csrf import CSRFProtect
@@ -48,6 +49,24 @@ def _fmt_interval_minutes(minutes: int | str | None) -> str:
         hours = value // 60
         return f"каждые {hours} ч"
     return f"каждые {value} мин"
+
+
+def _format_datetime(value) -> str:
+    """Format stored UTC timestamps for compact dashboard display."""
+    if value is None or value == "":
+        return "—"
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+    else:
+        return str(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).strftime("%d.%m %H:%M UTC")
 
 
 _logging_filter_installed = False
@@ -204,6 +223,7 @@ def create_app(config: dict | None = None):
     app.jinja_env.filters["status_class"] = status_class
     app.jinja_env.filters["fmt_iso_in_text"] = _fmt_iso_in_text
     app.jinja_env.filters["fmt_interval_minutes"] = _fmt_interval_minutes
+    app.jinja_env.filters["format_datetime"] = _format_datetime
 
     if config:
         app.config.update(config)

--- a/app/connections.py
+++ b/app/connections.py
@@ -258,6 +258,21 @@ def _require_owned_connection(slug: str, conn_id: str) -> tuple[dict, dict]:
     return project, conn
 
 
+def _persist_probe_result(project_id: str, connection_id: str, result: dict) -> None:
+    """Store the latest probe outcome for an already saved connection."""
+    status = "ok" if result.get("status") == "ok" else "error"
+    error = None
+    if status == "error":
+        error = result.get("message") or result.get("code") or "probe failed"
+    metrics_storage.update_connection_probe(
+        project_id,
+        connection_id,
+        status=status,
+        tables_found=result.get("tables_found"),
+        error=error,
+    )
+
+
 @bp.route("")
 @bp.route("/")
 @login_required
@@ -341,6 +356,7 @@ def new_connection(slug: str):
                 iceberg_warehouse=iceberg_wh if is_iceberg else None,
                 iceberg_auth_token=iceberg_token if is_iceberg else None,
             )
+            _persist_probe_result(project["id"], conn_row["id"], result)
             if result["status"] == "ok":
                 flash(
                     "Подключение проверено. Сбор метрик запустится через "
@@ -531,10 +547,12 @@ def test_connection(slug: str, conn_id: str):
     try:
         plain = crypto.decrypt_dsn(conn["dsn_encrypted"])
     except crypto.InvalidToken:
-        return jsonify({
+        result = {
             "status": "error", "code": "invalid_ciphertext",
             "message": "Сохранённый DSN не расшифровывается. Пересохрани подключение.",
-        }), 422
+        }
+        _persist_probe_result(project["id"], conn["id"], result)
+        return jsonify(result), 422
     # #234: decrypt the Iceberg auth token (if any) and pass all Iceberg
     # fields into probe_connection so the catalog smoke-test uses the
     # same config the collector will use. decrypt_token raises on key
@@ -546,19 +564,22 @@ def test_connection(slug: str, conn_id: str):
                 conn["iceberg_auth_token_encrypted"],
             )
         except crypto.InvalidToken:
-            return jsonify({
+            result = {
                 "status": "error", "code": "invalid_ciphertext",
                 "message": (
                     "Сохранённый Iceberg auth token не расшифровывается. "
                     "Пересохрани подключение."
                 ),
-            }), 422
+            }
+            _persist_probe_result(project["id"], conn["id"], result)
+            return jsonify(result), 422
     result = probe_connection(
         plain,
         iceberg_namespace=conn.get("iceberg_namespace"),
         iceberg_warehouse=conn.get("iceberg_warehouse"),
         iceberg_auth_token=iceberg_token,
     )
+    _persist_probe_result(project["id"], conn["id"], result)
     status_code = 200 if result["status"] == "ok" else 422
     return jsonify(result), status_code
 

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -411,14 +411,14 @@ def _migrate_existing_schema(engine: Engine) -> None:
     # ALTER TABLE … ADD COLUMN here.
     if _table_exists(engine, "connections"):
         present = _existing_columns(engine, "connections")
-        _safety_columns = [
+        safety_columns = [
             ("table_allowlist", "TEXT"),
             ("table_denylist", "TEXT"),
             ("max_tables_per_tick", "INTEGER DEFAULT 50"),
             ("skip_tables_larger_than_gb", "REAL"),
             ("statement_timeout_ms", "INTEGER DEFAULT 30000"),
         ]
-        for col, ddl in _safety_columns:
+        for col, ddl in safety_columns:
             if col not in present:
                 with engine.begin() as conn:
                     conn.execute(text(
@@ -430,12 +430,12 @@ def _migrate_existing_schema(engine: Engine) -> None:
         # auth token — binary ciphertext. BLOB on SQLite, BYTEA on Postgres;
         # ALTER TABLE syntax differs only in the type keyword.
         token_type = "BYTEA" if _is_postgres() else "BLOB"
-        _iceberg_columns = [
+        iceberg_columns = [
             ("iceberg_namespace", "TEXT"),
             ("iceberg_warehouse", "TEXT"),
             ("iceberg_auth_token_encrypted", token_type),
         ]
-        for col, ddl in _iceberg_columns:
+        for col, ddl in iceberg_columns:
             if col not in present:
                 with engine.begin() as conn:
                     conn.execute(text(
@@ -461,17 +461,39 @@ def _migrate_existing_schema(engine: Engine) -> None:
 
         # #235: Iceberg load-safety. namespace_allowlist TEXT (JSON-list);
         # metadata_only_mode INTEGER (0/1 — works as boolean on both engines).
-        _iceberg_safety = [
+        iceberg_safety = [
             ("iceberg_namespace_allowlist", "TEXT"),
             ("metadata_only_mode", "INTEGER DEFAULT 0"),
         ]
-        for col, ddl in _iceberg_safety:
+        for col, ddl in iceberg_safety:
             if col not in present:
                 with engine.begin() as conn:
                     conn.execute(text(
                         f"ALTER TABLE connections ADD COLUMN {col} {ddl}"
                     ))
                 logger.info("connections.%s added (#235 iceberg safety)", col)
+
+        probe_columns = {
+            "last_probe_at": "TEXT",
+            "last_probe_status": "TEXT",
+            "last_probe_tables_found": "INTEGER",
+            "last_probe_error": "TEXT",
+        }
+        if _is_postgres():
+            probe_columns["last_probe_at"] = "TIMESTAMPTZ"
+        missing_probe_cols = [
+            (name, ddl)
+            for name, ddl in probe_columns.items()
+            if name not in present
+        ]
+        if missing_probe_cols:
+            with engine.begin() as conn:
+                for name, ddl in missing_probe_cols:
+                    conn.execute(text(f"ALTER TABLE connections ADD COLUMN {name} {ddl}"))
+            logger.info(
+                "connections probe column(s) added: %s",
+                ", ".join(name for name, _ in missing_probe_cols),
+            )
 
     _migrate_project_scoped_ml_tables(engine)
 
@@ -2443,6 +2465,7 @@ def create_connection(
     iceberg_namespace: str | None = None,
     iceberg_warehouse: str | None = None,
     iceberg_auth_token_encrypted: bytes | None = None,
+    collection_mode: str = "full",
 ) -> dict:
     """Insert a new DB connection. dsn_encrypted is Fernet ciphertext.
 
@@ -2462,17 +2485,23 @@ def create_connection(
         "iceberg_namespace": iceberg_namespace,
         "iceberg_warehouse": iceberg_warehouse,
         "iceberg_auth_token_encrypted": iceberg_auth_token_encrypted,
+        "collection_mode": collection_mode,
+        "last_probe_at": None,
+        "last_probe_status": None,
+        "last_probe_tables_found": None,
+        "last_probe_error": None,
     }
     stmt = text("""
         INSERT INTO connections
             (id, project_id, name, dsn_encrypted, schema_name,
              interval_minutes, is_active, created_at,
-             iceberg_namespace, iceberg_warehouse, iceberg_auth_token_encrypted)
+             iceberg_namespace, iceberg_warehouse,
+             iceberg_auth_token_encrypted, collection_mode)
         VALUES
             (:id, :project_id, :name, :dsn_encrypted, :schema_name,
              :interval_minutes, :is_active, :created_at,
              :iceberg_namespace, :iceberg_warehouse,
-             :iceberg_auth_token_encrypted)
+             :iceberg_auth_token_encrypted, :collection_mode)
     """)
     with get_engine().begin() as conn:
         conn.execute(stmt, payload)
@@ -2488,7 +2517,9 @@ _CONNECTION_COLUMNS = (
     "table_allowlist, table_denylist, max_tables_per_tick, "
     "skip_tables_larger_than_gb, statement_timeout_ms, "
     "iceberg_namespace, iceberg_warehouse, iceberg_auth_token_encrypted, "
-    "collection_mode, iceberg_namespace_allowlist, metadata_only_mode"
+    "collection_mode, iceberg_namespace_allowlist, metadata_only_mode, "
+    "last_probe_at, last_probe_status, last_probe_tables_found, "
+    "last_probe_error"
 )
 
 
@@ -2529,6 +2560,12 @@ def _row_to_connection(row) -> dict | None:
         # metadata_only_mode is INTEGER on both backends; boolean cast.
         "iceberg_namespace_allowlist": row[17],
         "metadata_only_mode": bool(row[18]) if row[18] is not None else False,
+        "last_probe_at": _normalize_ts(row[19]) if row[19] is not None else None,
+        "last_probe_status": row[20],
+        "last_probe_tables_found": (
+            int(row[21]) if row[21] is not None else None
+        ),
+        "last_probe_error": row[22],
     }
 
 
@@ -2626,6 +2663,44 @@ def set_connection_active(
             "id": connection_id, "pid": project_id,
             "v": 1 if is_active else 0,
         })
+    return (result.rowcount or 0) > 0
+
+
+def update_connection_probe(
+    project_id: str,
+    connection_id: str,
+    *,
+    status: str,
+    tables_found: int | None = None,
+    error: str | None = None,
+    probed_at: datetime | None = None,
+) -> bool:
+    """Persist the latest live-probe result for an existing connection."""
+    if status not in {"ok", "error"}:
+        raise ValueError("status must be 'ok' or 'error'")
+    from app.security import scrub_value
+
+    cleaned_error = scrub_value(error) if error else None
+    payload = {
+        "id": connection_id,
+        "pid": project_id,
+        "last_probe_at": _iso(probed_at or datetime.now(UTC)),
+        "last_probe_status": status,
+        "last_probe_tables_found": (
+            int(tables_found) if tables_found is not None else None
+        ),
+        "last_probe_error": None if status == "ok" else cleaned_error,
+    }
+    stmt = text("""
+        UPDATE connections
+        SET last_probe_at = :last_probe_at,
+            last_probe_status = :last_probe_status,
+            last_probe_tables_found = :last_probe_tables_found,
+            last_probe_error = :last_probe_error
+        WHERE id = :id AND project_id = :pid
+    """)
+    with get_engine().begin() as conn:
+        result = conn.execute(stmt, payload)
     return (result.rowcount or 0) > 0
 
 
@@ -2839,6 +2914,57 @@ def list_collector_runs(
         }
         for row in run_rows
     ]
+
+
+def list_last_runs_for_connections(
+    project_id: str,
+    connection_ids: Iterable[str],
+) -> dict[str, dict]:
+    """Return the newest collector run per connection, scoped to project."""
+    ids = list(dict.fromkeys(connection_ids))
+    if not ids:
+        return {}
+    stmt = text("""
+        SELECT id, project_id, connection_id, started_at, finished_at, status,
+               mode, tables_total, tables_checked, tables_skipped,
+               metrics_collected, duration_ms, error_message
+        FROM (
+            SELECT id, project_id, connection_id, started_at, finished_at, status,
+                   mode, tables_total, tables_checked, tables_skipped,
+                   metrics_collected, duration_ms, error_message,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY connection_id
+                       ORDER BY started_at DESC, id DESC
+                   ) AS rn
+            FROM collector_runs
+            WHERE project_id = :project_id
+              AND connection_id IN :connection_ids
+        ) ranked
+        WHERE rn = 1
+    """).bindparams(bindparam("connection_ids", expanding=True))
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt, {
+            "project_id": project_id,
+            "connection_ids": ids,
+        }).fetchall()
+    return {
+        row[2]: {
+            "id": row[0],
+            "project_id": row[1],
+            "connection_id": row[2],
+            "started_at": _normalize_ts(row[3]),
+            "finished_at": _normalize_ts(row[4]),
+            "status": row[5],
+            "mode": row[6],
+            "tables_total": int(row[7] or 0),
+            "tables_checked": int(row[8] or 0),
+            "tables_skipped": int(row[9] or 0),
+            "metrics_collected": int(row[10] or 0),
+            "duration_ms": row[11],
+            "error_message": row[12],
+        }
+        for row in rows
+    }
 
 
 def record_successful_login(user_id: str, email: str) -> None:

--- a/app/projects.py
+++ b/app/projects.py
@@ -175,11 +175,37 @@ def detail(slug: str):
     role = metrics_storage.get_member_role(project["id"], current_user.id)
     project["role"] = role
 
-    from app.connections import list_connections_with_dsn
+    from app import crypto
+    from app.security import mask_dsn
+    from collectors.per_project import list_jobs_for_user
+    from collectors.scheduler import get_scheduler
 
+    connections = []
+    for c in metrics_storage.list_connections_for_project(project["id"]):
+        try:
+            dsn_masked = mask_dsn(crypto.decrypt_dsn(c["dsn_encrypted"]))
+        except crypto.InvalidToken:
+            dsn_masked = "<ошибка дешифровки>"
+        connections.append({**c, "dsn_masked": dsn_masked})
+    connection_ids = [c["id"] for c in connections]
+    latest_runs = metrics_storage.list_last_runs_for_connections(
+        project["id"],
+        connection_ids,
+    )
+    jobs = list_jobs_for_user(get_scheduler(), current_user.id)
+    jobs_by_connection = {
+        job["connection_id"]: job
+        for job in jobs
+        if job.get("project_id") == project["id"]
+    }
     connections = [
-        {**c, "dsn_masked": c["dsn_masked"]}
-        for c in list_connections_with_dsn(project["id"])
+        {
+            **c,
+            "dsn_masked": c["dsn_masked"],
+            "last_run": latest_runs.get(c["id"]),
+            "scheduler_job": jobs_by_connection.get(c["id"]),
+        }
+        for c in connections
     ]
     members = metrics_storage.list_project_members(project["id"])
     return render_template(

--- a/app/projects.py
+++ b/app/projects.py
@@ -175,18 +175,11 @@ def detail(slug: str):
     role = metrics_storage.get_member_role(project["id"], current_user.id)
     project["role"] = role
 
-    from app import crypto
-    from app.security import mask_dsn
+    from app.connections import list_connections_with_dsn
     from collectors.per_project import list_jobs_for_user
     from collectors.scheduler import get_scheduler
 
-    connections = []
-    for c in metrics_storage.list_connections_for_project(project["id"]):
-        try:
-            dsn_masked = mask_dsn(crypto.decrypt_dsn(c["dsn_encrypted"]))
-        except crypto.InvalidToken:
-            dsn_masked = "<ошибка дешифровки>"
-        connections.append({**c, "dsn_masked": dsn_masked})
+    connections = list_connections_with_dsn(project["id"])
     connection_ids = [c["id"] for c in connections]
     latest_runs = metrics_storage.list_last_runs_for_connections(
         project["id"],

--- a/scripts/metrics_schema.sql
+++ b/scripts/metrics_schema.sql
@@ -256,6 +256,10 @@ CREATE TABLE IF NOT EXISTS connections (
     -- = 1 → собирать только schema, без metrics (table_stats / column_nulls).
     iceberg_namespace_allowlist TEXT,
     metadata_only_mode INTEGER DEFAULT 0,
+    last_probe_at    TEXT,
+    last_probe_status TEXT CHECK (last_probe_status IN ('ok', 'error') OR last_probe_status IS NULL),
+    last_probe_tables_found INTEGER,
+    last_probe_error TEXT,
     CHECK (interval_minutes BETWEEN 5 AND 1440)
 );
 

--- a/scripts/timescale_schema.sql
+++ b/scripts/timescale_schema.sql
@@ -206,6 +206,10 @@ CREATE TABLE IF NOT EXISTS connections (
     -- #235 Iceberg load safety. См. metrics_schema.sql.
     iceberg_namespace_allowlist TEXT,
     metadata_only_mode INTEGER DEFAULT 0,
+    last_probe_at    TIMESTAMPTZ,
+    last_probe_status TEXT CHECK (last_probe_status IN ('ok', 'error') OR last_probe_status IS NULL),
+    last_probe_tables_found INTEGER,
+    last_probe_error TEXT,
     CHECK (interval_minutes BETWEEN 5 AND 1440)
 );
 

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -51,6 +51,73 @@
           <div class="text-xs text-slate-400 dark:text-slate-500">
             <span class="font-mono">{{ c.schema_name }}</span> · {{ c.interval_minutes|fmt_interval_minutes }}
           </div>
+          <dl class="mt-3 grid gap-2 text-xs text-slate-600 dark:text-slate-300 sm:grid-cols-2 lg:grid-cols-4">
+            <div class="min-w-0">
+              <dt class="font-medium text-slate-400 dark:text-slate-500">Probe</dt>
+              <dd class="mt-0.5">
+                {% if c.last_probe_status == 'ok' %}
+                  <span class="font-medium text-emerald-700 dark:text-emerald-300">Проверено</span>
+                  <span class="text-slate-400 dark:text-slate-500">
+                    · {{ c.last_probe_at|format_datetime }}
+                    {% if c.last_probe_tables_found is not none %}
+                      · {{ c.last_probe_tables_found }} табл.
+                    {% endif %}
+                  </span>
+                {% elif c.last_probe_status == 'error' %}
+                  <span class="font-medium text-red-600 dark:text-red-300">Ошибка</span>
+                  <span class="text-slate-400 dark:text-slate-500">· {{ c.last_probe_at|format_datetime }}</span>
+                  {% if c.last_probe_error %}
+                    <span class="block truncate text-slate-500 dark:text-slate-400">{{ c.last_probe_error|truncate(140, True) }}</span>
+                  {% endif %}
+                {% else %}
+                  <span class="text-slate-400 dark:text-slate-500">Не проверялось</span>
+                {% endif %}
+              </dd>
+            </div>
+            <div>
+              <dt class="font-medium text-slate-400 dark:text-slate-500">Collector</dt>
+              <dd class="mt-0.5">
+                {% if c.is_active %}
+                  <span class="font-medium text-emerald-700 dark:text-emerald-300">Включён</span>
+                {% else %}
+                  <span class="font-medium text-slate-500 dark:text-slate-400">Выключен</span>
+                {% endif %}
+              </dd>
+            </div>
+            <div class="min-w-0">
+              <dt class="font-medium text-slate-400 dark:text-slate-500">Следующий запуск</dt>
+              <dd class="mt-0.5">
+                {% if not c.is_active %}
+                  <span class="text-slate-400 dark:text-slate-500">Collector выключен</span>
+                {% elif c.scheduler_job and c.scheduler_job.next_run_time %}
+                  <span>{{ c.scheduler_job.next_run_time|format_datetime }}</span>
+                {% else %}
+                  <span class="text-amber-700 dark:text-amber-300">Не запланирован</span>
+                {% endif %}
+              </dd>
+            </div>
+            <div class="min-w-0">
+              <dt class="font-medium text-slate-400 dark:text-slate-500">Последний сбор</dt>
+              <dd class="mt-0.5">
+                {% if c.last_run %}
+                  {% if c.last_run.status == 'success' %}
+                    <span class="font-medium text-emerald-700 dark:text-emerald-300">success</span>
+                  {% elif c.last_run.status == 'warning' %}
+                    <span class="font-medium text-amber-700 dark:text-amber-300">warning</span>
+                  {% elif c.last_run.status == 'failed' %}
+                    <span class="font-medium text-red-600 dark:text-red-300">failed</span>
+                  {% elif c.last_run.status == 'skipped' %}
+                    <span class="font-medium text-slate-500 dark:text-slate-400">skipped</span>
+                  {% else %}
+                    <span class="font-medium text-blue-700 dark:text-blue-300">{{ c.last_run.status }}</span>
+                  {% endif %}
+                  <span class="text-slate-400 dark:text-slate-500">· {{ c.last_run.started_at|format_datetime }}</span>
+                {% else %}
+                  <span class="text-slate-400 dark:text-slate-500">Сборов ещё не было</span>
+                {% endif %}
+              </dd>
+            </div>
+          </dl>
         </div>
       {% else %}
         <div class="px-5 py-12 text-center text-sm text-slate-500 dark:text-slate-400">

--- a/tests/test_collector_run_log.py
+++ b/tests/test_collector_run_log.py
@@ -130,6 +130,73 @@ def test_collector_run_helpers_list_and_tenant_isolation(storage):
     assert storage.list_collector_runs(project_a["id"], conn_a["id"], limit="bad")[0]["id"] == run_a
 
 
+def test_update_connection_probe_scrubs_and_scopes(storage):
+    project_a, conn_a = _seed_connection(storage, project_id="proj-a")
+    project_b, _ = _seed_connection(storage, project_id="proj-b")
+
+    assert storage.update_connection_probe(
+        project_b["id"],
+        conn_a["id"],
+        status="ok",
+        tables_found=3,
+    ) is False
+
+    assert storage.update_connection_probe(
+        project_a["id"],
+        conn_a["id"],
+        status="error",
+        error="failed postgresql://user:secret@db/app?token=abc",
+    ) is True
+
+    conn = storage.get_connection(project_a["id"], conn_a["id"])
+    assert conn["last_probe_status"] == "error"
+    assert conn["last_probe_at"] is not None
+    assert "secret" not in conn["last_probe_error"]
+    assert "token=abc" not in conn["last_probe_error"]
+    assert "abc" not in conn["last_probe_error"]
+
+
+def test_list_last_runs_for_connections_returns_latest_per_connection(storage):
+    project_a, conn_a = _seed_connection(storage, project_id="proj-a")
+    conn_b = storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project_a["id"],
+        name="replica",
+        dsn_encrypted=crypto.encrypt_dsn("postgresql://user:pass@db/replica"),
+        schema_name="public",
+        is_active=True,
+    )
+    project_b, conn_other = _seed_connection(storage, project_id="proj-b")
+    old_started = datetime.now(UTC) - timedelta(minutes=10)
+    new_started = datetime.now(UTC)
+
+    old_run = uuid.uuid4().hex
+    storage.save_collector_run(old_run, project_a["id"], conn_a["id"], old_started)
+    storage.update_collector_run(old_run, status="failed", finished_at=old_started)
+
+    new_run = uuid.uuid4().hex
+    storage.save_collector_run(new_run, project_a["id"], conn_a["id"], new_started)
+    storage.update_collector_run(new_run, status="success", finished_at=new_started)
+
+    conn_b_run = uuid.uuid4().hex
+    storage.save_collector_run(conn_b_run, project_a["id"], conn_b["id"], new_started)
+    storage.update_collector_run(conn_b_run, status="warning", finished_at=new_started)
+
+    other_run = uuid.uuid4().hex
+    storage.save_collector_run(other_run, project_b["id"], conn_other["id"], new_started)
+    storage.update_collector_run(other_run, status="success", finished_at=new_started)
+
+    runs = storage.list_last_runs_for_connections(
+        project_a["id"],
+        [conn_a["id"], conn_b["id"], conn_other["id"]],
+    )
+
+    assert runs[conn_a["id"]]["id"] == new_run
+    assert runs[conn_a["id"]]["status"] == "success"
+    assert runs[conn_b["id"]]["id"] == conn_b_run
+    assert conn_other["id"] not in runs
+
+
 def test_cleanup_stale_collector_runs(storage):
     project, conn_row = _seed_connection(storage)
     started = datetime.now(UTC) - timedelta(seconds=2)

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -163,6 +163,19 @@ def _add_connection(client, slug="default", name="Local", dsn="postgresql://u:p@
     )
 
 
+def _default_project_and_connection():
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+
+    user = get_user_by_email("u@example.com")
+    project = list_projects_for_user(user["id"])[0]
+    conn = list_connections_for_project(project["id"])[0]
+    return project, conn
+
+
 def _guide_href(html: str) -> str:
     match = re.search(r'href="([^"]*PROD_CONNECTION_GUIDE\.md[^"]*)"', html)
     assert match is not None
@@ -240,6 +253,111 @@ def test_project_detail_lists_connections(client):
     body = resp.get_data(as_text=True)
     assert "Production DB" in body
     assert "В проекте пока нет подключений" not in body
+
+
+def test_test_connection_persists_probe_result(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 2,
+    })
+    _add_connection(client)
+    project, conn = _default_project_and_connection()
+
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "error",
+        "code": "error",
+        "message": "boom postgresql://u:secret@db/app?token=abc",
+    })
+    resp = client.post(f"/projects/default/connections/{conn['id']}/test")
+
+    assert resp.status_code == 422
+    from app.metrics_storage import get_connection
+    stored = get_connection(project["id"], conn["id"])
+    assert stored["last_probe_status"] == "error"
+    assert "secret" not in stored["last_probe_error"]
+    assert "token=abc" not in stored["last_probe_error"]
+    assert "abc" not in stored["last_probe_error"]
+
+
+def test_project_detail_shows_connection_status_checklist(client, monkeypatch):
+    import uuid
+    from datetime import UTC, datetime, timedelta
+
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 7,
+    })
+    _add_connection(client, name="Production DB")
+    project, conn = _default_project_and_connection()
+
+    import app.metrics_storage as storage
+    started = datetime(2026, 6, 8, 10, 30, tzinfo=UTC)
+    run_id = uuid.uuid4().hex
+    storage.save_collector_run(run_id, project["id"], conn["id"], started)
+    storage.update_collector_run(
+        run_id,
+        status="success",
+        finished_at=started + timedelta(seconds=1),
+        tables_total=7,
+        tables_checked=7,
+        metrics_collected=21,
+    )
+    monkeypatch.setattr("collectors.per_project.list_jobs_for_user", lambda scheduler, user_id: [])
+    monkeypatch.setattr("collectors.scheduler.get_scheduler", lambda: None)
+
+    resp = client.get("/projects/default")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "Production DB" in body
+    assert "Probe" in body
+    assert "Проверено" in body
+    assert "7 табл." in body
+    assert "Следующий запуск" in body
+    assert "Не запланирован" in body
+    assert "Последний сбор" in body
+    assert "success" in body
+    assert "08.06 10:30 UTC" in body
+
+
+def test_project_detail_shows_next_scheduled_run(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 1,
+    })
+    _add_connection(client, name="Scheduled DB")
+    project, conn = _default_project_and_connection()
+
+    monkeypatch.setattr("collectors.scheduler.get_scheduler", lambda: object())
+    monkeypatch.setattr("collectors.per_project.list_jobs_for_user", lambda scheduler, user_id: [{
+        "id": f"collect:{project['id']}:{conn['id']}",
+        "name": "collect",
+        "project_id": project["id"],
+        "connection_id": conn["id"],
+        "next_run_time": "2026-06-08T12:45:00+00:00",
+        "trigger": "interval[0:15:00]",
+    }])
+
+    resp = client.get("/projects/default")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "Scheduled DB" in body
+    assert "Следующий запуск" in body
+    assert "08.06 12:45 UTC" in body
+    assert "Не запланирован" not in body
 
 
 def test_toggle_flips_is_active(client):

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -870,3 +870,46 @@ def test_list_connections_with_dsn_keeps_row_when_decrypt_fails(client):
     assert names["rotated-key"]["dsn_masked"] == "<ошибка дешифровки>"
     assert names["good"]["id"] == good["id"]
     assert names["rotated-key"]["id"] == bad["id"]
+
+
+def test_project_detail_keeps_connection_when_decrypt_fails(client, monkeypatch):
+    import uuid
+
+    from cryptography.fernet import Fernet
+
+    from app import crypto, metrics_storage
+
+    _register(client)
+    user = metrics_storage.get_user_by_email("u@example.com")
+    project = metrics_storage.get_project_by_slug(user["id"], "default")
+    metrics_storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"],
+        name="rotated-key",
+        dsn_encrypted=Fernet(Fernet.generate_key()).encrypt(
+            b"postgresql://u:p@h:5432/d"
+        ),
+        schema_name="public",
+        interval_minutes=15,
+        is_active=True,
+    )
+    metrics_storage.create_connection(
+        connection_id=uuid.uuid4().hex,
+        project_id=project["id"],
+        name="good",
+        dsn_encrypted=crypto.encrypt_dsn("postgresql://u:p@h:5432/d"),
+        schema_name="public",
+        interval_minutes=15,
+        is_active=True,
+    )
+    monkeypatch.setattr("collectors.per_project.list_jobs_for_user", lambda scheduler, user_id: [])
+    monkeypatch.setattr("collectors.scheduler.get_scheduler", lambda: None)
+
+    resp = client.get("/projects/default")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "rotated-key" in body
+    assert "good" in body
+    assert "&lt;ошибка дешифровки&gt;" in body
+    assert "В проекте пока нет подключений" not in body

--- a/tests/test_metrics_storage.py
+++ b/tests/test_metrics_storage.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from sqlalchemy import text
 
 # #53: every metrics row carries a project_id. Pinning a constant here keeps
 # the test bodies focused on the assertions, not the tenant scaffolding.
@@ -243,6 +244,45 @@ def test_history_anomalies_are_scoped_by_project(storage):
     agg = storage.build_history_aggregate("proj-a")
 
     assert agg["anomalies_by_ts"] == {}
+
+
+def test_migrates_legacy_connections_probe_columns(tmp_path, monkeypatch):
+    import sqlite3
+
+    db_path = tmp_path / "legacy-connections.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript("""
+            CREATE TABLE connections (
+                id               TEXT NOT NULL PRIMARY KEY,
+                project_id       TEXT NOT NULL,
+                name             TEXT NOT NULL,
+                dsn_encrypted    BLOB NOT NULL,
+                schema_name      TEXT NOT NULL DEFAULT 'public',
+                interval_minutes INTEGER NOT NULL DEFAULT 15,
+                is_active        INTEGER NOT NULL DEFAULT 1,
+                created_at       TEXT NOT NULL,
+                CHECK (interval_minutes BETWEEN 5 AND 1440)
+            );
+        """)
+
+    import app.metrics_storage as storage_mod
+    monkeypatch.setattr(storage_mod.settings, "MONITOR_DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr(storage_mod, "_engine", None)
+    monkeypatch.setattr(storage_mod, "_initialized", False)
+
+    engine = storage_mod.get_engine()
+
+    with engine.connect() as conn:
+        cols = {
+            row[1]
+            for row in conn.execute(text("PRAGMA table_info(connections)"))
+        }
+    assert {
+        "last_probe_at",
+        "last_probe_status",
+        "last_probe_tables_found",
+        "last_probe_error",
+    }.issubset(cols)
 
 
 def test_migrates_legacy_ml_tables_to_project_scoped_pk(tmp_path, monkeypatch):

--- a/tests/test_safety_editor.py
+++ b/tests/test_safety_editor.py
@@ -88,7 +88,7 @@ def _conn_id(client, email="u@example.com"):
 def test_edit_get_renders_form_with_db_values(client):
     _register(client)
     _add_pg(client)
-    pid, cid = _conn_id(client)
+    _pid, cid = _conn_id(client)
     # Pre-set some safety values directly so we can assert pre-fill.
     from sqlalchemy import text
 
@@ -111,7 +111,7 @@ def test_edit_get_renders_form_with_db_values(client):
 def test_edit_iceberg_block_only_for_iceberg_dsn(client):
     _register(client)
     _add_pg(client)
-    pid, cid = _conn_id(client)
+    _pid, cid = _conn_id(client)
     body_pg = client.get(f"/projects/default/connections/{cid}/edit").get_data(as_text=True)
     assert "Iceberg" not in body_pg or "iceberg_namespace_allowlist" not in body_pg
 
@@ -119,7 +119,7 @@ def test_edit_iceberg_block_only_for_iceberg_dsn(client):
 def test_edit_iceberg_block_visible_for_iceberg(client):
     _register(client)
     _add_iceberg(client)
-    pid, cid = _conn_id(client)
+    _pid, cid = _conn_id(client)
     body = client.get(f"/projects/default/connections/{cid}/edit").get_data(as_text=True)
     assert "iceberg_namespace_allowlist" in body
     assert "metadata_only_mode" in body
@@ -306,7 +306,7 @@ def test_iceberg_fields_ignored_for_non_iceberg(client):
 def test_stranger_cannot_edit(client):
     _register(client, email="owner@x.io")
     _add_pg(client)
-    pid, cid = _conn_id(client, email="owner@x.io")
+    _pid, cid = _conn_id(client, email="owner@x.io")
 
     client.post("/auth/logout")
     _register(client, email="stranger@x.io")


### PR DESCRIPTION
Closes #240

## Описание

Добавляет на страницу проекта понятный статус каждого подключения: результат последнего probe, состояние collector, следующий запуск по расписанию и последний persisted collector run.

## Что изменилось

- Добавлены probe-поля в `connections` и migration path для существующих SQLite/Postgres схем.
- Добавлены storage helpers для сохранения probe-result и чтения последних collector runs по connection_id.
- Страница проекта теперь показывает Probe / Collector / Следующий запуск / Последний сбор для каждого подключения.
- Scheduler state подтягивается в project detail, включая happy path с `next_run_time`.
- Probe-result сохраняется после проверки подключения, ошибки scrubbed.
- Учтены свежие master-изменения по `collection_mode`, Iceberg safety и production params.

## Тесты

- `venv/bin/python -m ruff check app/app.py app/connections.py app/metrics_storage.py app/projects.py tests/test_collector_run_log.py tests/test_connections.py tests/test_metrics_storage.py tests/test_safety_editor.py`
- `venv/bin/python -m pytest tests/test_collector_run_log.py tests/test_connections.py tests/test_metrics_storage.py tests/test_safety_editor.py tests/test_projects.py tests/test_per_project.py`

## Примечание

`docs/PROD_CONNECTION_GUIDE.md` не входит в этот PR: он уже пришёл через PR #266 / issue #227.