### PR TITLE
fix: IcebergAdapter использует HTTP для Docker-хостов без точки (#290)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -556,8 +556,14 @@ class IcebergAdapter(DBAdapter):
             if ssl_param is not None:
                 use_tls = ssl_param.lower() in ("true", "1", "yes")
             else:
-                # hostname is None for hostless URLs (invalid anyway) → HTTPS
-                use_tls = parsed.hostname not in ("localhost", "127.0.0.1", "::1")
+                # Docker-сервисы (iceberg-rest, minio) не имеют точки → HTTP.
+                # localhost / 127.0.0.1 / ::1 → HTTP. Реальные домены → HTTPS.
+                _local = {"localhost", "127.0.0.1", "::1"}
+                use_tls = bool(
+                    parsed.hostname
+                    and parsed.hostname not in _local
+                    and "." in parsed.hostname
+                )
             scheme = "https" if use_tls else "http"
             props["uri"] = f"{scheme}://{parsed.netloc}"
             self._catalog = RestCatalog("rest", **props)

--- a/tests/test_iceberg_adapter.py
+++ b/tests/test_iceberg_adapter.py
@@ -95,6 +95,16 @@ def test_rest_adapter_init_localhost_defaults_to_http():
             assert called_uri.startswith("http://"), f"expected http:// for host {host!r}"
 
 
+def test_rest_adapter_docker_hostname_defaults_to_http():
+    """Docker-сервисы без точки в имени (iceberg-rest, minio) → HTTP (#290)."""
+    from app.db import IcebergAdapter
+    for host in ("iceberg-rest", "minio", "catalog-service"):
+        with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:
+            IcebergAdapter(f"iceberg+rest://{host}:8181?warehouse=s3://b/w")
+            called_uri = mock_cls.call_args[1]["uri"]
+            assert called_uri.startswith("http://"), f"expected http:// for Docker host {host!r}"
+
+
 def test_rest_adapter_init_ssl_false_overrides():
     """?ssl=false on a remote host forces HTTP; ssl must not reach PyIceberg (#260)."""
     with patch("pyiceberg.catalog.rest.RestCatalog") as mock_cls:


### PR DESCRIPTION
## Описание

Docker-сервисы (например `iceberg-rest`, `minio`) не содержат точки в hostname.
Старая проверка `not in ("localhost", "127.0.0.1", "::1")` расценивала их как
внешние хосты и выбирала HTTPS, что приводило к `SSLError: WRONG_VERSION_NUMBER`.

Новая логика: HTTP, если hostname в списке локальных (`localhost / 127.0.0.1 / ::1`)
**или** не содержит точки (Docker-сервисы). Реальные внешние домены
(`catalog.example.com`) по-прежнему получают HTTPS.

Closes #290

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены (`test_rest_adapter_docker_hostname_defaults_to_http`)
- [x] `pytest tests/test_iceberg_adapter.py` — 29/29 green
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы