### PR TITLE
fix(#280): FF_LLM_NOTIFICATIONS — отключить NIM в авто-уведомлениях по умолчанию

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,3 +86,12 @@ FLASK_ENV=development
 # и quota. Bump до 1.0 на staging, downsample до 0.01 на high-traffic prod.
 #   SENTRY_TRACES_SAMPLE_RATE=0.1
 #   SENTRY_PROFILES_SAMPLE_RATE=0.1
+
+# --- Feature flags --------------------------------------------------------
+#
+# FF_LLM_NOTIFICATIONS — вызывать NIM в теле Telegram-алёртов об аномалиях.
+# По умолчанию выключен: уведомления используют rule-based fallback,
+# токены NIM не расходуются. Включить только если нужно LLM-объяснение
+# прямо в Telegram (например, на демо).
+# Клики на аномалию в UI всегда вызывают NIM независимо от этого флага.
+#   FF_LLM_NOTIFICATIONS=1

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ venv/
 __pycache__/
 *.pyc
 monitor.db
+monitor.db.*
+env.txt
+.mcp.json
 models/*
 !models/.gitkeep
 .DS_Store

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -26,6 +26,7 @@ from sqlalchemy import text
 from telegram import Bot
 from telegram.error import TelegramError
 
+from app.feature_flags import is_enabled
 from app.llm import explain_anomaly
 from app.metrics_storage import (
     get_engine,
@@ -137,9 +138,12 @@ def notify_anomaly(
         return
 
     project_label = _project_label(project_id)
-    result = explain_anomaly(table, metric, ts, project_id=project_id)
-    is_llm = result.get("confidence", 0) > _RULE_BASED_CONFIDENCE
-    body = result.get("explanation", "Требуется ручная проверка данных.") if is_llm else "Требуется ручная проверка данных."
+    if is_enabled("llm_notifications"):
+        result = explain_anomaly(table, metric, ts, project_id=project_id)
+        is_llm = result.get("confidence", 0) > _RULE_BASED_CONFIDENCE
+        body = result.get("explanation", "Требуется ручная проверка данных.") if is_llm else "Требуется ручная проверка данных."
+    else:
+        body = "Требуется ручная проверка данных."
 
     text = (
         f"\U0001f6a8 DB Monitor: аномалия\n"

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -146,6 +146,7 @@ def _explain_stub(monkeypatch, *, confidence=0.85, explanation="ETL сбой"):
 
 
 def test_notify_anomaly_sends_message(storage, monkeypatch):
+    monkeypatch.setenv("FF_LLM_NOTIFICATIONS", "1")
     _explain_stub(monkeypatch)
     with patch("app.notifications.telegram.send_message",
                return_value=(True, None)) as mock_send:
@@ -164,6 +165,21 @@ def test_notify_anomaly_sends_message(storage, monkeypatch):
     # bot_token/chat_id flow through to send_message.
     assert mock_send.call_args.kwargs["bot_token"] == "tok"
     assert mock_send.call_args.kwargs["chat_id"] == "42"
+
+
+def test_notify_anomaly_llm_flag_disabled(storage, monkeypatch):
+    monkeypatch.delenv("FF_LLM_NOTIFICATIONS", raising=False)
+    mock_explain = MagicMock(return_value={"explanation": "ETL сбой", "confidence": 0.85})
+    monkeypatch.setattr("app.notifications.telegram.explain_anomaly", mock_explain)
+    with patch("app.notifications.telegram.send_message",
+               return_value=(True, None)) as mock_send:
+        notify_anomaly(_PID, "orders", _ts(), -0.14,
+                       bot_token="tok", chat_id="42")
+    mock_send.assert_called_once()
+    text = mock_send.call_args[0][0]
+    assert "ETL сбой" not in text
+    assert "Требуется ручная проверка данных." in text
+    mock_explain.assert_not_called()
 
 
 def test_notify_anomaly_no_config_records_failure_no_send(storage, monkeypatch):
@@ -193,6 +209,7 @@ def test_notify_anomaly_fallback_message(storage, monkeypatch):
 
 
 def test_notify_anomaly_passes_raw_ts_and_metric_to_explain(storage, monkeypatch):
+    monkeypatch.setenv("FF_LLM_NOTIFICATIONS", "1")
     received = {}
 
     def capture(t, m, ts, project_id="legacy"):
@@ -212,7 +229,6 @@ def test_notify_anomaly_passes_raw_ts_and_metric_to_explain(storage, monkeypatch
 
 
 def test_notify_anomaly_message_contains_score(storage, monkeypatch):
-    _explain_stub(monkeypatch, confidence=0.3)
     with patch("app.notifications.telegram.send_message",
                return_value=(True, None)) as mock_send:
         notify_anomaly(_PID, "orders", _ts(), -0.25,


### PR DESCRIPTION
## Описание

Closes #280.

Без флага NIM вызывался при каждой автоматической отправке Telegram-алёрта об аномалии — бесконтрольный расход токенов при любом активном мониторинге.

Добавлен feature flag `FF_LLM_NOTIFICATIONS` в `notify_anomaly()`:
- По умолчанию `false` — уведомления используют rule-based fallback, NIM не вызывается
- `FF_LLM_NOTIFICATIONS=1` в `.env` — поведение как раньше, LLM-объяснение в теле алёрта

Клики на аномалию в UI (`/api/anomaly/root_cause/`) флагом не затрагиваются.

## Тип изменения

- [x] Bug fix

## Чеклист

- [ ] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы