### PR TITLE
fix: единый формат времени YYYY-MM-DD HH:MM в MSK без UTC-метки (#292)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,3 +95,7 @@ FLASK_ENV=development
 # прямо в Telegram (например, на демо).
 # Клики на аномалию в UI всегда вызывают NIM независимо от этого флага.
 #   FF_LLM_NOTIFICATIONS=1
+
+# Часовой пояс для отображения времени в интерфейсе (IANA-название, напр. Europe/Moscow).
+# По умолчанию UTC.
+DISPLAY_TZ=Europe/Moscow

--- a/.env.example
+++ b/.env.example
@@ -98,4 +98,4 @@ FLASK_ENV=development
 
 # Часовой пояс для отображения времени в интерфейсе (IANA-название, напр. Europe/Moscow).
 # По умолчанию UTC.
-DISPLAY_TZ=Europe/Moscow
+# DISPLAY_TZ=Europe/Moscow

--- a/app/app.py
+++ b/app/app.py
@@ -60,6 +60,9 @@ def _get_display_tz() -> ZoneInfo:
         return ZoneInfo("UTC")
 
 
+_DISPLAY_TZ = _get_display_tz()
+
+
 def _format_datetime(value) -> str:
     """Format stored UTC timestamps for compact dashboard display."""
     if value is None or value == "":
@@ -75,9 +78,8 @@ def _format_datetime(value) -> str:
         return str(value)
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
-    tz = _get_display_tz()
-    localized = parsed.astimezone(tz)
-    tz_label = localized.strftime("%Z") or "UTC"
+    localized = parsed.astimezone(_DISPLAY_TZ)
+    tz_label = localized.tzname() or _DISPLAY_TZ.key or "UTC"
     return localized.strftime(f"%d.%m %H:%M {tz_label}")
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -61,6 +61,10 @@ def _get_display_tz() -> ZoneInfo:
 
 
 _DISPLAY_TZ = _get_display_tz()
+# UTC offset in whole hours, injected into templates for JS formatting.
+_DISPLAY_TZ_OFFSET_H: int = int(
+    datetime(2000, 1, 1, tzinfo=UTC).astimezone(_DISPLAY_TZ).utcoffset().total_seconds() // 3600
+)
 
 
 def _format_datetime(value) -> str:
@@ -78,9 +82,7 @@ def _format_datetime(value) -> str:
         return str(value)
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
-    localized = parsed.astimezone(_DISPLAY_TZ)
-    tz_label = localized.tzname() or _DISPLAY_TZ.key or "UTC"
-    return localized.strftime(f"%d.%m %H:%M {tz_label}")
+    return parsed.astimezone(_DISPLAY_TZ).strftime("%Y-%m-%d %H:%M")
 
 
 _logging_filter_installed = False
@@ -238,6 +240,7 @@ def create_app(config: dict | None = None):
     app.jinja_env.filters["fmt_iso_in_text"] = _fmt_iso_in_text
     app.jinja_env.filters["fmt_interval_minutes"] = _fmt_interval_minutes
     app.jinja_env.filters["format_datetime"] = _format_datetime
+    app.jinja_env.globals["display_tz_offset_h"] = _DISPLAY_TZ_OFFSET_H
 
     if config:
         app.config.update(config)

--- a/app/app.py
+++ b/app/app.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from datetime import UTC, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from flask import Flask, jsonify, redirect, render_template
 from flask_wtf.csrf import CSRFProtect
@@ -51,6 +52,14 @@ def _fmt_interval_minutes(minutes: int | str | None) -> str:
     return f"каждые {value} мин"
 
 
+def _get_display_tz() -> ZoneInfo:
+    tz_name = os.environ.get("DISPLAY_TZ", "UTC")
+    try:
+        return ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, KeyError):
+        return ZoneInfo("UTC")
+
+
 def _format_datetime(value) -> str:
     """Format stored UTC timestamps for compact dashboard display."""
     if value is None or value == "":
@@ -66,7 +75,10 @@ def _format_datetime(value) -> str:
         return str(value)
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC).strftime("%d.%m %H:%M UTC")
+    tz = _get_display_tz()
+    localized = parsed.astimezone(tz)
+    tz_label = localized.strftime("%Z") or "UTC"
+    return localized.strftime(f"%d.%m %H:%M {tz_label}")
 
 
 _logging_filter_installed = False

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -299,12 +299,14 @@ def _ml_last_runs(project_id: str) -> dict[str, str | None]:
     return {k: _fmt_ts(v) for k, v in out.items()}
 
 
-def _fmt_ts(value: str | datetime | None) -> str | None:
+def _fmt_ts(value: str | datetime | None) -> datetime | None:
     if not value:
         return None
-    if isinstance(value, datetime):
-        value = value.isoformat()
-    return value.replace("T", " ")[:16] + " UTC"
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value
 
 
 @bp.route("/schema")

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -72,7 +72,7 @@
           {% for n in items %}
             <tr class="align-top hover:bg-slate-50 dark:hover:bg-slate-800/60">
               <td class="whitespace-nowrap px-5 py-4 font-mono text-xs text-slate-500 dark:text-slate-400">
-                {{ n.ts.replace("T", " ")[:16] }} UTC
+                {{ n.ts|format_datetime }}
               </td>
               <td class="whitespace-nowrap px-5 py-4">
                 <span class="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -132,7 +132,7 @@
             <span class="block mt-1 text-xs text-slate-400 dark:text-slate-500 italic">{{ hint }}</span>
             <span class="inline-block mt-1 rounded-full bg-slate-100 dark:bg-slate-800 px-2 py-0.5 text-xs text-slate-500 dark:text-slate-400">{{ freq }}</span>
           </span>
-          <span class="shrink-0 text-xs tabular-nums text-slate-500 dark:text-slate-400">{{ last_run or "—" }}</span>
+          <span class="shrink-0 text-xs tabular-nums text-slate-500 dark:text-slate-400">{{ last_run|format_datetime }}</span>
         </div>
       {% endfor %}
     </div>

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -194,7 +194,7 @@
               <td class="px-5 py-3 text-right tabular-nums">
                 {% if t.size_bytes is not none %}{{ "{:,} KB".format((t.size_bytes / 1024)|round|int).replace(",", " ") }}{% else %}—{% endif %}
               </td>
-              <td class="px-5 py-3 text-slate-600 dark:text-slate-300">{{ (t.last_check[:16].replace("T", " ") + " UTC") if t.last_check else "—" }}</td>
+              <td class="px-5 py-3 text-slate-600 dark:text-slate-300">{{ t.last_check|format_datetime }}</td>
               <td class="px-5 py-3 text-right">
                 <a href="/dashboard/schema/{{ t.table_name }}" class="text-xs text-slate-500 hover:text-accent dark:text-slate-400">Подробнее →</a>
               </td>

--- a/templates/projects/list.html
+++ b/templates/projects/list.html
@@ -22,7 +22,7 @@
                class="text-base font-semibold text-accent hover:underline">{{ project.name }}</a>
             <div class="text-xs text-slate-500 dark:text-slate-400">
               <span class="font-mono">{{ project.slug }}</span>
-              · создан {{ project.created_at[:16].replace('T', ' ') }} UTC
+              · создан {{ project.created_at|format_datetime }}
             </div>
           </div>
           <div class="flex items-center gap-2">

--- a/templates/schema.html
+++ b/templates/schema.html
@@ -104,7 +104,7 @@
                       {% endif %}
                     </span>
                   </div>
-                  <span class="shrink-0 text-slate-400 dark:text-slate-500 tabular-nums">{{ e.ts[:16].replace('T', ' ') }} UTC</span>
+                  <span class="shrink-0 text-slate-400 dark:text-slate-500 tabular-nums">{{ e.ts|format_datetime }}</span>
                 </div>
               {% endfor %}
               {% if entry.schema_events|length > 5 %}

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -20,7 +20,7 @@
     {% set kpis = [
       ("Строк", ("{:,}".format(stats.row_count).replace(",", " ") if stats.row_count is not none else "—")),
       ("Размер", ("{:,} KB".format((stats.size_bytes / 1024)|round|int).replace(",", " ") if stats.size_bytes is not none else "—")),
-      ("Последняя проверка", (stats.last_check.replace("T", " ")[:16] + " UTC") if stats.last_check else "—"),
+      ("Последняя проверка", stats.last_check|format_datetime),
     ] %}
     {% for label, value in kpis %}
       <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -140,7 +140,7 @@
                   {% endif %}
                 </span>
               </div>
-              <span class="shrink-0 text-slate-400 dark:text-slate-500 tabular-nums">{{ e.ts[:16].replace('T', ' ') }} UTC</span>
+              <span class="shrink-0 text-slate-400 dark:text-slate-500 tabular-nums">{{ e.ts|format_datetime }}</span>
             </div>
           {% endfor %}
         </div>
@@ -196,6 +196,11 @@
         d_row_count: "Δ строк",
         d_null_rate: "Δ NULL rate",
       };
+      const _TZ_OFFSET_MS = {{ display_tz_offset_h }} * 3600000;
+      const fmtTs = iso => {
+        const d = new Date(new Date(iso).getTime() + _TZ_OFFSET_MS);
+        return d.toISOString().slice(0, 16).replace("T", " ");
+      };
       const fmtInt = v => Math.round(v).toLocaleString("ru-RU");
       const fmtSignedInt = v => (v >= 0 ? "+" : "") + fmtInt(v);
       const fmtRate = v => (v * 100).toFixed(2) + "%";
@@ -227,7 +232,7 @@
           // Newest first — operators usually scan the latest incident first.
           const sorted = [...flaggedAnomalies].sort((a, b) => b.ts.localeCompare(a.ts));
           anomaliesList.innerHTML = sorted.map(a => {
-            const tsLabel = a.ts.replace("T", " ").slice(0, 16);
+            const tsLabel = fmtTs(a.ts);
             const f = a.features;
             let topBadge = "";
             let breakdown = "";
@@ -269,7 +274,7 @@
                   class="anomaly-toggle flex w-full items-center justify-between gap-3 px-5 py-3 text-left transition hover:bg-slate-50 dark:hover:bg-slate-800/50">
                   <div class="flex items-center gap-2 min-w-0">
                     <span class="h-2 w-2 shrink-0 rounded-full bg-red-500"></span>
-                    <span class="font-mono tabular-nums text-sm text-slate-700 dark:text-slate-200">${tsLabel} UTC</span>
+                    <span class="font-mono tabular-nums text-sm text-slate-700 dark:text-slate-200">${tsLabel}</span>
                     ${topBadge}
                   </div>
                   <svg class="anomaly-chevron h-4 w-4 shrink-0 text-slate-400 transition-transform dark:text-slate-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
@@ -396,7 +401,7 @@
           const tsToValue = new Map(series.map(p => [p.ts, p.value]));
           const buildTooltip = a => {
             const f = a.features;
-            const head = `<b>Аномалия</b> ${a.ts.replace("T", " ").slice(0, 16)}<br>score: ${a.score.toFixed(4)}`;
+            const head = `<b>Аномалия</b> ${fmtTs(a.ts)}<br>score: ${a.score.toFixed(4)}`;
             if (!f) return head;
             const tz = f.z_scores[f.top_feature];
             const top = `<b>Источник:</b> ${featureLabels[f.top_feature]} (z = ${tz >= 0 ? "+" : ""}${tz.toFixed(2)}σ)`;
@@ -437,7 +442,7 @@
           bordercolor: "#dc2626", borderwidth: 1, borderpad: 3,
           font: { size: 10, color: isDark ? "#fecaca" : "#991b1b" },
           text: `▼ ${fmt(cp.value_before)} → ${fmt(cp.value_after)}`,
-          hovertext: `Сдвиг ${cp.ts.replace("T", " ").slice(0, 16)}<br>${metric}: ${fmt(cp.value_before)} → ${fmt(cp.value_after)}<br>score ${cp.score.toFixed(2)}`,
+          hovertext: `Сдвиг ${fmtTs(cp.ts)}<br>${metric}: ${fmt(cp.value_before)} → ${fmt(cp.value_after)}<br>score ${cp.score.toFixed(2)}`,
           captureevents: true,
         }));
         Plotly.newPlot(

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -412,7 +412,7 @@ def test_project_detail_shows_connection_status_checklist(client, monkeypatch):
     assert "Не запланирован" in body
     assert "Последний сбор" in body
     assert "success" in body
-    assert "08.06 10:30 UTC" in body
+    assert "2026-06-08 10:30" in body
 
 
 def test_project_detail_links_to_collector_run_detail(client, monkeypatch):
@@ -715,7 +715,7 @@ def test_project_detail_shows_next_scheduled_run(client, monkeypatch):
     assert resp.status_code == 200
     assert "Scheduled DB" in body
     assert "Следующий запуск" in body
-    assert "08.06 12:45 UTC" in body
+    assert "2026-06-08 12:45" in body
     assert "Не запланирован" not in body
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -93,8 +93,8 @@ def test_status_class_buckets():
 def test_fmt_ts_accepts_datetime_from_postgres():
     value = datetime(2026, 6, 6, 12, 34, 56, tzinfo=UTC)
 
-    assert _fmt_ts(value) == "2026-06-06 12:34 UTC"
-    assert _fmt_ts(value.isoformat()) == "2026-06-06 12:34 UTC"
+    assert _fmt_ts(value) == datetime(2026, 6, 6, 12, 34, 56, tzinfo=UTC)
+    assert _fmt_ts(value.isoformat()) == datetime(2026, 6, 6, 12, 34, 56, tzinfo=UTC)
 
 
 def test_root_renders_landing_for_anonymous(client):
@@ -466,7 +466,7 @@ def test_overview_last_check_formatted(client):
         resp = client.get("/dashboard")
 
     body = resp.get_data(as_text=True)
-    assert "2026-04-29 10:00 UTC" in body
+    assert "2026-04-29 10:00" in body
     assert "2026-04-29T10:00:00+00:00" not in body
 
 

--- a/tests/test_format_datetime.py
+++ b/tests/test_format_datetime.py
@@ -9,7 +9,6 @@ import pytest
 
 from app.app import _format_datetime
 
-
 MSK = ZoneInfo("Europe/Moscow")  # UTC+3
 NYC = ZoneInfo("America/New_York")  # UTC-4 (summer)
 

--- a/tests/test_format_datetime.py
+++ b/tests/test_format_datetime.py
@@ -1,0 +1,100 @@
+"""Tests for _format_datetime Jinja filter and DISPLAY_TZ support (#292)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.app import _format_datetime
+
+
+MSK = ZoneInfo("Europe/Moscow")  # UTC+3
+NYC = ZoneInfo("America/New_York")  # UTC-4 (summer)
+
+
+@pytest.fixture()
+def tz_utc(monkeypatch):
+    import app.app as m
+    monkeypatch.setattr(m, "_DISPLAY_TZ", ZoneInfo("UTC"))
+
+
+@pytest.fixture()
+def tz_moscow(monkeypatch):
+    import app.app as m
+    monkeypatch.setattr(m, "_DISPLAY_TZ", MSK)
+
+
+# ---------------------------------------------------------------------------
+# Базовые случаи — пустые / None
+# ---------------------------------------------------------------------------
+
+def test_none_returns_dash(tz_utc):
+    assert _format_datetime(None) == "—"
+
+
+def test_empty_string_returns_dash(tz_utc):
+    assert _format_datetime("") == "—"
+
+
+# ---------------------------------------------------------------------------
+# UTC (дефолт)
+# ---------------------------------------------------------------------------
+
+def test_datetime_utc_display(tz_utc):
+    ts = datetime(2026, 6, 10, 5, 0, tzinfo=UTC)
+    assert _format_datetime(ts) == "10.06 05:00 UTC"
+
+
+def test_iso_string_z_suffix_utc(tz_utc):
+    assert _format_datetime("2026-06-10T05:00:00Z") == "10.06 05:00 UTC"
+
+
+def test_iso_string_with_offset_utc(tz_utc):
+    assert _format_datetime("2026-06-10T05:00:00+00:00") == "10.06 05:00 UTC"
+
+
+# ---------------------------------------------------------------------------
+# Europe/Moscow (UTC+3)
+# ---------------------------------------------------------------------------
+
+def test_utc_converts_to_msk(tz_moscow):
+    ts = datetime(2026, 6, 10, 5, 0, tzinfo=UTC)
+    result = _format_datetime(ts)
+    assert result == "10.06 08:00 MSK"
+
+
+def test_iso_string_converts_to_msk(tz_moscow):
+    assert _format_datetime("2026-06-10T05:00:00Z") == "10.06 08:00 MSK"
+
+
+def test_midnight_utc_to_msk_crosses_day(tz_moscow):
+    # 23:00 UTC = 02:00 MSK следующего дня
+    ts = datetime(2026, 6, 10, 23, 0, tzinfo=UTC)
+    assert _format_datetime(ts) == "11.06 02:00 MSK"
+
+
+# ---------------------------------------------------------------------------
+# Naive datetime — должен трактоваться как UTC
+# ---------------------------------------------------------------------------
+
+def test_naive_datetime_treated_as_utc(tz_moscow):
+    ts = datetime(2026, 6, 10, 5, 0)  # без tzinfo
+    assert _format_datetime(ts) == "10.06 08:00 MSK"
+
+
+# ---------------------------------------------------------------------------
+# Невалидная ISO-строка — возвращается как есть
+# ---------------------------------------------------------------------------
+
+def test_invalid_iso_string_returned_as_is(tz_utc):
+    assert _format_datetime("not-a-date") == "not-a-date"
+
+
+# ---------------------------------------------------------------------------
+# Нестроковый / не-datetime тип
+# ---------------------------------------------------------------------------
+
+def test_integer_returns_str(tz_utc):
+    assert _format_datetime(42) == "42"

--- a/tests/test_format_datetime.py
+++ b/tests/test_format_datetime.py
@@ -44,15 +44,15 @@ def test_empty_string_returns_dash(tz_utc):
 
 def test_datetime_utc_display(tz_utc):
     ts = datetime(2026, 6, 10, 5, 0, tzinfo=UTC)
-    assert _format_datetime(ts) == "10.06 05:00 UTC"
+    assert _format_datetime(ts) == "2026-06-10 05:00"
 
 
 def test_iso_string_z_suffix_utc(tz_utc):
-    assert _format_datetime("2026-06-10T05:00:00Z") == "10.06 05:00 UTC"
+    assert _format_datetime("2026-06-10T05:00:00Z") == "2026-06-10 05:00"
 
 
 def test_iso_string_with_offset_utc(tz_utc):
-    assert _format_datetime("2026-06-10T05:00:00+00:00") == "10.06 05:00 UTC"
+    assert _format_datetime("2026-06-10T05:00:00+00:00") == "2026-06-10 05:00"
 
 
 # ---------------------------------------------------------------------------
@@ -61,18 +61,17 @@ def test_iso_string_with_offset_utc(tz_utc):
 
 def test_utc_converts_to_msk(tz_moscow):
     ts = datetime(2026, 6, 10, 5, 0, tzinfo=UTC)
-    result = _format_datetime(ts)
-    assert result == "10.06 08:00 MSK"
+    assert _format_datetime(ts) == "2026-06-10 08:00"
 
 
 def test_iso_string_converts_to_msk(tz_moscow):
-    assert _format_datetime("2026-06-10T05:00:00Z") == "10.06 08:00 MSK"
+    assert _format_datetime("2026-06-10T05:00:00Z") == "2026-06-10 08:00"
 
 
 def test_midnight_utc_to_msk_crosses_day(tz_moscow):
     # 23:00 UTC = 02:00 MSK следующего дня
     ts = datetime(2026, 6, 10, 23, 0, tzinfo=UTC)
-    assert _format_datetime(ts) == "11.06 02:00 MSK"
+    assert _format_datetime(ts) == "2026-06-11 02:00"
 
 
 # ---------------------------------------------------------------------------
@@ -81,7 +80,7 @@ def test_midnight_utc_to_msk_crosses_day(tz_moscow):
 
 def test_naive_datetime_treated_as_utc(tz_moscow):
     ts = datetime(2026, 6, 10, 5, 0)  # без tzinfo
-    assert _format_datetime(ts) == "10.06 08:00 MSK"
+    assert _format_datetime(ts) == "2026-06-10 08:00"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #292

## Описание

Время во всём интерфейсе отображалось на 3 часа меньше фактического — фильтр `format_datetime` принудительно конвертировал всё в UTC. Кроме того, часть страниц форматировала метки времени в шаблонах и Python-коде в обход фильтра, захардкодив `" UTC"`.

**Что сделано:**
- Добавлена переменная окружения `DISPLAY_TZ` (IANA-название, по умолчанию `UTC`) — задав `Europe/Moscow` получаем московское время везде
- Формат изменён с `dd.mm HH:MM TZ` на `YYYY-MM-DD HH:MM` без метки часового пояса
- `_DISPLAY_TZ` кэшируется на старте приложения; `display_tz_offset_h` передаётся в Jinja как глобал для JS
- Все инлайн-форматирования в шаблонах заменены на `|format_datetime`
- `_fmt_ts` в `dashboard.py` теперь возвращает `datetime` вместо строки с захардкоженным UTC
- JS-хелпер `fmtTs()` в `table_detail.html` применяет смещение из `display_tz_offset_h`

**Файлы:**
`app/app.py`, `app/dashboard.py`, `templates/notifications.html`, `templates/schema.html`, `templates/overview.html`, `templates/table_detail.html`, `templates/projects/list.html`, `.env.example`

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены
- [x] `pytest` проходит локально
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы