### PR TITLE
fix: рендер «Тест» для Iceberg — без «Прав» и ложного «не найдено»

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -731,12 +731,21 @@ def _probe_iceberg(
                     "latency_ms": latency_ms,
                 }
             tables = adapter.list_tables(namespace)
+            # ``list_tables`` returns dicts ({"table_name": ..., "schema":
+            # ...}) — pull the name for the UI preview list. The "Права"
+            # section is intentionally omitted (Iceberg has no
+            # SELECT/INSERT grants to surface); the JS renderer drops it
+            # when ``privileges`` is absent.
+            tables_preview = [
+                t["table_name"] for t in tables[:_PROBE_TABLES_PREVIEW]
+            ]
             latency_ms = int((time.monotonic() - started) * 1000)
             return {
                 "status": "ok",
                 "database": "iceberg",
                 "version": f"namespace={namespace}",
                 "tables_found": len(tables),
+                "tables_preview": tables_preview,
                 "latency_ms": latency_ms,
             }
         latency_ms = int((time.monotonic() - started) * 1000)

--- a/templates/connections/list.html
+++ b/templates/connections/list.html
@@ -97,12 +97,25 @@
     const renderOk = (data) => {
       const tables = data.tables_preview || [];
       const tablesFound = data.tables_found ?? 0;
-      const priv = data.privileges || {};
+      // Iceberg probe doesn't surface SELECT/INSERT grants — skip the
+      // "Права" block entirely when the backend didn't send it, so the
+      // operator doesn't see ✗ ✗ that imply "no permissions" when in
+      // fact the concept doesn't apply.
+      const priv = data.privileges;
       const warnings = data.warnings || [];
-      const previewList = tables.length
-        ? `<ul class="mt-1 list-disc pl-5 font-mono">${tables.map((t) =>
-            `<li>${escapeHtml(t)}</li>`).join("")}</ul>`
-        : `<div class="mt-1 italic text-slate-500">таблиц в схеме не найдено</div>`;
+      // Empty preview + tables_found=0 → "не найдено". But if
+      // tables_found > 0 with no preview (backend chose not to send
+      // names), show just the count — the "не найдено" line was
+      // misleading in that case.
+      let previewList;
+      if (tables.length) {
+        previewList = `<ul class="mt-1 list-disc pl-5 font-mono">${tables.map((t) =>
+          `<li>${escapeHtml(t)}</li>`).join("")}</ul>`;
+      } else if (tablesFound > 0) {
+        previewList = "";
+      } else {
+        previewList = `<div class="mt-1 italic text-slate-500">таблиц в схеме не найдено</div>`;
+      }
       const warningBlock = warnings.includes("write_privileges_detected")
         ? `<div class="mt-2 rounded border border-amber-300 bg-amber-50 px-2 py-1 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
                 data-warning="write_privileges_detected">
@@ -110,24 +123,28 @@
              (рекомендация least-privilege).
            </div>`
         : "";
+      const privBlock = priv
+        ? `<div data-section="privileges">
+             <div class="text-slate-500 dark:text-slate-400">Права:</div>
+             <ul class="mt-1 font-mono">
+               <li>SELECT: <span data-priv="select">${priv.select ? "✓" : "✗"}</span></li>
+               <li>INSERT: <span data-priv="insert">${priv.insert ? "✓" : "✗"}</span></li>
+             </ul>
+           </div>`
+        : "";
+      const gridCols = priv ? "grid-cols-2" : "grid-cols-1";
       return `
         <div class="font-medium text-emerald-700 dark:text-emerald-300">
           ✓ ${escapeHtml(data.database)} · ${escapeHtml(data.version)} · ${data.latency_ms} мс
         </div>
-        <div class="mt-2 grid grid-cols-2 gap-3">
+        <div class="mt-2 grid ${gridCols} gap-3">
           <div data-section="tables">
             <div class="text-slate-500 dark:text-slate-400">
               Найдено таблиц: <span data-tables-found class="font-mono text-slate-800 dark:text-slate-200">${tablesFound}</span>
             </div>
             ${previewList}
           </div>
-          <div data-section="privileges">
-            <div class="text-slate-500 dark:text-slate-400">Права:</div>
-            <ul class="mt-1 font-mono">
-              <li>SELECT: <span data-priv="select">${priv.select ? "✓" : "✗"}</span></li>
-              <li>INSERT: <span data-priv="insert">${priv.insert ? "✓" : "✗"}</span></li>
-            </ul>
-          </div>
+          ${privBlock}
         </div>
         ${warningBlock}
       `;

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -677,6 +677,38 @@ def test_probe_iceberg_namespace_exists_tables_zero(monkeypatch):
     )
     assert result["status"] == "ok"
     assert result["tables_found"] == 0
+    # JS renderer keys off this — empty preview list is fine for "0 tables".
+    assert result["tables_preview"] == []
+    # No "privileges" key — Iceberg has no SELECT/INSERT grants to show.
+    assert "privileges" not in result
+
+
+def test_probe_iceberg_returns_tables_preview(monkeypatch):
+    """Iceberg probe surfaces up to N table names so the JS Test-result
+    panel can list them like the Postgres path does, instead of saying
+    "таблиц в схеме не найдено" while tables_found > 0."""
+    from unittest.mock import MagicMock
+
+    from app.connections import _probe_iceberg
+
+    fake = MagicMock()
+    fake.list_namespaces.return_value = [("lakehouse",)]
+    fake.list_tables.return_value = [
+        {"table_name": "events", "schema": "lakehouse"},
+        {"table_name": "orders", "schema": "lakehouse"},
+        {"table_name": "customers", "schema": "lakehouse"},
+        {"table_name": "sessions", "schema": "lakehouse"},
+    ]
+    monkeypatch.setattr("app.db.make_adapter_for_url", lambda dsn, **_: fake)
+
+    result = _probe_iceberg(
+        "iceberg+rest://h:8181?warehouse=s3://b/w",
+        namespace="lakehouse",
+    )
+    assert result["status"] == "ok"
+    assert result["tables_found"] == 4
+    assert result["tables_preview"] == ["events", "orders", "customers", "sessions"]
+    assert "privileges" not in result
 
 
 def test_probe_iceberg_passes_overrides_to_adapter(monkeypatch):


### PR DESCRIPTION
## Зачем

После клика «Тест» на Iceberg-подключении UI показывал:
- «таблиц в схеме не найдено» — хотя \`tables_found = 4\`
- «Права: SELECT: ✗ INSERT: ✗» — у Iceberg нет таких грантов вообще

Оба блока скопированы с Postgres-пути и для других диалектов вводят в заблуждение.

## Что делаем

- \`_probe_iceberg\` добавляет \`tables_preview\` (имена первых N таблиц из \`list_tables(namespace)\`) и не возвращает \`privileges\`.
- JS-renderer: скрывает «Права» если \`data.privileges\` отсутствует; не пишет «не найдено» если \`tables_found > 0\` и preview пуст; grid переключается между 2 колонками (postgres) и 1 (iceberg).

## Test plan
- [x] \`pytest tests/test_connections.py\` — 44 пройдено, новый \`test_probe_iceberg_returns_tables_preview\`.
- [x] \`ruff check .\` — clean.
- [x] Manual: «Тест» на iceberg-подключении показывает 4 таблицы списком, без блока «Права».

🤖 Generated with [Claude Code](https://claude.com/claude-code)