### PR TITLE
fix(#261): row_count завышен на Iceberg MoR-таблицах

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -597,7 +597,13 @@ class IcebergAdapter(DBAdapter):
             }
 
         summary = snapshot.summary
-        row_count = int(summary.get("total-records", 0) or 0)
+        # MoR tables accumulate delete files before compaction; subtract both
+        # positional and equality deletes so row_count reflects live rows only.
+        # total-equality-deletes counts delete entries, not matched rows — approximate for equality-delete tables (e.g. CDC).
+        total = int(summary.get("total-records", 0) or 0)
+        deletes = int(summary.get("total-position-deletes", 0) or 0) + \
+                  int(summary.get("total-equality-deletes", 0) or 0)
+        row_count = max(0, total - deletes)
         size_bytes = int(summary.get("total-files-size", 0) or 0)
         last_analyze = datetime.fromtimestamp(
             snapshot.timestamp_ms / 1000, tz=UTC

--- a/tests/test_iceberg_adapter.py
+++ b/tests/test_iceberg_adapter.py
@@ -209,6 +209,47 @@ def test_table_stats_unknown_table_returns_none():
     assert result is None
 
 
+def test_table_stats_mor_subtracts_delete_records():
+    """MoR tables: live row_count = total-records minus positional + equality deletes."""
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        mock_table = mock_cls.return_value.load_table.return_value
+        mock_snapshot = MagicMock()
+        mock_snapshot.timestamp_ms = 1_700_000_000_000
+        mock_snapshot.summary.get.side_effect = lambda k, d=0: {
+            "total-records": "1000",
+            "total-files-size": "2048",
+            "total-position-deletes": "300",
+            "total-equality-deletes": "150",
+        }.get(k, d)
+        mock_table.current_snapshot.return_value = mock_snapshot
+
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.table_stats("events", "myns")
+
+    assert result["row_count"] == 550  # 1000 - 300 - 150
+
+
+def test_table_stats_mor_row_count_never_negative():
+    """Stale metadata edge-case: deletes > total-records clamps to 0, not negative."""
+    with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+        mock_table = mock_cls.return_value.load_table.return_value
+        mock_snapshot = MagicMock()
+        mock_snapshot.timestamp_ms = 1_700_000_000_000
+        mock_snapshot.summary.get.side_effect = lambda k, d=0: {
+            "total-records": "10",
+            "total-files-size": "512",
+            "total-position-deletes": "15",
+        }.get(k, d)
+        mock_table.current_snapshot.return_value = mock_snapshot
+
+        from app.db import IcebergAdapter
+        adapter = IcebergAdapter(REST_DSN)
+        result = adapter.table_stats("events", "myns")
+
+    assert result["row_count"] == 0
+
+
 # ---------------------------------------------------------------------------
 # column_nulls — manifest metadata path (no full scan)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Описание

`total-records` в Iceberg snapshot summary считает все записи в data-файлах, включая строки, помеченные к удалению delete-файлами до компакции (MoR-режим). В результате `row_count` был завышен на таблицах с CDC-удалениями или streaming-ingestion через Flink.

Фикс: вычитаем `total-position-deletes` и `total-equality-deletes` из `total-records`. `max(0, ...)` защищает от отрицательного значения при рассинхроне метаданных в in-flight compaction.

Примечание: `total-equality-deletes` считает записи в delete-файлах, а не количество удалённых строк — для equality-delete таблиц это приближение (задокументировано в комментарии).

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы