### PR TITLE
Исправить ClickHouse-сбор в timeout-потоке

### DIFF
--- a/collectors/per_project.py
+++ b/collectors/per_project.py
@@ -194,11 +194,13 @@ def _run_with_timeout(fn, *args, timeout: float | None = None, **kwargs):
     looked up at call time so monkeypatching that constant works in tests.
     """
     import concurrent.futures
+    from contextvars import copy_context
 
     if timeout is None:
         timeout = _METADATA_CALL_TIMEOUT_S
+    ctx = copy_context()
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        future = pool.submit(fn, *args, **kwargs)
+        future = pool.submit(ctx.run, fn, *args, **kwargs)
         try:
             return future.result(timeout=timeout)
         except concurrent.futures.TimeoutError as exc:

--- a/tests/test_per_project.py
+++ b/tests/test_per_project.py
@@ -18,6 +18,7 @@ from cryptography.fernet import Fernet
 
 from app import crypto
 from collectors.per_project import (
+    _run_with_timeout,
     add_job_for_connection,
     collect_for_connection,
     job_id_for,
@@ -112,6 +113,27 @@ def test_parse_job_id_returns_none_for_non_collect_ids():
     assert parse_job_id("collect_all_tables") is None
     assert parse_job_id("retrain_forecasts") is None
     assert parse_job_id("collect:single") is None
+
+
+def test_run_with_timeout_preserves_db_contextvars():
+    """Regression for #282: metadata calls run in a worker thread, so the
+    per-connection engine/adapter context must be copied explicitly."""
+    from sqlalchemy import create_engine
+
+    import app.db as db_mod
+
+    engine = create_engine("sqlite:///:memory:")
+    adapter = db_mod.PostgresAdapter()
+    try:
+        with db_mod.using_engine(engine, adapter):
+            seen_engine, seen_adapter = _run_with_timeout(
+                lambda: (db_mod.get_engine(), db_mod.get_adapter()),
+            )
+    finally:
+        engine.dispose()
+
+    assert seen_engine is engine
+    assert seen_adapter is adapter
 
 
 # --- add_job_for_connection / remove ---------------------------------------


### PR DESCRIPTION
Closes #282

## Описание

Исправлен ClickHouse-сбор для per-project collector: metadata-вызовы внутри `_run_with_timeout()` теперь сохраняют `ContextVar`-контекст `db.using_engine()` при переходе в worker thread.

Без этого ClickHouseAdapter мог выполнять `FROM system.tables` через глобальный Postgres `DATABASE_URL`, что давало ошибку `psycopg2.errors.UndefinedTable: relation "system.tables" does not exist`.

## Что изменилось

- `_run_with_timeout()` переносит текущий контекст через `contextvars.copy_context()`.
- Добавлен regression test на видимость per-connection engine/adapter внутри timeout worker thread.

## Проверка

- `venv/bin/python -m pytest tests/test_per_project.py::test_run_with_timeout_preserves_db_contextvars -q`
- `venv/bin/python -m pytest tests/test_per_project.py -q`
- Проверено в UI: Events ClickHouse → Local ClickHouse → Детали сбора, статус успешный, 4 таблицы, 66 метрик, ошибки `system.tables` нет.