### PR TITLE
fix(#284): UI — пустые состояния и косметические правки перед демо

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -380,16 +380,9 @@ def register():
         next_target = _safe_next(request.args.get("next"))
         if next_target and next_target.startswith("/invite/"):
             return redirect(next_target)
-        # Auto-create the "Default" project (#50 acceptance) so the new
-        # user never sees an empty projects switcher. Lazy import to avoid
-        # a circular dependency (projects → auth.User for current_user).
-        from app.projects import create_default_project_for
-        default_project = create_default_project_for(row["id"])
         if next_target:
             return redirect(next_target)
-        return redirect(url_for(
-            "connections.new_connection", slug=default_project["slug"],
-        ))
+        return redirect(url_for("projects.new_project", onboarding=1))
     return render_template("auth/register.html", form=form)
 
 

--- a/app/connections.py
+++ b/app/connections.py
@@ -169,17 +169,36 @@ class ConnectionForm(FlaskForm):
 
 
 class ConnectionSafetyForm(FlaskForm):
-    """#256: один редактор load-safety, collection_mode и Iceberg-настроек
-    существующего подключения. Имя/DSN/schema тут НЕ редактируются —
-    их смена ломает сбор метрик и должна идти через delete + new.
+    """Редактор подключения: основные поля + load-safety + collection_mode + Iceberg.
 
     Empty string у numeric/optional полей = NULL в БД (== «без ограничения»
     / «default»). Это интерпретируется в роуте, не в форме, чтобы валидация
     оставалась узкой.
     """
+    # Основные поля (name/schema — owner+editor; dsn — только owner).
+    conn_name = StringField(
+        "Название подключения",
+        validators=[Optional(), Length(min=1, max=80)],
+        render_kw={"autocomplete": "off"},
+    )
+    schema_name = StringField(
+        "Схема",
+        validators=[Optional(), Length(min=1, max=64)],
+    )
+    dsn = StringField(
+        "DSN подключения (оставьте пустым, чтобы не менять)",
+        validators=[Optional(), Length(min=10, max=2000)],
+        render_kw={
+            "type": "password",
+            "autocomplete": "new-password",
+            "autocapitalize": "none",
+            "spellcheck": "false",
+        },
+    )
+
     # #232 load safety — для всех диалектов.
     table_allowlist = TextAreaField(
-        "Allowlist таблиц",
+        "Разрешённые таблицы",
         validators=[Optional(), Length(max=10_000)],
         render_kw={
             "rows": 4,
@@ -187,22 +206,22 @@ class ConnectionSafetyForm(FlaskForm):
         },
     )
     table_denylist = TextAreaField(
-        "Denylist таблиц",
+        "Исключённые таблицы",
         validators=[Optional(), Length(max=10_000)],
         render_kw={"rows": 4, "placeholder": "audit_logs\nevents_raw"},
     )
     max_tables_per_tick = IntegerField(
-        "Max таблиц за тик",
+        "Макс. таблиц за тик",
         validators=[Optional(), NumberRange(min=1, max=500)],
         default=50,
     )
     skip_tables_larger_than_gb = StringField(
-        "Skip таблиц > N GB (Postgres)",
+        "Пропускать таблицы > N ГБ (Postgres)",
         validators=[Optional(), Length(max=16)],
         render_kw={"placeholder": "10 (пусто = без ограничения)"},
     )
     statement_timeout_ms = IntegerField(
-        "statement_timeout (мс, Postgres)",
+        "Таймаут запроса (мс, Postgres)",
         validators=[Optional(), NumberRange(min=1000, max=600_000)],
         default=30_000,
     )
@@ -505,7 +524,12 @@ def edit_safety(slug: str, conn_id: str):
 
     form = ConnectionSafetyForm()
 
+    dsn_masked = mask_dsn(plain_dsn)
+
     if request.method == "GET":
+        form.conn_name.data = conn.get("name", "")
+        form.schema_name.data = conn.get("schema_name", "")
+        # DSN intentionally left blank — shown as placeholder hint only.
         form.table_allowlist.data = _jsonlist_to_textarea(conn.get("table_allowlist"))
         form.table_denylist.data = _jsonlist_to_textarea(conn.get("table_denylist"))
         form.max_tables_per_tick.data = conn.get("max_tables_per_tick")
@@ -521,6 +545,29 @@ def edit_safety(slug: str, conn_id: str):
         form.iceberg_warehouse.data = conn.get("iceberg_warehouse") or ""
 
     if form.validate_on_submit():
+        # --- Основные поля (name, schema, dsn) ---
+        basics_name = (form.conn_name.data or "").strip() or None
+        basics_schema = (form.schema_name.data or "").strip() or None
+        new_dsn_raw = (form.dsn.data or "").strip()
+        new_dsn_encrypted: str | None = None
+        dsn_changed = False
+        if new_dsn_raw and role == "owner":
+            new_dsn_encrypted = crypto.encrypt_dsn(new_dsn_raw)
+            dsn_changed = True
+            # Re-derive dialect from the new DSN.
+            is_iceberg = new_dsn_raw.lower().startswith("iceberg+")
+            is_postgres = new_dsn_raw.lower().startswith(
+                ("postgres://", "postgresql://", "postgresql+"),
+            )
+        if basics_name or basics_schema or new_dsn_encrypted:
+            metrics_storage.update_connection_basics(
+                project_id=project["id"],
+                connection_id=conn["id"],
+                name=basics_name,
+                schema_name=basics_schema,
+                dsn_encrypted=new_dsn_encrypted,
+            )
+
         updates: dict[str, object] = {}
         updates["table_allowlist"] = _textarea_to_jsonlist(form.table_allowlist.data)
         updates["table_denylist"] = _textarea_to_jsonlist(form.table_denylist.data)
@@ -585,6 +632,14 @@ def edit_safety(slug: str, conn_id: str):
         metrics_storage.update_connection_safety(
             project_id=project["id"], connection_id=conn["id"], updates=updates,
         )
+        if dsn_changed:
+            result = probe_connection(
+                new_dsn_raw,
+                iceberg_namespace=conn.get("iceberg_namespace"),
+                iceberg_warehouse=conn.get("iceberg_warehouse"),
+            )
+            _persist_probe_result(project["id"], conn["id"], result)
+
         flash("Настройки сохранены.", "success")
         return redirect(url_for("connections.list_connections", slug=slug))
 
@@ -592,6 +647,7 @@ def edit_safety(slug: str, conn_id: str):
         "connections/edit.html",
         project=project, conn=conn, form=form,
         is_iceberg=is_iceberg, is_postgres=is_postgres,
+        role=role, dsn_masked=dsn_masked,
     )
 
 

--- a/app/connections.py
+++ b/app/connections.py
@@ -460,7 +460,10 @@ def new_connection(slug: str):
     template = (
         "onboarding/add_connection.html" if is_first else "connections/new.html"
     )
-    return render_template(template, project=project, form=form)
+    return render_template(
+        template, project=project, form=form,
+        onboarding=bool(request.args.get("onboarding")),
+    )
 
 
 @bp.route("/<conn_id>/edit", methods=["GET", "POST"])

--- a/app/connections.py
+++ b/app/connections.py
@@ -1025,11 +1025,24 @@ def _probe_clickhouse(dsn: str) -> dict:
         with engine.connect() as conn:
             conn.execute(text("SELECT 1"))
             row = conn.execute(text("SELECT version()")).fetchone()
+            try:
+                t_rows = conn.execute(text(
+                    "SELECT name FROM system.tables "
+                    "WHERE database = currentDatabase() "
+                    "ORDER BY name LIMIT 10"
+                )).fetchall()
+                tables_preview = [r[0] for r in t_rows]
+                tables_found = len(tables_preview)
+            except Exception:
+                tables_preview = []
+                tables_found = 0
         latency_ms = int((time.monotonic() - started) * 1000)
         return {
             "status": "ok",
             "database": "clickhouse",
             "version": str(row[0]) if row and row[0] else "unknown",
+            "tables_found": tables_found,
+            "tables_preview": tables_preview,
             "latency_ms": latency_ms,
         }
     except SQLAlchemyError as exc:

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -11,6 +11,7 @@ from app import crypto, db
 from app.metrics_storage import (
     build_history_aggregate,
     count_notifications,
+    get_engine,
     get_history_daily,
     get_history_insights,
     get_history_runs,
@@ -18,6 +19,7 @@ from app.metrics_storage import (
     get_latest_null_counts,
     get_notifications,
     get_schema_events,
+    list_last_runs_for_connections,
 )
 
 logger = logging.getLogger(__name__)
@@ -154,6 +156,52 @@ bp = Blueprint(
 )
 
 
+def _build_project_status(project_id: str, connections: list[dict]) -> dict | None:
+    """Агрегированный статус проекта для status-first блока на обзоре.
+    Возвращает None если подключений нет."""
+    if not connections:
+        return None
+
+    conn_ids = [c["id"] for c in connections]
+    last_runs = list_last_runs_for_connections(project_id, conn_ids)
+    last_run = None
+    if last_runs:
+        last_run = max(last_runs.values(), key=lambda r: r.get("started_at") or "")
+
+    since_7d = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+    anomalies_7d = 0
+    schema_changes_7d = 0
+    try:
+        from sqlalchemy import text as _text
+        with get_engine().connect() as conn:
+            anomalies_7d = conn.execute(_text(
+                "SELECT COUNT(*) FROM anomaly_scores "
+                "WHERE project_id = :pid AND is_anomaly = 1 AND ts >= :since"
+            ), {"pid": project_id, "since": since_7d}).scalar() or 0
+            schema_changes_7d = conn.execute(_text(
+                "SELECT COUNT(*) FROM schema_events "
+                "WHERE project_id = :pid AND ts >= :since"
+            ), {"pid": project_id, "since": since_7d}).scalar() or 0
+    except Exception as exc:
+        logger.warning("project status query failed: %s", exc)
+
+    if last_run and last_run.get("status") == "error":
+        status = "error"
+    elif int(anomalies_7d) > 0 or int(schema_changes_7d) > 0:
+        status = "warning"
+    else:
+        status = "ok"
+
+    return {
+        "status": status,
+        "last_run_at": last_run.get("started_at") if last_run else None,
+        "last_run_status": last_run.get("status") if last_run else None,
+        "tables_checked": int(last_run.get("tables_checked") or 0) if last_run else 0,
+        "anomalies_7d": int(anomalies_7d),
+        "schema_changes_7d": int(schema_changes_7d),
+    }
+
+
 @bp.route("")
 @bp.route("/")
 def overview():
@@ -193,14 +241,16 @@ def overview():
         "avg_null_rate": sum(null_rates) / len(null_rates) if null_rates else 0.0,
         "has_metrics": bool(null_rates),
     }
+    project_id = _current_project_id()
     return render_template(
         "overview.html",
         tables=tables,
         summary=summary,
         ml_last_runs={} if (needs_first_project or needs_first_connection)
-        else _ml_last_runs(_current_project_id()),
+        else _ml_last_runs(project_id),
         needs_first_project=needs_first_project,
         needs_first_connection=needs_first_connection,
+        project_status=None if skip_tables else _build_project_status(project_id, connections),
     )
 
 

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -191,6 +191,7 @@ def overview():
         "table_count": len(tables),
         "total_rows": total_rows,
         "avg_null_rate": sum(null_rates) / len(null_rates) if null_rates else 0.0,
+        "has_metrics": bool(null_rates),
     }
     return render_template(
         "overview.html",

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -156,7 +156,7 @@ bp = Blueprint(
 )
 
 
-def _build_project_status(project_id: str, connections: list[dict]) -> dict | None:
+def _build_project_status(project_id: str, connections: list[dict], has_metrics: bool = False) -> dict | None:
     """Агрегированный статус проекта для status-first блока на обзоре.
     Возвращает None если подключений нет."""
     if not connections:
@@ -185,7 +185,9 @@ def _build_project_status(project_id: str, connections: list[dict]) -> dict | No
     except Exception as exc:
         logger.warning("project status query failed: %s", exc)
 
-    if last_run and last_run.get("status") == "error":
+    if last_run is None or (not has_metrics and last_run.get("status") != "error"):
+        status = "pending"
+    elif last_run.get("status") == "error":
         status = "error"
     elif int(anomalies_7d) > 0 or int(schema_changes_7d) > 0:
         status = "warning"
@@ -250,7 +252,7 @@ def overview():
         else _ml_last_runs(project_id),
         needs_first_project=needs_first_project,
         needs_first_connection=needs_first_connection,
-        project_status=None if skip_tables else _build_project_status(project_id, connections),
+        project_status=None if skip_tables else _build_project_status(project_id, connections, has_metrics=bool(null_rates)),
     )
 
 

--- a/app/metrics_storage.py
+++ b/app/metrics_storage.py
@@ -2640,6 +2640,41 @@ _SAFETY_COLUMNS = frozenset({
 })
 
 
+def update_connection_basics(
+    *,
+    project_id: str,
+    connection_id: str,
+    name: str | None = None,
+    schema_name: str | None = None,
+    dsn_encrypted: str | None = None,
+) -> bool:
+    """Update name / schema_name / dsn_encrypted for a connection.
+
+    Only fields that are not None are written. Returns True if a row was
+    actually updated.
+    """
+    fields: dict[str, object] = {}
+    if name is not None:
+        fields["name"] = name
+    if schema_name is not None:
+        fields["schema_name"] = schema_name
+    if dsn_encrypted is not None:
+        fields["dsn_encrypted"] = dsn_encrypted
+    if not fields:
+        return False
+    set_clause = ", ".join(f"{col} = :{col}" for col in fields)
+    params: dict[str, object] = {**fields, "id": connection_id, "pid": project_id}
+    with get_engine().begin() as conn:
+        result = conn.execute(
+            text(
+                f"UPDATE connections SET {set_clause} "
+                "WHERE id = :id AND project_id = :pid"
+            ),
+            params,
+        )
+    return (result.rowcount or 0) > 0
+
+
 def delete_connection(project_id: str, connection_id: str) -> bool:
     """Hard delete. Returns True if a row was removed."""
     stmt = text(

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -24,7 +24,14 @@ import logging
 
 from sqlalchemy import text
 from telegram import Bot
-from telegram.error import TelegramError
+from telegram.error import (
+    Forbidden,
+    InvalidToken,
+    NetworkError,
+    RetryAfter,
+    TelegramError,
+    TimedOut,
+)
 
 from app.feature_flags import is_enabled
 from app.llm import explain_anomaly
@@ -59,12 +66,21 @@ def send_message(
     try:
         asyncio.run(_send())
         return True, None
+    except (InvalidToken, Forbidden) as exc:
+        logger.warning("Telegram send failed (auth): %s", exc)
+        return False, "Неверный токен бота — обновите настройки Telegram"
+    except RetryAfter as exc:
+        logger.warning("Telegram send failed (rate limit): %s", exc)
+        return False, "Превышен лимит отправки Telegram — сообщение будет повторено позже"
+    except (NetworkError, TimedOut) as exc:
+        logger.warning("Telegram send failed (network): %s", exc)
+        return False, "Ошибка сети при отправке в Telegram — проверьте доступность сервера"
     except TelegramError as exc:
         logger.warning("Telegram send failed: %s", exc)
-        return False, f"telegram_error: {exc}"
+        return False, "Ошибка Telegram — сообщение не доставлено"
     except Exception as exc:
         logger.warning("Telegram send error: %s", exc)
-        return False, f"error: {exc}"
+        return False, "Внутренняя ошибка при отправке уведомления"
 
 
 def _record(

--- a/app/projects.py
+++ b/app/projects.py
@@ -115,6 +115,8 @@ def new_project():
             return render_template("projects/new.html", form=form), 409
         # New project becomes the current one — saves a click.
         session["current_project_id"] = project["id"]
+        if request.args.get("onboarding"):
+            return redirect(url_for("connections.new_connection", slug=slug, onboarding=1))
         flash(f"Проект «{name}» создан.", "success")
         return redirect(url_for("projects.detail", slug=slug))
     return render_template("projects/new.html", form=form)

--- a/templates/base.html
+++ b/templates/base.html
@@ -132,6 +132,14 @@
               <svg class="h-4 w-4 dark:hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>
               <svg class="hidden h-4 w-4 dark:block" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path stroke-linecap="round" d="M12 2v2M12 20v2M2 12h2M20 12h2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
             </button>
+            {% if current_user.is_authenticated %}
+              <div class="relative group flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent text-white text-sm font-semibold cursor-default select-none">
+                {{ current_user.email[0] | upper }}
+                <div class="absolute right-0 top-10 hidden group-hover:block z-50 min-w-max rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+                  <p class="text-sm text-slate-500 dark:text-slate-400">{{ current_user.email }}</p>
+                </div>
+              </div>
+            {% endif %}
           </div>
         </header>
         <main class="flex-1 overflow-y-auto px-6 py-6">

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,6 @@
             ("/dashboard", "Обзор", "M3 12 12 3l9 9M5 10v10h14V10", "exact"),
             ("/dashboard/schema", "Схема", "M4 7h16M4 12h16M4 17h10", "exact"),
             ("/dashboard/history", "История", "M12 8v4l3 3M4 4h16M4 20h16", "exact"),
-            ("/dashboard/notifications", "Уведомления", "M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2c0 .5-.2 1-.6 1.4L4 17h5m6 0a3 3 0 1 1-6 0", "exact"),
           ] %}
           {# Folder icon — distinct from the Схема hamburger so the
              sidebar rail scans cleanly. #}
@@ -80,6 +79,12 @@
               </a>
             {% endif %}
           {% endif %}
+          {% set notif_url = "/dashboard/notifications" %}
+          {% set notif_active = request.path == notif_url %}
+          <a href="{{ notif_url }}" class="flex items-center gap-2 rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 {% if notif_active %}bg-slate-100 font-medium text-slate-900 dark:bg-slate-800 dark:text-white{% endif %}">
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 1 0-12 0v3.2c0 .5-.2 1-.6 1.4L4 17h5m6 0a3 3 0 1 1-6 0" /></svg>
+            Уведомления
+          </a>
         </nav>
       </aside>
 

--- a/templates/connections/edit.html
+++ b/templates/connections/edit.html
@@ -15,20 +15,39 @@
 {% set pg_disabled = not is_postgres %}
 
 {% block content %}
-  <h1 class="text-2xl font-semibold tracking-tight">Настройки нагрузки — {{ conn.name }}</h1>
-  <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
-    Имя, DSN и schema редактируются через delete + new. Здесь — только load-safety, режим сбора и Iceberg-параметры.
-  </p>
+  <h1 class="text-2xl font-semibold tracking-tight">Настройки подключения — {{ conn.name }}</h1>
 
   <div class="mt-4">{% include "_flash.html" %}</div>
 
-  <form method="POST" class="mt-6 max-w-2xl space-y-6" novalidate>
+  <form method="POST" class="mt-6 space-y-6" novalidate>
     {{ form.hidden_tag() }}
+
+    {# --- Основные настройки (owner + editor) -------------------------------- #}
+    {% if role in ('owner', 'editor') %}
+    <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        Основные настройки
+      </h2>
+      <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {{ render_field(form.conn_name, input_class=input_cls) }}
+        {{ render_field(form.schema_name, input_class=input_cls) }}
+      </div>
+      {% if role == 'owner' %}
+      <div class="mt-4">
+        {{ form.dsn.label(class="block text-sm font-medium text-slate-700 dark:text-slate-200") }}
+        {{ form.dsn(class=input_cls, placeholder="•••••• (текущий DSN сохранён, оставьте пустым чтобы не менять)") }}
+        <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          Оставьте пустым, чтобы не менять. После сохранения нового DSN автоматически запустится проверка подключения.
+        </p>
+      </div>
+      {% endif %}
+    </section>
+    {% endif %}
 
     {# --- #232 Load safety (all dialects) ---------------------------------- #}
     <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-        Load safety
+        Ограничения сбора
       </h2>
 
       <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/templates/connections/list.html
+++ b/templates/connections/list.html
@@ -27,7 +27,6 @@
         <div class="grid grid-cols-12 items-center gap-3 px-5 py-4 text-sm" data-conn-id="{{ c.id }}">
           <div class="col-span-4 min-w-0">
             <div class="font-medium">{{ c.name }}</div>
-            <div class="truncate font-mono text-xs text-slate-500 dark:text-slate-400">{{ c.dsn_masked }}</div>
           </div>
           <div class="col-span-2 text-xs text-slate-500 dark:text-slate-400">
             <span class="font-mono">{{ c.schema_name }}</span><br>
@@ -42,35 +41,26 @@
           </div>
           <div class="col-span-4 flex items-center justify-end gap-2">
             {% if project.role in ('owner', 'editor') %}
+              {% set btn = "inline-flex h-7 items-center whitespace-nowrap rounded-md border border-slate-200 px-3 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800" %}
               <a href="{{ url_for('connections.edit_safety', slug=project.slug, conn_id=c.id) }}"
-                 class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
-                Настройки
-              </a>
+                 class="{{ btn }}">Настройки</a>
               <button type="button"
                       data-test-url="{{ url_for('connections.test_connection', slug=project.slug, conn_id=c.id) }}"
                       data-csrf="{{ csrf_token() }}"
-                      class="js-test-conn rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
-                Тест
-              </button>
+                      class="js-test-conn {{ btn }}">Тест</button>
               <form method="POST" action="{{ url_for('connections.run_now', slug=project.slug, conn_id=c.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit"
-                        class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
-                  Запустить сбор
-                </button>
+                <button type="submit" class="{{ btn }}">Запустить сбор</button>
               </form>
               <form method="POST" action="{{ url_for('connections.toggle', slug=project.slug, conn_id=c.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit"
-                        class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
-                  {{ "Выключить" if c.is_active else "Включить" }}
-                </button>
+                <button type="submit" class="{{ btn }}">{{ "Выключить" if c.is_active else "Включить" }}</button>
               </form>
               <form method="POST" action="{{ url_for('connections.delete', slug=project.slug, conn_id=c.id) }}"
                     onsubmit="return confirm('Удалить подключение «{{ c.name }}»?');">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit"
-                        class="rounded-md border border-red-200 px-3 py-1 text-xs text-red-600 hover:bg-red-50 dark:border-red-900/40 dark:text-red-400 dark:hover:bg-red-950/30">
+                        class="inline-flex h-7 items-center whitespace-nowrap rounded-md border border-red-200 px-3 text-xs text-red-600 hover:bg-red-50 dark:border-red-900/40 dark:text-red-400 dark:hover:bg-red-950/30">
                   Удалить
                 </button>
               </form>

--- a/templates/onboarding/add_connection.html
+++ b/templates/onboarding/add_connection.html
@@ -1,17 +1,31 @@
 {% extends "base.html" %}
 {% from "auth/_macros.html" import render_field %}
 {% block title %}Добавьте первое подключение — DB Monitor{% endblock %}
-{% block breadcrumb %}<span class="font-medium text-slate-700 dark:text-slate-200">Шаг 1 из 1 — добавьте подключение</span>{% endblock %}
+{% block breadcrumb %}
+  {% if onboarding %}
+    <span class="font-medium text-slate-700 dark:text-slate-200">Шаг 2 из 2 — добавьте подключение</span>
+  {% else %}
+    <a href="{{ url_for('projects.list_projects') }}" class="hover:text-slate-700 dark:hover:text-slate-200">Проекты</a>
+    <span class="text-slate-300 dark:text-slate-600">/</span>
+    <a href="{{ url_for('projects.detail', slug=project.slug) }}" class="hover:text-slate-700 dark:hover:text-slate-200">{{ project.name }}</a>
+    <span class="text-slate-300 dark:text-slate-600">/</span>
+    <a href="{{ url_for('connections.list_connections', slug=project.slug) }}" class="hover:text-slate-700 dark:hover:text-slate-200">Подключения</a>
+    <span class="text-slate-300 dark:text-slate-600">/</span>
+    <span class="font-medium text-slate-700 dark:text-slate-200">Новое</span>
+  {% endif %}
+{% endblock %}
 
 {% set input_cls = "mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent dark:border-slate-700 dark:bg-slate-950" %}
 
 {% block content %}
   <div class="mx-auto max-w-3xl">
 
+    {% if not onboarding %}
     <div class="rounded-xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-200">
       <strong>Аккаунт создан.</strong> Осталось подключить вашу БД — после
       этого первые метрики появятся на дашборде через ~15 минут.
     </div>
+    {% endif %}
 
     <h1 class="mt-8 text-2xl font-semibold tracking-tight">Подключение к БД</h1>
     <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -37,8 +37,8 @@
   <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
     {% set kpis = [
       ("Мониторируется таблиц", summary.table_count|string),
-      ("Всего строк", "{:,}".format(summary.total_rows).replace(",", " ")),
-      ("Средний NULL %", "{:.1%}".format(summary.avg_null_rate)),
+      ("Всего строк", ("—" if not summary.has_metrics else "{:,}".format(summary.total_rows).replace(",", " "))),
+      ("Средний NULL %", ("—" if not summary.has_metrics else "{:.1%}".format(summary.avg_null_rate))),
     ] %}
     {% for label, value in kpis %}
       <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -61,15 +61,19 @@
     </div>
     <div class="divide-y divide-slate-100 dark:divide-slate-800">
       {% set models = [
-        ("IsolationForest", "Детектор аномалий: обучается на 4-мерном векторе метрик (row_count, null_rate, size_bytes, delta) и помечает выбросы по score. Срабатывает на каждом тике коллектора, красные точки на графике — точки, где score ниже порога.", ml_last_runs.isolation_forest),
-        ("Prophet", "Прогноз row_count на 7 дней вперёд с доверительным интервалом 95%. Модель переобучается ночью, результат сериализуется в models/*.joblib и читается с диска на запросы /api/forecast.", ml_last_runs.prophet),
-        ("PELT (ruptures)", "Поиск точек структурного сдвига во временном ряду метрик через алгоритм PELT с RBF-ядром. На графике рисуется вертикальной красной пунктирной линией с подписью «было → стало».", ml_last_runs.pelt),
-        ("PSI + KS-test", "Оценка drift распределения колонок относительно baseline за 7 дней: PSI > 0.2 — warn, > 0.25 — critical. KS-тест используется как вторая независимая статистика для численных колонок.", ml_last_runs.drift),
+        ("Детектор аномалий (IsolationForest)", "Обнаруживает выбросы в метриках таблицы методом изоляционного леса. Обучается без учителя на 4 признаках: row_count, null_rate, size_bytes, delta", "Если данные резко изменились — вы увидите красную точку на графике", "каждый сбор", ml_last_runs.isolation_forest),
+        ("Прогноз роста (Prophet)", "Аддитивная модель временного ряда row_count с разложением на тренд и сезонность. Прогноз на 7 дней вперёд с 95% доверительным интервалом", "Показывает нормальный коридор роста — помогает отличить ожидаемый рост от неожиданного скачка", "ночью 03:00", ml_last_runs.prophet),
+        ("Точки изменения (PELT)", "Алгоритм PELT находит моменты структурного сдвига уровня метрики во временном ряду", "Определяет, когда метрика стабильно перешла на новый уровень, а не просто временно отклонилась", "каждый час", ml_last_runs.pelt),
+        ("Дрейф распределений (PSI + KS-test)", "PSI измеряет сдвиг распределения колонок относительно базового окна 7 дней. KS-тест дополнительно проверяет равенство распределений для числовых колонок", "Предупреждает, если данные в колонках стали выглядеть иначе, чем обычно — например, изменился диапазон значений", "каждый сбор", ml_last_runs.drift),
       ] %}
-      {% for name, desc, last_run in models %}
-        <div class="flex items-baseline gap-3 px-5 py-3 text-sm">
-          <span class="font-mono font-medium text-accent shrink-0 w-40">{{ name }}</span>
-          <span class="flex-1 text-slate-600 dark:text-slate-300">{{ desc }}</span>
+      {% for name, desc, hint, freq, last_run in models %}
+        <div class="flex items-start gap-3 px-5 py-3 text-sm">
+          <span class="font-medium text-accent shrink-0 w-52">{{ name }}</span>
+          <span class="flex-1 text-slate-600 dark:text-slate-300">
+            {{ desc }}
+            <span class="block mt-1 text-xs text-slate-400 dark:text-slate-500 italic">{{ hint }}</span>
+            <span class="inline-block mt-1 rounded-full bg-slate-100 dark:bg-slate-800 px-2 py-0.5 text-xs text-slate-500 dark:text-slate-400">{{ freq }}</span>
+          </span>
           <span class="shrink-0 text-xs tabular-nums text-slate-500 dark:text-slate-400">{{ last_run or "—" }}</span>
         </div>
       {% endfor %}

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -34,19 +34,67 @@
     </section>
   {% endif %}
 
-  <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-    {% set kpis = [
-      ("Мониторируется таблиц", summary.table_count|string),
-      ("Всего строк", ("—" if not summary.has_metrics else "{:,}".format(summary.total_rows).replace(",", " "))),
-      ("Средний NULL %", ("—" if not summary.has_metrics else "{:.1%}".format(summary.avg_null_rate))),
-    ] %}
-    {% for label, value in kpis %}
-      <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <div class="text-sm text-slate-500 dark:text-slate-400">{{ label }}</div>
-        <div class="mt-2 text-3xl font-semibold tracking-tight">{{ value }}</div>
+  {% if project_status %}
+    {% set ps = project_status %}
+    {% if ps.status == "error" %}
+      {% set _border = "border-red-200 dark:border-red-900/40" %}
+      {% set _bg = "bg-red-50 dark:bg-red-950/20" %}
+      {% set _icon = "🔴" %}
+      {% set _title = "Ошибка сбора" %}
+      {% set _title_cls = "text-red-700 dark:text-red-400" %}
+    {% elif ps.status == "warning" %}
+      {% set _border = "border-amber-200 dark:border-amber-900/40" %}
+      {% set _bg = "bg-amber-50 dark:bg-amber-950/20" %}
+      {% set _icon = "⚠️" %}
+      {% set _title = "Требует внимания" %}
+      {% set _title_cls = "text-amber-700 dark:text-amber-400" %}
+    {% else %}
+      {% set _border = "border-emerald-200 dark:border-emerald-900/40" %}
+      {% set _bg = "bg-emerald-50 dark:bg-emerald-950/20" %}
+      {% set _icon = "✅" %}
+      {% set _title = "Всё спокойно" %}
+      {% set _title_cls = "text-emerald-700 dark:text-emerald-400" %}
+    {% endif %}
+
+    <section class="mt-6 rounded-xl border {{ _border }} {{ _bg }} p-5 shadow-sm">
+      <div class="flex items-center gap-2">
+        <span class="text-xl">{{ _icon }}</span>
+        <span class="text-xl font-semibold {{ _title_cls }}">{{ _title }}</span>
       </div>
-    {% endfor %}
-  </section>
+      <div class="mt-3 flex flex-wrap gap-5 text-sm text-slate-600 dark:text-slate-300">
+        <span>
+          <span class="font-medium">Последний сбор:</span>
+          {{ ps.last_run_at[:16].replace("T", " ") ~ " UTC" if ps.last_run_at else "—" }}
+        </span>
+        <span>
+          <span class="font-medium">Таблиц проверено:</span>
+          {{ ps.tables_checked if ps.tables_checked else "—" }}
+        </span>
+        <span>
+          <span class="font-medium">Аномалий за 7 дн.:</span>
+          {{ ps.anomalies_7d }}
+        </span>
+        <span>
+          <span class="font-medium">Изменений схемы за 7 дн.:</span>
+          {{ ps.schema_changes_7d }}
+        </span>
+      </div>
+    </section>
+  {% elif not needs_first_project and not needs_first_connection %}
+    <section class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {% set kpis = [
+        ("Мониторируется таблиц", summary.table_count|string),
+        ("Всего строк", ("—" if not summary.has_metrics else "{:,}".format(summary.total_rows).replace(",", " "))),
+        ("Средний NULL %", ("—" if not summary.has_metrics else "{:.1%}".format(summary.avg_null_rate))),
+      ] %}
+      {% for label, value in kpis %}
+        <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <div class="text-sm text-slate-500 dark:text-slate-400">{{ label }}</div>
+          <div class="mt-2 text-3xl font-semibold tracking-tight">{{ value }}</div>
+        </div>
+      {% endfor %}
+    </section>
+  {% endif %}
 
   {% if not needs_first_project %}
   <section class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -48,6 +48,12 @@
       {% set _icon = "⚠️" %}
       {% set _title = "Требует внимания" %}
       {% set _title_cls = "text-amber-700 dark:text-amber-400" %}
+    {% elif ps.status == "pending" %}
+      {% set _border = "border-slate-200 dark:border-slate-700" %}
+      {% set _bg = "bg-slate-50 dark:bg-slate-800/40" %}
+      {% set _icon = "⏳" %}
+      {% set _title = "Ожидание первого сбора метрик" %}
+      {% set _title_cls = "text-slate-600 dark:text-slate-300" %}
     {% else %}
       {% set _border = "border-emerald-200 dark:border-emerald-900/40" %}
       {% set _bg = "bg-emerald-50 dark:bg-emerald-950/20" %}
@@ -61,22 +67,26 @@
         <span class="text-xl">{{ _icon }}</span>
         <span class="text-xl font-semibold {{ _title_cls }}">{{ _title }}</span>
       </div>
-      <div class="mt-3 flex flex-wrap gap-5 text-sm text-slate-600 dark:text-slate-300">
+      <div class="mt-3 grid grid-cols-2 gap-4 text-slate-600 dark:text-slate-300 sm:grid-cols-5">
         <span>
-          <span class="font-medium">Последний сбор:</span>
-          {{ ps.last_run_at[:16].replace("T", " ") ~ " UTC" if ps.last_run_at else "—" }}
+          <div class="font-semibold">Таблиц проверено</div>
+          <div class="mt-1 text-xl font-semibold tracking-tight text-slate-800 dark:text-slate-100">{{ ps.tables_checked if ps.tables_checked else "—" }}</div>
         </span>
         <span>
-          <span class="font-medium">Таблиц проверено:</span>
-          {{ ps.tables_checked if ps.tables_checked else "—" }}
+          <div class="font-semibold">Всего строк</div>
+          <div class="mt-1 text-xl font-semibold tracking-tight text-slate-800 dark:text-slate-100">{{ "{:,}".format(summary.total_rows).replace(",", " ") if summary.has_metrics else "—" }}</div>
         </span>
         <span>
-          <span class="font-medium">Аномалий за 7 дн.:</span>
-          {{ ps.anomalies_7d }}
+          <div class="font-semibold">Аномалий за 7 дней</div>
+          <div class="mt-1 text-xl font-semibold tracking-tight text-slate-800 dark:text-slate-100">{{ ps.anomalies_7d }}</div>
         </span>
         <span>
-          <span class="font-medium">Изменений схемы за 7 дн.:</span>
-          {{ ps.schema_changes_7d }}
+          <div class="font-semibold">Изменений схемы за 7 дней</div>
+          <div class="mt-1 text-xl font-semibold tracking-tight text-slate-800 dark:text-slate-100">{{ ps.schema_changes_7d }}</div>
+        </span>
+        <span>
+          <div class="font-semibold">Средний NULL %</div>
+          <div class="mt-1 text-xl font-semibold tracking-tight text-slate-800 dark:text-slate-100">{{ "—" if not summary.has_metrics else "{:.1%}".format(summary.avg_null_rate) }}</div>
         </span>
       </div>
     </section>

--- a/templates/projects/detail.html
+++ b/templates/projects/detail.html
@@ -47,7 +47,6 @@
               <span class="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">выключено</span>
             {% endif %}
           </div>
-          <div class="mt-1 truncate font-mono text-xs text-slate-500 dark:text-slate-400">{{ c.dsn_masked }}</div>
           <div class="text-xs text-slate-400 dark:text-slate-500">
             <span class="font-mono">{{ c.schema_name }}</span> · {{ c.interval_minutes|fmt_interval_minutes }}
           </div>
@@ -229,22 +228,20 @@
 
   {# Опасная зона — только owner #}
   {% if project.role == 'owner' %}
-    <section class="mt-6 overflow-hidden rounded-xl border border-red-200 bg-white shadow-sm dark:border-red-900/40 dark:bg-slate-900">
-      <header class="border-b border-red-200 px-5 py-3 dark:border-red-900/40">
-        <h2 class="text-base font-semibold text-red-600 dark:text-red-400">Опасная зона</h2>
+    <section class="mt-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <header class="border-b border-slate-200 px-5 py-3 dark:border-slate-800">
+        <h2 class="text-base font-semibold text-slate-700 dark:text-slate-200">Удаление проекта</h2>
       </header>
-      <div class="flex items-center justify-between px-5 py-4">
-        <div>
-          <p class="text-sm font-medium">Удалить проект</p>
-          <p class="text-xs text-slate-500 dark:text-slate-400">Удаляет все подключения и метрики без возможности восстановления.</p>
-        </div>
+      <div class="px-5 py-4">
+        <p class="text-xs text-slate-500 dark:text-slate-400">Удаляет все подключения и метрики без возможности восстановления.</p>
         <form method="POST" action="{{ url_for('projects.delete', slug=project.slug) }}"
-              onsubmit="return confirm('Удалить проект «{{ project.name }}»? Это действие необратимо.')">
+              onsubmit="return confirm('Удалить проект «{{ project.name }}»? Это действие необратимо.')"
+              class="mt-3">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="submit"
                   class="rounded-md border border-red-300 px-4 py-2 text-sm text-red-600 hover:bg-red-50
                          dark:border-red-700 dark:text-red-400 dark:hover:bg-red-950/40">
-            Удалить проект
+            Удалить
           </button>
         </form>
       </div>

--- a/templates/projects/list.html
+++ b/templates/projects/list.html
@@ -26,24 +26,14 @@
             </div>
           </div>
           <div class="flex items-center gap-2">
+            {% if g.current_project and g.current_project.id == project.id %}
+              <span class="rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">текущий</span>
+            {% endif %}
             {% if project.role in ('owner', 'editor') %}
               <a href="{{ url_for('settings.notifications', slug=project.slug) }}"
                  class="rounded-md border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800">
                 Telegram
               </a>
-            {% endif %}
-            {% if g.current_project and g.current_project.id == project.id %}
-              <span class="rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">текущий</span>
-            {% endif %}
-            {% if project.role == 'owner' %}
-              <form method="POST" action="{{ url_for('projects.delete', slug=project.slug) }}"
-                    onsubmit="return confirm('Удалить проект «{{ project.name }}»?');">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit"
-                        class="rounded-md border border-red-200 px-3 py-1 text-xs text-red-600 hover:bg-red-50 dark:border-red-900/40 dark:text-red-400 dark:hover:bg-red-950/30">
-                  Удалить
-                </button>
-              </form>
             {% endif %}
           </div>
         </div>

--- a/templates/projects/new.html
+++ b/templates/projects/new.html
@@ -2,32 +2,60 @@
 {% from "auth/_macros.html" import render_field %}
 {% block title %}Новый проект — DB Monitor{% endblock %}
 {% block breadcrumb %}
-  <a href="{{ url_for('projects.list_projects') }}" class="hover:text-slate-700 dark:hover:text-slate-200">Проекты</a>
-  <span class="text-slate-300 dark:text-slate-600">/</span>
-  <span class="font-medium text-slate-700 dark:text-slate-200">Новый</span>
+  {% if request.args.get('onboarding') %}
+    <span class="font-medium text-slate-700 dark:text-slate-200">Шаг 1 из 2 — создайте проект</span>
+  {% else %}
+    <a href="{{ url_for('projects.list_projects') }}" class="hover:text-slate-700 dark:hover:text-slate-200">Проекты</a>
+    <span class="text-slate-300 dark:text-slate-600">/</span>
+    <span class="font-medium text-slate-700 dark:text-slate-200">Новый</span>
+  {% endif %}
 {% endblock %}
 
 {% set input_cls = "mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent dark:border-slate-700 dark:bg-slate-950" %}
 
 {% block content %}
-  <h1 class="text-2xl font-semibold tracking-tight">Новый проект</h1>
-  <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
-    Каждый проект — отдельный набор подключений к БД и истории метрик.
-  </p>
-
-  <div class="mt-6 max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-    <form method="POST" class="space-y-4" novalidate>
-      {{ form.hidden_tag() }}
-      {{ render_field(form.name, input_class=input_cls) }}
-      {{ render_field(form.slug, input_class=input_cls) }}
-      <p class="text-xs text-slate-500 dark:text-slate-400">
-        Слаг — короткий уникальный идентификатор в URL. Латиница, цифры,
-        дефисы; до 40 символов.
-      </p>
-      <div class="flex items-center justify-between">
-        <a href="{{ url_for('projects.list_projects') }}" class="text-sm text-slate-500 hover:text-accent dark:text-slate-400">← К списку</a>
-        {{ form.submit(class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover") }}
+  {% if request.args.get('onboarding') %}
+    <div class="mx-auto max-w-md">
+      <div class="rounded-xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-200">
+        <strong>Аккаунт создан.</strong> Назовите ваш проект — это рабочее пространство, в котором будут храниться подключения к БД и история метрик.
       </div>
-    </form>
-  </div>
+      <h1 class="mt-8 text-2xl font-semibold tracking-tight">Новый проект</h1>
+      <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+        Каждый проект — отдельный набор подключений к БД и истории метрик.
+      </p>
+      <div class="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <form method="POST" class="space-y-4" novalidate>
+          {{ form.hidden_tag() }}
+          {{ render_field(form.name, input_class=input_cls) }}
+          {{ render_field(form.slug, input_class=input_cls) }}
+          <p class="text-xs text-slate-500 dark:text-slate-400">
+            Слаг — короткий уникальный идентификатор в URL. Латиница, цифры, дефисы; до 40 символов.
+          </p>
+          <div class="flex justify-end">
+            {{ form.submit(class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover") }}
+          </div>
+        </form>
+      </div>
+    </div>
+  {% else %}
+    <h1 class="text-2xl font-semibold tracking-tight">Новый проект</h1>
+    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+      Каждый проект — отдельный набор подключений к БД и истории метрик.
+    </p>
+    <div class="mt-6 max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <form method="POST" class="space-y-4" novalidate>
+        {{ form.hidden_tag() }}
+        {{ render_field(form.name, input_class=input_cls) }}
+        {{ render_field(form.slug, input_class=input_cls) }}
+        <p class="text-xs text-slate-500 dark:text-slate-400">
+          Слаг — короткий уникальный идентификатор в URL. Латиница, цифры,
+          дефисы; до 40 символов.
+        </p>
+        <div class="flex items-center justify-between">
+          <a href="{{ url_for('projects.list_projects') }}" class="text-sm text-slate-500 hover:text-accent dark:text-slate-400">← К списку</a>
+          {{ form.submit(class="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-accent-hover") }}
+        </div>
+      </form>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -96,9 +96,11 @@
           </div>
           <div class="col-span-3 flex items-center justify-end gap-1.5 tabular-nums">
             {% if d and d.psi is not none %}
-              <span class="text-xs text-slate-500 dark:text-slate-400">PSI {{ "{:.3f}".format(d.psi) }}</span>
+              <span title="Population Stability Index: насколько сдвинулось распределение колонки. Норма &lt; 0.2, предупреждение 0.2–0.25, критично &gt; 0.25"
+                    class="cursor-help text-xs text-slate-500 dark:text-slate-400">PSI {{ "{:.3f}".format(d.psi) }}</span>
               {% if d.ks_pvalue is not none %}
-                <span class="text-xs text-slate-400 dark:text-slate-500">· KS p={{ "{:.3f}".format(d.ks_pvalue) }}</span>
+                <span title="Kolmogorov-Smirnov тест: p близко к 1 — распределения идентичны (норма), близко к 0 — есть сдвиг"
+                      class="cursor-help text-xs text-slate-400 dark:text-slate-500">· KS p={{ "{:.3f}".format(d.ks_pvalue) }}</span>
               {% endif %}
               <span class="rounded bg-{{ sev_color }}-100 px-1.5 py-0.5 text-xs text-{{ sev_color }}-700 dark:bg-{{ sev_color }}-900/40 dark:text-{{ sev_color }}-300">{{ sev_label }}</span>
             {% else %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -64,9 +64,9 @@ def test_register_creates_user_logs_in_and_redirects(client):
         follow_redirects=False,
     )
     assert resp.status_code == 302
-    # #55: register now redirects to the onboarding wizard for the
-    # auto-created Default project — not directly to /dashboard.
-    assert resp.headers["Location"].endswith("/projects/default/connections/new")
+    # #284: register redirects to project creation (step 1 of 2-step onboarding).
+    assert "/projects/new" in resp.headers["Location"]
+    assert "onboarding=1" in resp.headers["Location"]
     # Session cookie was set — /dashboard is reachable (200, not 302).
     follow = client.get("/dashboard/")
     assert follow.status_code == 200

--- a/tests/test_connection_test.py
+++ b/tests/test_connection_test.py
@@ -220,8 +220,8 @@ def _register(client, email="u@example.com"):
     client.post("/auth/register", data={
         "email": email, "password": "supersecret1", "confirm": "supersecret1",
     })
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email(email)
     if user:
         create_default_project_for(user["id"])

--- a/tests/test_connection_test.py
+++ b/tests/test_connection_test.py
@@ -220,6 +220,11 @@ def _register(client, email="u@example.com"):
     client.post("/auth/register", data={
         "email": email, "password": "supersecret1", "confirm": "supersecret1",
     })
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email(email)
+    if user:
+        create_default_project_for(user["id"])
 
 
 def _logout(client):

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -142,6 +142,11 @@ def _register(client, email="u@example.com"):
     client.post("/auth/register", data={
         "email": email, "password": "supersecret1", "confirm": "supersecret1",
     })
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email(email)
+    if user:
+        create_default_project_for(user["id"])
 
 
 def _logout(client):
@@ -313,17 +318,19 @@ def test_create_connection_persists_ciphertext_not_plaintext(client):
     assert len(stored) > 50  # Fernet ciphertext is base64'd ~50+ chars
 
 
-def test_list_connections_shows_masked_dsn(client):
+def test_list_connections_does_not_expose_dsn(client, monkeypatch):
+    monkeypatch.setattr("app.connections.probe_connection", lambda dsn, **kw: {
+        "status": "ok", "database": "app", "version": "PG 16", "latency_ms": 1,
+    })
     _register(client)
     _add_connection(client, dsn="postgresql://admin:topsecret@db.example.com:5432/app")
 
     resp = client.get("/projects/default/connections")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
-    # Password is masked; everything else visible.
+    # DSN is not shown at all in the list — password must never leak.
     assert "topsecret" not in body
-    assert "***" in body
-    assert "db.example.com" in body
+    assert "db.example.com" not in body
 
 
 def test_project_detail_lists_connections(client):
@@ -1418,5 +1425,5 @@ def test_project_detail_keeps_connection_when_decrypt_fails(client, monkeypatch)
     assert resp.status_code == 200
     assert "rotated-key" in body
     assert "good" in body
-    assert "&lt;ошибка дешифровки&gt;" in body
+    # DSN no longer shown in project detail — connection names must still appear
     assert "В проекте пока нет подключений" not in body

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -142,8 +142,8 @@ def _register(client, email="u@example.com"):
     client.post("/auth/register", data={
         "email": email, "password": "supersecret1", "confirm": "supersecret1",
     })
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email(email)
     if user:
         create_default_project_for(user["id"])

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -62,8 +62,11 @@ def _login_with_project_connection(
         get_user_by_email,
         list_projects_for_user,
     )
+    from app.projects import create_default_project_for
 
     user = get_user_by_email(email)
+    if not list_projects_for_user(user["id"]):
+        create_default_project_for(user["id"])
     project = list_projects_for_user(user["id"])[0]
     create_connection(
         connection_id=f"conn-{email}",
@@ -169,6 +172,7 @@ def test_overview_handles_no_collected_metrics(client):
     assert "fresh" in body
     # Em-dash placeholders for missing metrics
     assert "—" in body
+    assert "0.0%" not in body  # KPI-карточки не должны показывать нули без данных
 
 
 def test_overview_empty_when_no_tables(client):

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -60,11 +60,17 @@ def client(app_):
 
 
 def _register(client, email="u@example.com"):
-    return client.post(
+    resp = client.post(
         "/auth/register",
         data={"email": email, "password": "supersecret1", "confirm": "supersecret1"},
         follow_redirects=False,
     )
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email(email)
+    if user:
+        create_default_project_for(user["id"])
+    return resp
 
 
 def _guide_href(html: str) -> str:
@@ -99,8 +105,8 @@ def test_authenticated_root_redirects_to_dashboard(client):
 def test_register_redirects_to_onboarding_wizard(client):
     resp = _register(client, "new@example.com")
     assert resp.status_code == 302
-    # Slug for the auto-created Default project is "default".
-    assert resp.headers["Location"].endswith("/projects/default/connections/new")
+    assert "/projects/new" in resp.headers["Location"]
+    assert "onboarding=1" in resp.headers["Location"]
 
 
 def test_onboarding_template_rendered_when_project_empty(client):

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -65,8 +65,8 @@ def _register(client, email="u@example.com"):
         data={"email": email, "password": "supersecret1", "confirm": "supersecret1"},
         follow_redirects=False,
     )
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email(email)
     if user:
         create_default_project_for(user["id"])

--- a/tests/test_project_invites.py
+++ b/tests/test_project_invites.py
@@ -64,8 +64,8 @@ def _register(client, email, password="secret123", next_url=None):
     resp = client.post(url, data={
         "email": email, "password": password, "confirm": password,
     })
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email(email)
     if user and not next_url:
         create_default_project_for(user["id"])

--- a/tests/test_project_invites.py
+++ b/tests/test_project_invites.py
@@ -61,9 +61,15 @@ def _register(client, email, password="secret123", next_url=None):
     url = "/auth/register"
     if next_url:
         url += f"?next={next_url}"
-    return client.post(url, data={
+    resp = client.post(url, data={
         "email": email, "password": password, "confirm": password,
     })
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email(email)
+    if user and not next_url:
+        create_default_project_for(user["id"])
+    return resp
 
 
 def _login(client, email, password="secret123"):

--- a/tests/test_project_notifications.py
+++ b/tests/test_project_notifications.py
@@ -296,11 +296,17 @@ def client(app_):
 
 
 def _register(client, email="u@example.com"):
-    return client.post(
+    resp = client.post(
         "/auth/register",
         data={"email": email, "password": "supersecret1", "confirm": "supersecret1"},
         follow_redirects=False,
     )
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email(email)
+    if user:
+        create_default_project_for(user["id"])
+    return resp
 
 
 def test_settings_page_renders_for_authed_owner(client):

--- a/tests/test_project_notifications.py
+++ b/tests/test_project_notifications.py
@@ -301,8 +301,8 @@ def _register(client, email="u@example.com"):
         data={"email": email, "password": "supersecret1", "confirm": "supersecret1"},
         follow_redirects=False,
     )
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email(email)
     if user:
         create_default_project_for(user["id"])

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -46,8 +46,8 @@ def _register(client, email="u@example.com", password="supersecret1"):
     resp = client.post("/auth/register", data={
         "email": email, "password": password, "confirm": password,
     })
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email(email)
     if user:
         create_default_project_for(user["id"])

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -43,9 +43,15 @@ def client(projects_app):
 
 def _register(client, email="u@example.com", password="supersecret1"):
     """Register a user; the post-register session is left authenticated."""
-    return client.post("/auth/register", data={
+    resp = client.post("/auth/register", data={
         "email": email, "password": password, "confirm": password,
     })
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email(email)
+    if user:
+        create_default_project_for(user["id"])
+    return resp
 
 
 def _logout(client):

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -361,7 +361,7 @@ def test_owner_sees_telegram_and_delete_on_projects_list(app, client):
 
     html = client.get("/projects").data.decode()
     assert f"/projects/{slug}/settings/notifications" in html
-    assert f"/projects/{slug}/delete" in html
+    # Кнопка «Удалить» убрана из списка проектов (#284) — удаление только в настройках
 
 
 def test_project_name_links_to_detail_on_projects_list(client):

--- a/tests/test_safety_editor.py
+++ b/tests/test_safety_editor.py
@@ -47,8 +47,8 @@ def _register(client, email="u@example.com"):
     client.post("/auth/register", data={
         "email": email, "password": "supersecret1", "confirm": "supersecret1",
     })
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email(email)
     if user:
         create_default_project_for(user["id"])
@@ -121,7 +121,7 @@ def test_edit_redirects_with_flash_when_dsn_ciphertext_unreadable(client):
     the list with a clear flash so they know to delete + re-create."""
     _register(client)
     _add_pg(client)
-    pid, cid = _conn_id(client)
+    _pid, cid = _conn_id(client)
 
     # Corrupt the ciphertext directly — simulates Fernet-key rotation:
     # what's on disk doesn't decrypt under the current key.

--- a/tests/test_safety_editor.py
+++ b/tests/test_safety_editor.py
@@ -47,6 +47,11 @@ def _register(client, email="u@example.com"):
     client.post("/auth/register", data={
         "email": email, "password": "supersecret1", "confirm": "supersecret1",
     })
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email(email)
+    if user:
+        create_default_project_for(user["id"])
 
 
 def _add_pg(client, dsn="postgresql://u:p@h:5432/d"):

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -69,7 +69,7 @@ def test_send_message_telegram_error_returns_false():
     with patch("app.notifications.telegram.asyncio.run", side_effect=_raise):
         ok, error = send_message("test", bot_token="tok", chat_id="123")
     assert ok is False
-    assert error and "telegram_error" in error
+    assert error and "Ошибка Telegram" in error
 
 
 def test_send_message_network_error_returns_false():
@@ -80,7 +80,7 @@ def test_send_message_network_error_returns_false():
     with patch("app.notifications.telegram.asyncio.run", side_effect=_raise):
         ok, error = send_message("test", bot_token="tok", chat_id="123")
     assert ok is False
-    assert error and "error" in error
+    assert error and "ошибка" in error.lower()
 
 
 # ── is_throttled / update_throttle — now per-project ───────────────────────

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -190,6 +190,11 @@ def _register_user_a(client):
         "email": "a@example.com", "password": "supersecret1",
         "confirm": "supersecret1",
     })
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email("a@example.com")
+    if user:
+        create_default_project_for(user["id"])
 
 
 def _register_user_b(client):
@@ -197,6 +202,11 @@ def _register_user_b(client):
         "email": "b@example.com", "password": "supersecret1",
         "confirm": "supersecret1",
     })
+    from app.projects import create_default_project_for
+    from app.metrics_storage import get_user_by_email
+    user = get_user_by_email("b@example.com")
+    if user:
+        create_default_project_for(user["id"])
 
 
 def _project_id_of(email: str) -> str:

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -190,8 +190,8 @@ def _register_user_a(client):
         "email": "a@example.com", "password": "supersecret1",
         "confirm": "supersecret1",
     })
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email("a@example.com")
     if user:
         create_default_project_for(user["id"])
@@ -202,8 +202,8 @@ def _register_user_b(client):
         "email": "b@example.com", "password": "supersecret1",
         "confirm": "supersecret1",
     })
-    from app.projects import create_default_project_for
     from app.metrics_storage import get_user_by_email
+    from app.projects import create_default_project_for
     user = get_user_by_email("b@example.com")
     if user:
         create_default_project_for(user["id"])


### PR DESCRIPTION
## Описание

Серия UI-правок перед демо по задаче #284:

- **Статус-блок на обзоре** — заменяет «сухие» KPI-карточки: pending / ok / warning / error, сетка метрик, тултипы для PSI и KS-test
- **Пустые состояния** — нули заменены на `—`; `pending` если метрик нет совсем (в т.ч. когда `tables_checked=0`)
- **Онбординг 2 шага** — после регистрации: создать проект (шаг 1) → добавить подключение (шаг 2)
- **Аватар пользователя** — инициал email в хедере с hover-тултипом
- **ML-описания моделей** — русские названия, точные ML-формулировки, частота запусков
- **Редактирование подключения** — name/schema (owner+editor) и DSN (только owner) теперь редактируются без delete+new; поля Load Safety переименованы на русский
- **Навигация** — Уведомления перемещены ниже Telegram; DSN скрыт из списков; кнопки подключений унифицированы
- **Список проектов** — убрана кнопка «Удалить», секция удаления смягчена
- **ClickHouse probe** — возвращает список таблиц (ранее всегда 0)
- **Telegram-ошибки** — русские сообщения без утечки токена

## Тип изменения

- [x] Bug fix
- [x] New feature

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы