### PR TITLE
feat: кнопка «Запустить сбор» в списке подключений

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from datetime import UTC, datetime
 
 from flask import (
     Blueprint,
@@ -624,6 +625,57 @@ def toggle(slug: str, conn_id: str):
         f"Подключение «{conn['name']}» {'выключено' if conn['is_active'] else 'включено'}.",
         "info",
     )
+    return redirect(url_for("connections.list_connections", slug=slug))
+
+
+@bp.route("/<conn_id>/run", methods=["POST"])
+@login_required
+def run_now(slug: str, conn_id: str):
+    """Trigger one collector tick immediately without waiting for the
+    regular interval — useful right after editing safety settings to see
+    the new filter behavior in the next dashboard refresh.
+
+    Implemented as a one-shot APScheduler ``date`` job so the request
+    returns immediately (collection happens in the scheduler thread). The
+    recurring interval job is left untouched.
+    """
+    project, conn = _require_owned_connection(slug, conn_id)
+    role = metrics_storage.get_member_role(project["id"], current_user.id)
+    if role not in ("owner", "editor"):
+        abort(403)
+    if not conn["is_active"]:
+        flash(
+            f"Подключение «{conn['name']}» выключено — сначала включите.",
+            "error",
+        )
+        return redirect(url_for("connections.list_connections", slug=slug))
+
+    from collectors.per_project import collect_for_connection, job_id_for
+    from collectors.scheduler import get_scheduler
+
+    sched = get_scheduler()
+    if sched is None or not sched.running:
+        # No scheduler (e.g. under TESTING) — fall back to synchronous run
+        # so the operator still sees a result. Acceptable cost: the
+        # request blocks for one tick. In prod the scheduler is always up.
+        collect_for_connection(project["id"], conn["id"])
+        flash(f"Сбор для «{conn['name']}» выполнен.", "success")
+        return redirect(url_for("connections.list_connections", slug=slug))
+
+    # Unique one-shot id so multiple clicks queue rather than overwrite.
+    sched.add_job(
+        collect_for_connection,
+        "date",
+        run_date=datetime.now(UTC),  # one-shot, fires immediately
+        args=[project["id"], conn["id"]],
+        id=f"{job_id_for(project['id'], conn['id'])}:manual:{uuid.uuid4().hex[:8]}",
+        name=f"manual run project={project['id']} conn={conn['id']}",
+        misfire_grace_time=300,
+        coalesce=True,
+        max_instances=1,
+        replace_existing=False,
+    )
+    flash(f"Сбор для «{conn['name']}» запущен.", "info")
     return redirect(url_for("connections.list_connections", slug=slug))
 
 

--- a/templates/connections/list.html
+++ b/templates/connections/list.html
@@ -52,6 +52,13 @@
                       class="js-test-conn rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
                 Тест
               </button>
+              <form method="POST" action="{{ url_for('connections.run_now', slug=project.slug, conn_id=c.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit"
+                        class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
+                  Запустить сбор
+                </button>
+              </form>
               <form method="POST" action="{{ url_for('connections.toggle', slug=project.slug, conn_id=c.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit"

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -383,6 +383,129 @@ def test_toggle_flips_is_active(client):
     assert conns[0]["is_active"] is True
 
 
+# --- Run-now (manual tick) -------------------------------------------------
+
+
+def test_run_now_falls_back_to_sync_when_scheduler_absent(client, monkeypatch):
+    """Under TESTING the scheduler is not running; the route falls back to
+    a synchronous ``collect_for_connection`` so the operator still gets a
+    result and a "сбор выполнен" flash."""
+    _register(client)
+    _add_connection(client)
+
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+    user = get_user_by_email("u@example.com")
+    project = list_projects_for_user(user["id"])[0]
+    conn_id = list_connections_for_project(project["id"])[0]["id"]
+
+    called: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "collectors.per_project.collect_for_connection",
+        lambda pid, cid: called.append((pid, cid)),
+    )
+
+    resp = client.post(
+        f"/projects/default/connections/{conn_id}/run",
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert called == [(project["id"], conn_id)]
+    assert "выполнен" in resp.get_data(as_text=True)
+
+
+def test_run_now_schedules_one_shot_when_scheduler_running(client, monkeypatch):
+    """With a running scheduler, the route enqueues a one-shot date job and
+    returns immediately — does NOT block on collect_for_connection."""
+    _register(client)
+    _add_connection(client)
+
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+    user = get_user_by_email("u@example.com")
+    project = list_projects_for_user(user["id"])[0]
+    conn_id = list_connections_for_project(project["id"])[0]["id"]
+
+    class _FakeSched:
+        running = True
+
+        def __init__(self):
+            self.added: list[dict] = []
+
+        def add_job(self, func, trigger, **kw):
+            self.added.append({"trigger": trigger, **kw})
+
+    fake = _FakeSched()
+    monkeypatch.setattr("collectors.scheduler.get_scheduler", lambda: fake)
+    # Sanity: collect_for_connection must NOT be called inline.
+    sync_calls: list = []
+    monkeypatch.setattr(
+        "collectors.per_project.collect_for_connection",
+        lambda *a: sync_calls.append(a),
+    )
+
+    resp = client.post(
+        f"/projects/default/connections/{conn_id}/run",
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert sync_calls == []  # request returned without blocking
+    assert len(fake.added) == 1
+    job = fake.added[0]
+    assert job["trigger"] == "date"
+    assert job["args"] == [project["id"], conn_id]
+    assert "запущен" in resp.get_data(as_text=True)
+
+
+def test_run_now_blocks_inactive_connection(client):
+    _register(client)
+    _add_connection(client)
+
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+    user = get_user_by_email("u@example.com")
+    project = list_projects_for_user(user["id"])[0]
+    conn_id = list_connections_for_project(project["id"])[0]["id"]
+    # Disable.
+    client.post(f"/projects/default/connections/{conn_id}/toggle")
+
+    resp = client.post(
+        f"/projects/default/connections/{conn_id}/run",
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "выключено" in body
+
+
+def test_run_now_stranger_forbidden(client):
+    _register(client, email="owner@x.io")
+    _add_connection(client)
+
+    from app.metrics_storage import (
+        get_user_by_email,
+        list_connections_for_project,
+        list_projects_for_user,
+    )
+    user = get_user_by_email("owner@x.io")
+    project = list_projects_for_user(user["id"])[0]
+    conn_id = list_connections_for_project(project["id"])[0]["id"]
+
+    _logout(client)
+    _register(client, email="stranger@x.io")
+    resp = client.post(f"/projects/default/connections/{conn_id}/run")
+    assert resp.status_code in (403, 404)
+
+
 def test_delete_removes_connection(client):
     _register(client)
     _add_connection(client)


### PR DESCRIPTION
## Зачем

После правки safety-настроек подключения (load-safety / collection_mode / Iceberg) приходилось либо ждать 15 мин до следующего interval-тика, либо делать \`docker restart db-monitoring-app\` ради \`run_immediately=True\`. Это разрывает обратную связь при отладке фильтров.

## Что делаем

Новый POST-эндпоинт \`/projects/<slug>/connections/<conn_id>/run\`:
- С запущенным APScheduler — кладёт one-shot \`date\` job на \`next_run_time=now\`, не трогая основной interval-job. Запрос возвращается сразу, сбор бежит в фоне.
- Без планировщика (TESTING) — синхронный \`collect_for_connection\`, чтобы оператор всё равно увидел результат.
- Owner/editor only. Выключенное подключение → flash «сначала включите», без сбора.

В \`templates/connections/list.html\` появляется кнопка «Запустить сбор» между «Тест» и «Выключить».

## Test plan
- [x] \`pytest tests/test_connections.py\` — 47 пройдено, включая 4 новых:
  - \`test_run_now_falls_back_to_sync_when_scheduler_absent\`
  - \`test_run_now_schedules_one_shot_when_scheduler_running\`
  - \`test_run_now_blocks_inactive_connection\`
  - \`test_run_now_stranger_forbidden\`
- [x] \`ruff check .\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)