### PR TITLE
feat: UI детализации collector run tables

### DIFF
--- a/app/connections.py
+++ b/app/connections.py
@@ -274,6 +274,85 @@ def _persist_probe_result(project_id: str, connection_id: str, result: dict) -> 
     )
 
 
+_RUN_STATUS_LABELS = {
+    "running": "Выполняется",
+    "success": "Успешно",
+    "warning": "С предупреждениями",
+    "failed": "Ошибка",
+    "skipped": "Пропущен",
+}
+
+_TABLE_STATUS_LABELS = {
+    "success": "Успешно",
+    "skipped": "Пропущена",
+    "failed": "Ошибка",
+}
+
+_SKIP_REASON_LABELS = {
+    "denylisted": "Исключена denylist",
+    "not_in_allowlist": "Не входит в allowlist",
+    "too_large": "Слишком большая таблица",
+    "timeout": "Таймаут",
+    "max_tables_limit": "Лимит таблиц за тик",
+}
+
+
+def _format_duration_ms(value) -> str:
+    if value is None:
+        return "—"
+    try:
+        ms = int(value)
+    except (TypeError, ValueError):
+        return "—"
+    if ms < 1000:
+        return f"{ms} мс"
+    if ms < 60_000:
+        return f"{ms / 1000:.1f} с"
+    minutes, rest_ms = divmod(ms, 60_000)
+    seconds = rest_ms // 1000
+    return f"{minutes} мин {seconds:02d} с"
+
+
+def _display_count(value) -> str:
+    if value is None:
+        return "—"
+    return str(value)
+
+
+def _truncate_text(value: str | None, limit: int = 240) -> str | None:
+    if not value:
+        return None
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"
+
+
+def _decorate_run_detail(run: dict) -> dict:
+    run = {**run}
+    run["status_label"] = _RUN_STATUS_LABELS.get(run["status"], "Неизвестный статус")
+    run["duration_label"] = _format_duration_ms(run.get("duration_ms"))
+    run["error_message"] = _truncate_text(run.get("error_message"))
+    rows = []
+    for row in run.get("rows", []):
+        decorated = {**row}
+        decorated["status_label"] = _TABLE_STATUS_LABELS.get(
+            row.get("status"),
+            "Неизвестный статус",
+        )
+        skip_reason = row.get("skip_reason")
+        decorated["skip_reason_label"] = (
+            _SKIP_REASON_LABELS.get(skip_reason, "Другая причина")
+            if skip_reason
+            else None
+        )
+        decorated["rows_observed_label"] = _display_count(row.get("rows_observed"))
+        decorated["duration_label"] = _format_duration_ms(row.get("duration_ms"))
+        decorated["error_message"] = _truncate_text(row.get("error_message"))
+        rows.append(decorated)
+    run["rows"] = rows
+    return run
+
+
 @bp.route("")
 @bp.route("/")
 @login_required
@@ -508,6 +587,43 @@ def edit_safety(slug: str, conn_id: str):
         "connections/edit.html",
         project=project, conn=conn, form=form,
         is_iceberg=is_iceberg, is_postgres=is_postgres,
+    )
+
+
+@bp.route("/<conn_id>/runs/<run_id>")
+@login_required
+def collector_run_detail(slug: str, conn_id: str, run_id: str):
+    project, conn = _require_owned_connection(slug, conn_id)
+    project["role"] = metrics_storage.get_member_role(project["id"], current_user.id)
+
+    requested_status = request.args.get("status")
+    status_filter = (
+        requested_status
+        if requested_status in {"failed", "skipped", "success"}
+        else None
+    )
+    run = metrics_storage.get_collector_run_detail(
+        project["id"],
+        conn["id"],
+        run_id,
+        status=status_filter,
+        limit=100,
+    )
+    if run is None:
+        abort(404)
+
+    return render_template(
+        "connections/run_detail.html",
+        project=project,
+        conn=conn,
+        run=_decorate_run_detail(run),
+        status_filter=status_filter,
+        status_tabs=[
+            ("", "Все"),
+            ("failed", "Ошибки"),
+            ("skipped", "Пропущенные"),
+            ("success", "Успешные"),
+        ],
     )
 
 

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -2967,6 +2967,103 @@ def list_last_runs_for_connections(
     }
 
 
+def get_collector_run_detail(
+    project_id: str,
+    connection_id: str,
+    run_id: str,
+    *,
+    status: str | None = None,
+    limit: int = 100,
+) -> dict | None:
+    """Return one collector run with limited, sorted table-level rows."""
+    from app.security import scrub_value
+
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = 100
+    limit = max(1, min(limit, 100))
+
+    status_filter = status if status in {"failed", "skipped", "success"} else None
+    status_sql = "AND status = :status" if status_filter else ""
+    params = {
+        "project_id": project_id,
+        "connection_id": connection_id,
+        "run_id": run_id,
+        "limit": limit,
+    }
+    if status_filter:
+        params["status"] = status_filter
+
+    with get_engine().connect() as conn:
+        run_row = conn.execute(text("""
+            SELECT id, project_id, connection_id, started_at, finished_at, status,
+                   mode, tables_total, tables_checked, tables_skipped,
+                   metrics_collected, duration_ms, error_message
+            FROM collector_runs
+            WHERE id = :run_id
+              AND project_id = :project_id
+              AND connection_id = :connection_id
+        """), params).fetchone()
+        if run_row is None:
+            return None
+
+        rows_total = conn.execute(text(f"""
+            SELECT COUNT(*)
+            FROM collector_run_tables
+            WHERE run_id = :run_id
+              {status_sql}
+        """), params).scalar_one()
+
+        table_rows = conn.execute(text(f"""
+            SELECT id, table_name, status, metrics_collected, rows_observed,
+                   duration_ms, skip_reason, error_message
+            FROM collector_run_tables
+            WHERE run_id = :run_id
+              {status_sql}
+            ORDER BY
+              CASE status
+                WHEN 'failed' THEN 0
+                WHEN 'skipped' THEN 1
+                WHEN 'success' THEN 2
+                ELSE 3
+              END,
+              LOWER(table_name)
+            LIMIT :limit
+        """), params).fetchall()
+
+    return {
+        "id": run_row[0],
+        "project_id": run_row[1],
+        "connection_id": run_row[2],
+        "started_at": _normalize_ts(run_row[3]),
+        "finished_at": _normalize_ts(run_row[4]),
+        "status": run_row[5],
+        "mode": run_row[6],
+        "tables_total": int(run_row[7] or 0),
+        "tables_checked": int(run_row[8] or 0),
+        "tables_skipped": int(run_row[9] or 0),
+        "metrics_collected": int(run_row[10] or 0),
+        "duration_ms": run_row[11],
+        "error_message": scrub_value(run_row[12]) if run_row[12] else None,
+        "rows_total": int(rows_total or 0),
+        "rows_limit": limit,
+        "rows": [
+            {
+                "id": row[0],
+                "table_name": row[1],
+                "status": row[2],
+                "metrics_collected": int(row[3] or 0),
+                "rows_observed": row[4],
+                "duration_ms": row[5],
+                "skip_reason": row[6],
+                "error_message": scrub_value(row[7]) if row[7] else None,
+            }
+            for row in table_rows
+        ],
+    }
+
+
 def record_successful_login(user_id: str, email: str) -> None:
     """Atomic side-effects of a successful login: stamp last_login_at AND
     clear the email's failed-login counter, both in one transaction.

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -3032,34 +3032,41 @@ def get_collector_run_detail(
             LIMIT :limit
         """), params).fetchall()
 
+    run = run_row._mapping
     return {
-        "id": run_row[0],
-        "project_id": run_row[1],
-        "connection_id": run_row[2],
-        "started_at": _normalize_ts(run_row[3]),
-        "finished_at": _normalize_ts(run_row[4]),
-        "status": run_row[5],
-        "mode": run_row[6],
-        "tables_total": int(run_row[7] or 0),
-        "tables_checked": int(run_row[8] or 0),
-        "tables_skipped": int(run_row[9] or 0),
-        "metrics_collected": int(run_row[10] or 0),
-        "duration_ms": run_row[11],
-        "error_message": scrub_value(run_row[12]) if run_row[12] else None,
+        "id": run["id"],
+        "project_id": run["project_id"],
+        "connection_id": run["connection_id"],
+        "started_at": _normalize_ts(run["started_at"]),
+        "finished_at": _normalize_ts(run["finished_at"]),
+        "status": run["status"],
+        "mode": run["mode"],
+        "tables_total": int(run["tables_total"] or 0),
+        "tables_checked": int(run["tables_checked"] or 0),
+        "tables_skipped": int(run["tables_skipped"] or 0),
+        "metrics_collected": int(run["metrics_collected"] or 0),
+        "duration_ms": run["duration_ms"],
+        "error_message": (
+            scrub_value(run["error_message"]) if run["error_message"] else None
+        ),
         "rows_total": int(rows_total or 0),
         "rows_limit": limit,
         "rows": [
             {
-                "id": row[0],
-                "table_name": row[1],
-                "status": row[2],
-                "metrics_collected": int(row[3] or 0),
-                "rows_observed": row[4],
-                "duration_ms": row[5],
-                "skip_reason": row[6],
-                "error_message": scrub_value(row[7]) if row[7] else None,
+                "id": table["id"],
+                "table_name": table["table_name"],
+                "status": table["status"],
+                "metrics_collected": int(table["metrics_collected"] or 0),
+                "rows_observed": table["rows_observed"],
+                "duration_ms": table["duration_ms"],
+                "skip_reason": table["skip_reason"],
+                "error_message": (
+                    scrub_value(table["error_message"])
+                    if table["error_message"]
+                    else None
+                ),
             }
-            for row in table_rows
+            for table in (row._mapping for row in table_rows)
         ],
     }
 

--- a/templates/connections/run_detail.html
+++ b/templates/connections/run_detail.html
@@ -1,0 +1,149 @@
+{% extends "base.html" %}
+
+{% block title %}Детали сбора · {{ conn.name }}{% endblock %}
+
+{% block content %}
+  <div class="space-y-6">
+    <nav class="text-sm text-slate-500 dark:text-slate-400">
+      <a href="{{ url_for('projects.list_projects') }}" class="hover:text-accent">Проекты</a>
+      <span class="mx-2">/</span>
+      <a href="{{ url_for('projects.detail', slug=project.slug) }}" class="hover:text-accent">{{ project.name }}</a>
+      <span class="mx-2">/</span>
+      <span>Детали сбора</span>
+    </nav>
+
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <a
+          href="{{ url_for('projects.detail', slug=project.slug) }}"
+          class="text-sm text-slate-500 hover:text-accent dark:text-slate-400"
+        >← К проекту</a>
+        <h1 class="mt-3 text-3xl font-bold text-slate-900 dark:text-slate-100">Детали сбора</h1>
+        <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          {{ conn.name }} · {{ run.started_at|format_datetime }}
+        </p>
+      </div>
+
+      {% set status_class = {
+        "success": "bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-300 dark:ring-emerald-800",
+        "warning": "bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-900/20 dark:text-amber-300 dark:ring-amber-800",
+        "failed": "bg-red-50 text-red-700 ring-red-200 dark:bg-red-900/20 dark:text-red-300 dark:ring-red-800",
+        "running": "bg-blue-50 text-blue-700 ring-blue-200 dark:bg-blue-900/20 dark:text-blue-300 dark:ring-blue-800",
+        "skipped": "bg-slate-100 text-slate-600 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700",
+      }.get(run.status, "bg-slate-100 text-slate-600 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700") %}
+      <span class="inline-flex w-fit items-center rounded-full px-3 py-1 text-sm font-medium ring-1 {{ status_class }}">
+        {{ run.status_label }}
+      </span>
+    </div>
+
+    <section class="rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div class="grid gap-px bg-slate-200 dark:bg-slate-800 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="bg-white p-4 dark:bg-slate-900">
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Начался</div>
+          <div class="mt-1 text-sm font-medium">{{ run.started_at|format_datetime }}</div>
+        </div>
+        <div class="bg-white p-4 dark:bg-slate-900">
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Завершился</div>
+          <div class="mt-1 text-sm font-medium">{{ run.finished_at|format_datetime }}</div>
+        </div>
+        <div class="bg-white p-4 dark:bg-slate-900">
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Длительность</div>
+          <div class="mt-1 text-sm font-medium">{{ run.duration_label }}</div>
+        </div>
+        <div class="bg-white p-4 dark:bg-slate-900">
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Метрик собрано</div>
+          <div class="mt-1 text-sm font-medium">{{ run.metrics_collected }}</div>
+        </div>
+        <div class="bg-white p-4 dark:bg-slate-900">
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Таблиц всего</div>
+          <div class="mt-1 text-sm font-medium">{{ run.tables_total }}</div>
+        </div>
+        <div class="bg-white p-4 dark:bg-slate-900">
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Проверено</div>
+          <div class="mt-1 text-sm font-medium">{{ run.tables_checked }}</div>
+        </div>
+        <div class="bg-white p-4 dark:bg-slate-900">
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Пропущено</div>
+          <div class="mt-1 text-sm font-medium">{{ run.tables_skipped }}</div>
+        </div>
+        <div class="bg-white p-4 dark:bg-slate-900">
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Mode</div>
+          <div class="mt-1 text-sm font-medium">{{ run.mode }}</div>
+        </div>
+      </div>
+      {% if run.error_message %}
+        <div class="border-t border-slate-200 p-4 text-sm text-red-700 dark:border-slate-800 dark:text-red-300">
+          {{ run.error_message }}
+        </div>
+      {% endif %}
+    </section>
+
+    <section class="rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div class="flex flex-col gap-3 border-b border-slate-200 p-4 dark:border-slate-800 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-base font-semibold">Таблицы запуска</h2>
+          <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Показано {{ run.rows|length }} из {{ run.rows_total }}
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          {% for key, label in status_tabs %}
+            {% set href = url_for('connections.collector_run_detail', slug=project.slug, conn_id=conn.id, run_id=run.id, status=key) if key else url_for('connections.collector_run_detail', slug=project.slug, conn_id=conn.id, run_id=run.id) %}
+            {% set active = (status_filter or '') == key %}
+            <a
+              href="{{ href }}"
+              class="rounded-md border px-3 py-1.5 text-sm font-medium {% if active %}border-accent bg-accent text-white{% else %}border-slate-200 text-slate-600 hover:border-accent hover:text-accent dark:border-slate-700 dark:text-slate-300{% endif %}"
+            >{{ label }}</a>
+          {% endfor %}
+        </div>
+      </div>
+
+      {% if run.rows %}
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase text-slate-500 dark:bg-slate-950 dark:text-slate-400">
+              <tr>
+                <th class="px-4 py-3">Таблица</th>
+                <th class="px-4 py-3">Статус</th>
+                <th class="px-4 py-3">Метрики</th>
+                <th class="px-4 py-3">Rows</th>
+                <th class="px-4 py-3">Длительность</th>
+                <th class="px-4 py-3">Причина / ошибка</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-100 dark:divide-slate-800">
+              {% for row in run.rows %}
+                <tr>
+                  <td class="max-w-xs px-4 py-3 font-medium text-slate-900 dark:text-slate-100">
+                    <span class="break-words">{{ row.table_name }}</span>
+                  </td>
+                  <td class="px-4 py-3">{{ row.status_label }}</td>
+                  <td class="px-4 py-3">{{ row.metrics_collected }}</td>
+                  <td class="px-4 py-3">{{ row.rows_observed_label }}</td>
+                  <td class="px-4 py-3">{{ row.duration_label }}</td>
+                  <td class="max-w-md px-4 py-3 text-slate-600 dark:text-slate-300">
+                    {% if row.error_message %}
+                      <span class="break-words text-red-700 dark:text-red-300">{{ row.error_message }}</span>
+                    {% elif row.skip_reason_label %}
+                      {{ row.skip_reason_label }}
+                    {% else %}
+                      —
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <div class="p-10 text-center text-sm text-slate-500 dark:text-slate-400">
+          {% if status_filter %}
+            Для выбранного фильтра строк нет.
+          {% else %}
+            В этом запуске нет table-level строк.
+          {% endif %}
+        </div>
+      {% endif %}
+    </section>
+  </div>
+{% endblock %}

--- a/templates/connections/run_detail.html
+++ b/templates/connections/run_detail.html
@@ -67,8 +67,8 @@
           <div class="mt-1 text-sm font-medium">{{ run.tables_skipped }}</div>
         </div>
         <div class="bg-white p-4 dark:bg-slate-900">
-          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Mode</div>
-          <div class="mt-1 text-sm font-medium">{{ run.mode }}</div>
+          <div class="text-xs font-medium uppercase text-slate-400 dark:text-slate-500">Режим</div>
+          <div class="mt-1 text-sm font-medium">{{ run.mode or "—" }}</div>
         </div>
       </div>
       {% if run.error_message %}
@@ -137,7 +137,9 @@
         </div>
       {% else %}
         <div class="p-10 text-center text-sm text-slate-500 dark:text-slate-400">
-          {% if status_filter %}
+          {% if run.status == 'running' %}
+            Сбор ещё выполняется, строки появятся после завершения.
+          {% elif status_filter %}
             Для выбранного фильтра строк нет.
           {% else %}
             В этом запуске нет table-level строк.

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -112,6 +112,10 @@
                     <span class="font-medium text-blue-700 dark:text-blue-300">{{ c.last_run.status }}</span>
                   {% endif %}
                   <span class="text-slate-400 dark:text-slate-500">· {{ c.last_run.started_at|format_datetime }}</span>
+                  <a
+                    href="{{ url_for('connections.collector_run_detail', slug=project.slug, conn_id=c.id, run_id=c.last_run.id) }}"
+                    class="ml-1 text-accent hover:underline"
+                  >Подробнее</a>
                 {% else %}
                   <span class="text-slate-400 dark:text-slate-500">Сборов ещё не было</span>
                 {% endif %}

--- a/tests/test_collector_run_log.py
+++ b/tests/test_collector_run_log.py
@@ -197,6 +197,95 @@ def test_list_last_runs_for_connections_returns_latest_per_connection(storage):
     assert conn_other["id"] not in runs
 
 
+def test_get_collector_run_detail_scopes_sorts_filters_scrubs_and_limits(storage):
+    project_a, conn_a = _seed_connection(storage, project_id="proj-a")
+    project_b, conn_b = _seed_connection(storage, project_id="proj-b")
+    started = datetime.now(UTC)
+    run_id = uuid.uuid4().hex
+    storage.save_collector_run(run_id, project_a["id"], conn_a["id"], started)
+    storage.update_collector_run(
+        run_id,
+        status="warning",
+        finished_at=started + timedelta(seconds=2),
+        tables_total=104,
+        tables_checked=103,
+        tables_skipped=1,
+        metrics_collected=101,
+        duration_ms=2000,
+        error_message="run failed postgresql://u:secret@db/app?token=abc",
+    )
+    storage.save_run_table(
+        run_id,
+        "Z_success",
+        "success",
+        metrics_collected=1,
+        rows_observed=42,
+        duration_ms=12,
+    )
+    storage.save_run_table(
+        run_id,
+        "A_failed",
+        "failed",
+        error_message="table failed postgresql://u:secret@db/app?token=abc",
+    )
+    storage.save_run_table(
+        run_id,
+        "b_skipped",
+        "skipped",
+        skip_reason="too_large",
+    )
+    for i in range(101):
+        storage.save_run_table(run_id, f"filler_{i:03d}", "success")
+
+    storage.save_collector_run(uuid.uuid4().hex, project_b["id"], conn_b["id"], started)
+
+    detail = storage.get_collector_run_detail(project_a["id"], conn_a["id"], run_id)
+    failed = storage.get_collector_run_detail(
+        project_a["id"],
+        conn_a["id"],
+        run_id,
+        status="failed",
+    )
+
+    assert storage.get_collector_run_detail(project_b["id"], conn_a["id"], run_id) is None
+    assert storage.get_collector_run_detail(project_a["id"], conn_b["id"], run_id) is None
+    assert detail is not None
+    assert detail["rows_total"] == 104
+    assert detail["rows_limit"] == 100
+    assert len(detail["rows"]) == 100
+    assert [row["table_name"] for row in detail["rows"][:3]] == [
+        "A_failed",
+        "b_skipped",
+        "filler_000",
+    ]
+    assert "secret" not in detail["error_message"]
+    assert "token=abc" not in detail["error_message"]
+    assert "secret" not in detail["rows"][0]["error_message"]
+    assert failed["rows_total"] == 1
+    assert [row["status"] for row in failed["rows"]] == ["failed"]
+
+
+def test_get_collector_run_detail_filter_applies_before_limit(storage):
+    project, conn_row = _seed_connection(storage)
+    started = datetime.now(UTC)
+    run_id = uuid.uuid4().hex
+    storage.save_collector_run(run_id, project["id"], conn_row["id"], started)
+    storage.update_collector_run(run_id, status="warning", finished_at=started)
+    for i in range(101):
+        storage.save_run_table(run_id, f"success_{i:03d}", "success")
+    storage.save_run_table(run_id, "late_failed", "failed")
+
+    detail = storage.get_collector_run_detail(
+        project["id"],
+        conn_row["id"],
+        run_id,
+        status="failed",
+    )
+
+    assert detail["rows_total"] == 1
+    assert [row["table_name"] for row in detail["rows"]] == ["late_failed"]
+
+
 def test_cleanup_stale_collector_runs(storage):
     project, conn_row = _seed_connection(storage)
     started = datetime.now(UTC) - timedelta(seconds=2)

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -566,7 +566,8 @@ def test_run_detail_running_run_and_empty_rows(client, monkeypatch):
 
     assert resp.status_code == 200
     assert "Выполняется" in body
-    assert "В этом запуске нет table-level строк." in body
+    assert "Сбор ещё выполняется, строки появятся после завершения." in body
+    assert ">None<" not in body
     assert ">—<" in body
 
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+import uuid
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from cryptography.fernet import Fernet
@@ -146,6 +148,10 @@ def _logout(client):
     client.post("/auth/logout")
 
 
+def _login(client, email="u@example.com", password="supersecret1"):
+    return client.post("/auth/login", data={"email": email, "password": password})
+
+
 def _make_project(client, slug="prod"):
     return client.post("/projects/new", data={"name": "Prod", "slug": slug})
 
@@ -163,17 +169,72 @@ def _add_connection(client, slug="default", name="Local", dsn="postgresql://u:p@
     )
 
 
-def _default_project_and_connection():
+def _default_project_and_connection(email: str = "u@example.com"):
     from app.metrics_storage import (
         get_user_by_email,
         list_connections_for_project,
         list_projects_for_user,
     )
 
-    user = get_user_by_email("u@example.com")
+    user = get_user_by_email(email)
     project = list_projects_for_user(user["id"])[0]
     conn = list_connections_for_project(project["id"])[0]
     return project, conn
+
+
+def _seed_run(
+    project_id: str,
+    connection_id: str,
+    *,
+    status: str = "success",
+    finished: bool = True,
+    table_rows: bool = True,
+) -> str:
+    import app.metrics_storage as storage
+
+    started = datetime(2026, 6, 8, 10, 30, tzinfo=UTC)
+    run_id = uuid.uuid4().hex
+    storage.save_collector_run(run_id, project_id, connection_id, started)
+    if finished:
+        storage.update_collector_run(
+            run_id,
+            status=status,
+            finished_at=started + timedelta(milliseconds=1250),
+            tables_total=3,
+            tables_checked=2,
+            tables_skipped=1,
+            metrics_collected=7,
+            duration_ms=1250,
+            error_message=None,
+        )
+    if table_rows:
+        storage.save_run_table(
+            run_id,
+            "orders",
+            "failed",
+            metrics_collected=0,
+            rows_observed=None,
+            duration_ms=250,
+            error_message="select failed",
+        )
+        storage.save_run_table(
+            run_id,
+            "sessions",
+            "skipped",
+            metrics_collected=0,
+            rows_observed=None,
+            duration_ms=None,
+            skip_reason="too_large",
+        )
+        storage.save_run_table(
+            run_id,
+            "customers",
+            "success",
+            metrics_collected=7,
+            rows_observed=42,
+            duration_ms=1250,
+        )
+    return run_id
 
 
 def _guide_href(html: str) -> str:
@@ -326,6 +387,277 @@ def test_project_detail_shows_connection_status_checklist(client, monkeypatch):
     assert "Последний сбор" in body
     assert "success" in body
     assert "08.06 10:30 UTC" in body
+
+
+def test_project_detail_links_to_collector_run_detail(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 7,
+    })
+    _add_connection(client, name="Production DB")
+    project, conn = _default_project_and_connection()
+    run_id = _seed_run(project["id"], conn["id"], table_rows=False)
+
+    monkeypatch.setattr("collectors.per_project.list_jobs_for_user", lambda scheduler, user_id: [])
+    monkeypatch.setattr("collectors.scheduler.get_scheduler", lambda: None)
+
+    resp = client.get("/projects/default")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "Подробнее" in body
+    assert f"/projects/default/connections/{conn['id']}/runs/{run_id}" in body
+
+
+def test_run_detail_renders_summary_rows_and_human_values(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 3,
+    })
+    _add_connection(client, name="Production DB")
+    project, conn = _default_project_and_connection()
+    run_id = _seed_run(project["id"], conn["id"])
+
+    resp = client.get(f"/projects/default/connections/{conn['id']}/runs/{run_id}")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "Детали сбора" in body
+    assert "Production DB" in body
+    assert "Успешно" in body
+    assert "1.2 с" in body
+    assert "Показано 3 из 3" in body
+    assert body.index("orders") < body.index("sessions") < body.index("customers")
+    assert "Ошибка" in body
+    assert "Пропущена" in body
+    assert "Слишком большая таблица" in body
+    assert ">—<" in body
+
+
+def test_run_detail_filters_rows_and_handles_empty_filter(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 1,
+    })
+    _add_connection(client, name="Production DB")
+    project, conn = _default_project_and_connection()
+    run_id = _seed_run(project["id"], conn["id"], table_rows=False)
+
+    import app.metrics_storage as storage
+    storage.save_run_table(run_id, "orders", "failed", error_message="boom")
+
+    failed = client.get(
+        f"/projects/default/connections/{conn['id']}/runs/{run_id}?status=failed"
+    ).get_data(as_text=True)
+    skipped = client.get(
+        f"/projects/default/connections/{conn['id']}/runs/{run_id}?status=skipped"
+    ).get_data(as_text=True)
+
+    assert "orders" in failed
+    assert "Показано 1 из 1" in failed
+    assert "Для выбранного фильтра строк нет." in skipped
+
+
+def test_run_detail_404_for_foreign_connection_or_run(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 1,
+    })
+    _add_connection(client, name="Primary")
+    _add_connection(client, name="Other")
+    project, conn = _default_project_and_connection()
+
+    import app.metrics_storage as storage
+    conns = storage.list_connections_for_project(project["id"])
+    other_conn = next(c for c in conns if c["id"] != conn["id"])
+    run_id = _seed_run(project["id"], conn["id"], table_rows=False)
+
+    same_project_wrong_conn = client.get(
+        f"/projects/default/connections/{other_conn['id']}/runs/{run_id}"
+    )
+
+    _logout(client)
+    _register(client, email="other@example.com")
+    _add_connection(client, name="Foreign")
+    other_project, other_user_conn = _default_project_and_connection(
+        email="other@example.com",
+    )
+    foreign_run_id = _seed_run(
+        other_project["id"],
+        other_user_conn["id"],
+        table_rows=False,
+    )
+    _logout(client)
+    _login(client)
+
+    foreign_run = client.get(
+        f"/projects/default/connections/{conn['id']}/runs/{foreign_run_id}"
+    )
+
+    assert same_project_wrong_conn.status_code == 404
+    assert foreign_run.status_code == 404
+
+
+def test_run_detail_viewer_can_open(client, monkeypatch):
+    _register(client, email="owner@example.com")
+    _make_project(client, slug="shared-run")
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 1,
+    })
+    _add_connection(client, slug="shared-run", name="Shared DB")
+
+    import app.metrics_storage as storage
+    owner = storage.get_user_by_email("owner@example.com")
+    project = storage.get_project_by_slug(owner["id"], "shared-run")
+    conn = storage.list_connections_for_project(project["id"])[0]
+    run_id = _seed_run(project["id"], conn["id"], table_rows=False)
+
+    _logout(client)
+    _register(client, email="viewer@example.com")
+    viewer = storage.get_user_by_email("viewer@example.com")
+    storage.add_project_member(project["id"], viewer["id"], "viewer")
+
+    resp = client.get(f"/projects/shared-run/connections/{conn['id']}/runs/{run_id}")
+
+    assert resp.status_code == 200
+    assert "Детали сбора" in resp.get_data(as_text=True)
+
+
+def test_run_detail_running_run_and_empty_rows(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 1,
+    })
+    _add_connection(client, name="Running DB")
+    project, conn = _default_project_and_connection()
+    run_id = _seed_run(
+        project["id"],
+        conn["id"],
+        finished=False,
+        table_rows=False,
+    )
+
+    resp = client.get(f"/projects/default/connections/{conn['id']}/runs/{run_id}")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "Выполняется" in body
+    assert "В этом запуске нет table-level строк." in body
+    assert ">—<" in body
+
+
+def test_run_detail_no_secrets_in_html(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 1,
+    })
+    _add_connection(client, name="Secret DB")
+    project, conn = _default_project_and_connection()
+    run_id = _seed_run(project["id"], conn["id"], table_rows=False)
+
+    import app.metrics_storage as storage
+    storage.save_run_table(
+        run_id,
+        "orders",
+        "failed",
+        error_message=(
+            "postgresql://user:secret@db/app?token=abc "
+            "Authorization: Bearer very-secret-token "
+            f"bot=1234567890:{'A' * 35}"
+        ),
+    )
+
+    resp = client.get(f"/projects/default/connections/{conn['id']}/runs/{run_id}")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "secret@db" not in body
+    assert "token=abc" not in body
+    assert "very-secret-token" not in body
+    assert "A" * 35 not in body
+    assert "***" in body
+
+
+def test_run_detail_skipped_without_reason_uses_dash(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 1,
+    })
+    _add_connection(client, name="Skipped DB")
+    project, conn = _default_project_and_connection()
+    run_id = _seed_run(project["id"], conn["id"], table_rows=False)
+
+    import app.metrics_storage as storage
+    storage.save_run_table(
+        run_id,
+        "orders",
+        "skipped",
+    )
+
+    resp = client.get(f"/projects/default/connections/{conn['id']}/runs/{run_id}")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "Пропущена" in body
+    assert ">—<" in body
+
+
+def test_run_detail_shows_limited_count(client, monkeypatch):
+    _register(client)
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kwargs: {
+        "status": "ok",
+        "database": "app",
+        "version": "PostgreSQL",
+        "latency_ms": 5,
+        "tables_found": 101,
+    })
+    _add_connection(client, name="Large DB")
+    project, conn = _default_project_and_connection()
+    run_id = _seed_run(project["id"], conn["id"], table_rows=False)
+
+    import app.metrics_storage as storage
+    for i in range(101):
+        storage.save_run_table(run_id, f"table_{i:03d}", "success")
+
+    resp = client.get(f"/projects/default/connections/{conn['id']}/runs/{run_id}")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "Показано 100 из 101" in body
+    assert "table_099" in body
+    assert "table_100" not in body
 
 
 def test_project_detail_shows_next_scheduled_run(client, monkeypatch):


### PR DESCRIPTION
Closes #252

## Описание

Добавляет страницу детализации table-level результатов collector run.

### Что сделано

- Добавлен scoped storage helper `get_collector_run_detail()`:
  - проверка `project_id + connection_id + run_id`
  - фильтр `status=failed|skipped|success`
  - лимит 100 строк и `rows_total`
  - сортировка `failed → skipped → success → LOWER(table_name)`
  - scrub `error_message` на уровне run и table rows
- Добавлен read-only route:
  - `GET /projects/<slug>/connections/<connection_id>/runs/<run_id>`
  - доступен owner/editor/viewer через существующий project membership scope
  - foreign run / foreign connection возвращают 404
- Добавлен UI:
  - ссылка `Подробнее` у последнего сбора на странице проекта
  - summary запуска: статус, started/finished, duration, tables, metrics, mode
  - table-level таблица с фильтрами по статусам
  - empty states для running/no rows/empty filter
  - humanized duration и `—` для отсутствующих значений
  - отображение `Показано 100 из N` при лимите

## Что не делаем в этом PR

- Не добавляем пагинацию / show more
- Не добавляем API endpoint
- Не меняем collector schema
- Не меняем глобальный contract Telegram scrubber: bot id остается публичной частью, hash маскируется

## Тесты

- `python -m ruff check app/connections.py app/metrics_storage.py tests/test_collector_run_log.py tests/test_connections.py`
- `python -m pytest tests/test_collector_run_log.py tests/test_connections.py`
- `PATH=/Users/ks_dergach/Desktop/db-monitoring/venv/bin:$PATH python -m pytest`

Полный локальный прогон: `967 passed, 6 skipped, 17 deselected`.
