### PR TITLE
fix(e2e): обновить _mock_probe после добавления iceberg_namespace

### DIFF
--- a/tests/e2e/test_connection_smoke_ui.py
+++ b/tests/e2e/test_connection_smoke_ui.py
@@ -34,7 +34,7 @@ def _free_port() -> int:
 _PROBE_RESULT: dict = {}
 
 
-def _mock_probe(_dsn: str) -> dict:
+def _mock_probe(_dsn: str, **_kwargs) -> dict:
     return dict(_PROBE_RESULT)
 
 


### PR DESCRIPTION
## Описание

PR #272 добавил `iceberg_namespace` в `probe_connection`, но e2e-мок `_mock_probe` не был обновлён и не принимал этот аргумент — падал с `TypeError`. Добавляем `**_kwargs` чтобы мок был устойчив к будущим аргументам.

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы