### PR TITLE
fix(forecast): убрать отрицательный прогноз и неверную стрелку changepoint

### DIFF
--- a/ml/forecast.py
+++ b/ml/forecast.py
@@ -104,6 +104,37 @@ def _fit_prophet(points: list[tuple[datetime, float]]):  # pragma: no cover - he
     return m
 
 
+_SEVERE_DROP_RATIO = 0.2
+
+
+def _is_severe_drop(cp: dict, threshold: float = _SEVERE_DROP_RATIO) -> bool:
+    """True when the changepoint represents a large sudden decrease.
+
+    Criterion: value_after < value_before AND value_after / value_before < threshold.
+    Used to switch the training strategy: instead of a full-window fit that
+    extrapolates the negative trend into the future, we use only post-CP data.
+    """
+    before = cp.get("value_before", 1.0)
+    after = cp.get("value_after", 0.0)
+    if before <= 0:
+        return False
+    return after < before and (after / before) < threshold
+
+
+def _normalize_forecast_point(p: dict) -> dict:
+    """Clamp all forecast values to [0, ∞) and restore CI ordering.
+
+    Called unconditionally after any shift so the invariants hold regardless
+    of whether an anchor shift was applied.
+    """
+    p["yhat"]       = max(0.0, p["yhat"])
+    p["yhat_lower"] = max(0.0, p["yhat_lower"])
+    p["yhat_upper"] = max(0.0, p["yhat_upper"])
+    p["yhat_lower"] = min(p["yhat_lower"], p["yhat"])
+    p["yhat_upper"] = max(p["yhat_upper"], p["yhat"])
+    return p
+
+
 def _anchor_shift(out: list[dict], last_value: float | None) -> list[dict]:
     """Shift the entire forecast so its first point lands on `last_value`.
 
@@ -115,15 +146,17 @@ def _anchor_shift(out: list[dict], last_value: float | None) -> list[dict]:
     user's actual last-observed value, eliminating the visual gap between
     fact and forecast on the chart.
     """
-    if not out or last_value is None:
+    if not out:
         return out
-    shift = last_value - out[0]["yhat"]
-    if shift == 0:
-        return out
+    if last_value is not None:
+        shift = last_value - out[0]["yhat"]
+        if shift != 0:
+            for p in out:
+                p["yhat"]       = p["yhat"]       + shift
+                p["yhat_lower"] = p["yhat_lower"] + shift
+                p["yhat_upper"] = p["yhat_upper"] + shift
     for p in out:
-        p["yhat"] = p["yhat"] + shift
-        p["yhat_lower"] = max(0.0, p["yhat_lower"] + shift)
-        p["yhat_upper"] = p["yhat_upper"] + shift
+        _normalize_forecast_point(p)
     return out
 
 
@@ -177,7 +210,9 @@ def train(
 ) -> dict[str, Any]:
     """Fit a forecast model for (table, metric, project_id), persist it, return metadata."""
     cps = get_changepoints(table, metric, window=timedelta(days=60), project_id=project_id)
-    last_cp_ts: str | None = cps[-1]["ts"] if cps else None
+    last_cp = cps[-1] if cps else None
+    last_cp_ts: str | None = last_cp["ts"] if last_cp else None
+    last_value_override: float | None = None
 
     if last_cp_ts is not None:
         since = _parse_ts(last_cp_ts)
@@ -195,15 +230,31 @@ def train(
             ]
             if len(points) < MIN_POINTS:
                 points = _load_history(table, metric, project_id=project_id)
+        elif last_cp is not None and _is_severe_drop(last_cp):
+            # Recent severe drop (e.g. 96k → 4): the full window carries a
+            # strong negative trend that Prophet/OLS extrapolates into negative
+            # territory after anchor-shift. Use post-CP points to capture the
+            # new regime. When not enough post-CP metrics exist yet, synthesize
+            # a flat series from cp.value_after — not from the last recorded
+            # metric, which could still be the pre-CP value.
+            full_points = _load_history(table, metric, project_id=project_id)
+            post_cp_points = [p for p in full_points if p[0] >= since]
+            if len(post_cp_points) >= MIN_POINTS:
+                points = post_cp_points
+            else:
+                last_ts = full_points[-1][0] if full_points else since
+                flat_val = last_cp["value_after"]
+                points = [
+                    (last_ts - timedelta(hours=1), flat_val),
+                    (last_ts, flat_val),
+                ]
+                last_value_override = flat_val
         else:
-            # Recent changepoint — fitting on post-cp alone leaves only a
-            # short flat plateau (e.g. ~10 ticks for a cp 10h ago), so the
-            # forecast would lose the longer-term growth context entirely
-            # and produce a flat line that contradicts the 14-day trend
-            # visible to the user. Use the full window: Prophet's
-            # piecewise trend handles step shifts natively, and the linear
-            # fallback at least carries the long-term slope rather than
-            # extrapolating a single regime jump as a runaway trend.
+            # Recent changepoint that is not a severe drop (e.g. growth or
+            # moderate step). Fitting on post-cp alone would leave a short
+            # flat plateau and lose the longer-term trend context. Use the
+            # full window: Prophet's piecewise trend handles step shifts
+            # natively, and the linear fallback carries the long-term slope.
             points = _load_history(table, metric, project_id=project_id)
     else:
         points = _load_history(table, metric, project_id=project_id)
@@ -227,6 +278,7 @@ def train(
         "last_ts": points[-1][0].isoformat(),
         "last_changepoint_ts": last_cp_ts,
         "trained_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "last_value_override": last_value_override,
     }
     if _HAS_JOBLIB:
         try:
@@ -284,7 +336,8 @@ def forecast(
             "model": _fit_linear(points),
         }
 
-    last_value = points[-1][1]
+    override = persisted.get("last_value_override")
+    last_value = override if override is not None else points[-1][1]
     if persisted["kind"] == "prophet":  # pragma: no cover - heavy
         return _predict_prophet(persisted["model"], horizon_days, last_value=last_value)
     return _predict_linear(persisted["model"], last_ts, horizon_days, last_value=last_value)

--- a/templates/table_detail.html
+++ b/templates/table_detail.html
@@ -441,7 +441,7 @@
           bgcolor: isDark ? "rgba(220,38,38,0.2)" : "rgba(254,226,226,0.95)",
           bordercolor: "#dc2626", borderwidth: 1, borderpad: 3,
           font: { size: 10, color: isDark ? "#fecaca" : "#991b1b" },
-          text: `▼ ${fmt(cp.value_before)} → ${fmt(cp.value_after)}`,
+          text: `${cp.value_after >= cp.value_before ? "▲" : "▼"} ${fmt(cp.value_before)} → ${fmt(cp.value_after)}`,
           hovertext: `Сдвиг ${fmtTs(cp.ts)}<br>${metric}: ${fmt(cp.value_before)} → ${fmt(cp.value_after)}<br>score ${cp.score.toFixed(2)}`,
           captureevents: true,
         }));

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -227,6 +227,132 @@ def test_model_path_isolated_per_project(tmp_path, monkeypatch):
     assert "project" not in path_legacy.name  # legacy keeps old filename format
 
 
+# ---------------------------------------------------------------------------
+# Severe-drop strategy and guardrail normalization
+# ---------------------------------------------------------------------------
+
+def test_severe_drop_uses_post_cp_points(tmp_path, monkeypatch):
+    """Recent severe drop: train() must fit only on post-CP data, not full window."""
+    monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(fc_mod, "_HAS_PROPHET", False)
+
+    now = datetime.now(UTC).replace(microsecond=0)
+    cp_dt = now - timedelta(hours=10)
+    fake_cp = [{"ts": cp_dt.isoformat(), "metric_name": "row_count", "score": 15.0,
+                "value_before": 96000.0, "value_after": 4.0}]
+
+    pre_rows = [
+        {"ts": (cp_dt - timedelta(hours=i + 1)).isoformat(timespec="seconds"),
+         "value": 96000.0, "tags": None}
+        for i in range(20, 0, -1)
+    ]
+    post_rows = [
+        {"ts": (cp_dt + timedelta(hours=i + 1)).isoformat(timespec="seconds"),
+         "value": 4.0, "tags": None}
+        for i in range(5)
+    ]
+    all_rows = pre_rows + post_rows
+
+    captured_points: list = []
+    original_fit = fc_mod._fit_linear
+    def spy_fit(points):
+        captured_points.extend(points)
+        return original_fit(points)
+
+    with patch.object(fc_mod, "get_changepoints", return_value=fake_cp), \
+         patch.object(fc_mod, "get_metrics", return_value=all_rows), \
+         patch.object(fc_mod, "_fit_linear", side_effect=spy_fit):
+        fc_mod.train("t", "row_count")
+
+    assert len(captured_points) == 5, "severe drop: должны использоваться только 5 post-CP точек"
+    assert all(v == 4.0 for _, v in captured_points), "severe drop: все точки обучения из нового режима"
+
+
+def test_severe_drop_flat_when_no_post_cp(tmp_path, monkeypatch):
+    """Recent severe drop с нулём post-CP точек: forecast() должен держаться около value_after.
+
+    Без last_value_override forecast() взял бы last metric = 96000 и сдвинул бы
+    плоский прогноз (4) обратно к 96000 через _anchor_shift. Override фиксирует это.
+    """
+    monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(fc_mod, "_HAS_PROPHET", False)
+
+    now = datetime.now(UTC).replace(microsecond=0)
+    cp_dt = now - timedelta(hours=2)
+    fake_cp = [{"ts": cp_dt.isoformat(), "metric_name": "row_count", "score": 15.0,
+                "value_before": 96000.0, "value_after": 4.0}]
+
+    # Только pre-CP точки — ни одной записи после changepoint (0 post-CP)
+    pre_rows = [
+        {"ts": (cp_dt - timedelta(hours=i + 1)).isoformat(timespec="seconds"),
+         "value": 96000.0, "tags": None}
+        for i in range(20, 0, -1)
+    ]
+
+    with patch.object(fc_mod, "get_changepoints", return_value=fake_cp), \
+         patch.object(fc_mod, "get_metrics", return_value=pre_rows):
+        result = fc_mod.forecast("t", "row_count", horizon_days=1)
+
+    assert all(p["yhat"] >= 0 for p in result), "yhat не должен уходить в минус"
+    assert all(p["yhat_lower"] >= 0 for p in result), "yhat_lower не должен уходить в минус"
+    assert all(p["yhat_upper"] >= 0 for p in result), "yhat_upper не должен уходить в минус"
+    assert all(abs(p["yhat"] - 4.0) < 1.0 for p in result), \
+        "прогноз должен держаться около value_after=4, не уходить к pre-CP значению 96000"
+
+
+def test_non_severe_recent_drop_uses_full_window(tmp_path, monkeypatch):
+    """Умеренный recent drop (не severe): train() должен использовать полное окно."""
+    monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(fc_mod, "_HAS_PROPHET", False)
+
+    now = datetime.now(UTC).replace(microsecond=0)
+    cp_dt = now - timedelta(hours=10)
+    # ratio = 80/100 = 0.8 — выше порога 0.2, не severe
+    fake_cp = [{"ts": cp_dt.isoformat(), "metric_name": "row_count", "score": 5.0,
+                "value_before": 100.0, "value_after": 80.0}]
+
+    rows = _series(50, step_hours=1, slope=1.0, start=50.0)
+    captured_windows = []
+
+    def fake_get_metrics(table, metric, project_id, window):
+        captured_windows.append(window)
+        return rows
+
+    with patch.object(fc_mod, "get_changepoints", return_value=fake_cp), \
+         patch.object(fc_mod, "get_metrics", side_effect=fake_get_metrics):
+        fc_mod.train("t", "row_count")
+
+    assert len(captured_windows) == 1
+    assert captured_windows[0] == timedelta(days=60), "умеренный drop: должно использоваться полное 60-дневное окно"
+
+
+def test_anchor_shift_no_negative_values():
+    """Все yhat* >= 0 после большого отрицательного сдвига."""
+    out = [
+        {"ts": f"2026-01-01T{h:02d}:00:00+00:00",
+         "yhat": 100.0 - 20.0 * h,
+         "yhat_lower": 95.0 - 20.0 * h,
+         "yhat_upper": 105.0 - 20.0 * h}
+        for h in range(10)
+    ]
+    result = fc_mod._anchor_shift(out, last_value=4.0)
+    for p in result:
+        assert p["yhat"] >= 0
+        assert p["yhat_lower"] >= 0
+        assert p["yhat_upper"] >= 0
+        assert p["yhat_lower"] <= p["yhat"] <= p["yhat_upper"]
+
+
+def test_anchor_shift_normalizes_when_no_shift():
+    """Нормализация должна работать даже когда last_value=None (shift не применяется)."""
+    out = [{"ts": "2026-01-01T00:00:00+00:00",
+            "yhat": -5.0, "yhat_lower": -10.0, "yhat_upper": -1.0}]
+    result = fc_mod._anchor_shift(out, last_value=None)
+    assert result[0]["yhat"] == 0.0
+    assert result[0]["yhat_lower"] == 0.0
+    assert result[0]["yhat_upper"] == 0.0
+
+
 def test_train_writes_to_project_scoped_path(tmp_path, monkeypatch):
     """train() with a real project_id must write to the project-scoped file."""
     monkeypatch.setattr(fc_mod, "MODELS_DIR", tmp_path)


### PR DESCRIPTION
## Описание

Закрывает #294.

На детальной странице таблицы после резкого changepoint прогноз `row_count` уходил в отрицательные значения, а стрелка changepoint-аннотации всегда показывала `▼` даже при росте.

- **Guardrail**: `_normalize_forecast_point()` клампит `yhat`/`yhat_lower`/`yhat_upper` к `>= 0` и восстанавливает порядок CI — вызывается из `_anchor_shift()` всегда (в том числе при `shift == 0` и `last_value = None`)
- **ML-фикс**: `_is_severe_drop()` детектирует резкое падение (`value_after / value_before < 0.2`); `train()` при таком кейсе обучает модель только на post-CP точках, а при нехватке данных строит синтетический flat-ряд от `cp.value_after`
- **`last_value_override`**: сохраняется в payload модели — не даёт `_anchor_shift` сдвинуть плоский прогноз обратно к pre-CP значению (96k вместо 4)
- **Стрелка**: inline ternary `▲`/`▼` в `table_detail.html` вместо захардкоженной `▼`

## Тип изменения

- [x] Bug fix

## Чеклист

- [x] Тесты написаны / обновлены (5 новых тестов в `test_forecast.py`)
- [x] `pytest` проходит локально (988 passed)
- [ ] Если изменена схема БД — обновлены `scripts/schema.sql` и соответствующие коллекторы