### PR TITLE
fix: тест secrets-scrub ложно падал на bare-слове password (#286)

### DIFF
--- a/tests/test_secrets_scrub.py
+++ b/tests/test_secrets_scrub.py
@@ -166,8 +166,11 @@ def test_healthz_payload_does_not_contain_secrets(health_client):
     # DSN-форма
     assert "postgresql://" not in body
     assert "clickhouse://" not in body
-    # password в ключах (нечастый, но проверяем)
-    assert "password" not in body.lower()
+    # Реальный пароль не должен утекать — проверяем паттерны credentials,
+    # а не слово "password", которое может быть в тексте ошибки драйвера
+    # (например, psycopg2: "password authentication failed for user").
+    assert "password=" not in body.lower()          # URL-параметр ?password=secret
+    assert not re.search(r"://[^:@/]+:[^@/]+@", body)  # DSN с кредами user:pass@host
     # AWS key / Bearer
     assert not re.search(r"AKIA[0-9A-Z]{16}", body)
     assert not re.search(r"ASIA[0-9A-Z]{16}", body)


### PR DESCRIPTION
## Описание

Тест `test_healthz_payload_does_not_contain_secrets` ложно падал из-за того, что слово `password` появлялось в `/healthz` JSON как часть стандартного сообщения psycopg2 (`password authentication failed for user`), а не как утечка секрета.

Заменяем избыточную проверку на точные паттерны утечки credentials:
- `password=` — URL-параметр вида `?password=secret`  
- `://user:pass@host` — DSN с паролем в открытом виде

Closes #286

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально (971 passed, 0 failed)
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы